### PR TITLE
[WIP] Update mainswitchbar

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ rikkax-parcelablelist = { module = "dev.rikka.rikkax.parcelablelist:parcelableli
 rikkax-preference = { module = "dev.rikka.rikkax.material:material-preference", version = "2.0.0" }
 rikkax-recyclerview = { module = "dev.rikka.rikkax.recyclerview:recyclerview-ktx", version = "1.3.2" }
 rikkax-widget-borderview = { module = "dev.rikka.rikkax.widget:borderview", version = "1.1.0" }
-rikkax-widget-mainswitchbar = { module = "dev.rikka.rikkax.widget:mainswitchbar", version = "1.0.2" }
+rikkax-widget-mainswitchbar = { module = "dev.rikka.rikkax.widget:mainswitchbar", version = "1.1.0" }
 
 androidx-activity = { module = "androidx.activity:activity", version = "1.9.1" }
 androidx-annotation = { module = "androidx.annotation:annotation", version = "1.8.2" }


### PR DESCRIPTION
Updating RikkaX widget mainswitchbar causes issues.

In this commit, something broke the LSPosed.
https://github.com/RikkaApps/RikkaX/commit/3dc0d92aae741ffe1a7c87cddb98c957fdcec422

Bug: when you open the manager, you can no longer config the scope since the manager keep refreshing.

https://github.com/user-attachments/assets/e5cafada-68a7-4289-a481-250e12d34ee1

A fix from @JingMatrix will be very welcomed or simply close and ignore the PR.