### PR TITLE
Show system framework in the scope for all users

### DIFF
--- a/app/src/main/java/org/lsposed/manager/adapters/ScopeAdapter.java
+++ b/app/src/main/java/org/lsposed/manager/adapters/ScopeAdapter.java
@@ -537,8 +537,7 @@ public class ScopeAdapter extends EmptyStateRecyclerView.EmptyStateAdapter<Scope
             appList.parallelStream().forEach(info -> {
                 int userId = info.applicationInfo.uid / App.PER_USER_RANGE;
                 String packageName = info.packageName;
-                if (packageName.equals("system") && userId != 0 ||
-                        packageName.equals(module.packageName) ||
+                if (packageName.equals(module.packageName) ||
                         packageName.equals(BuildConfig.APPLICATION_ID)) {
                     return;
                 }
@@ -549,7 +548,7 @@ public class ScopeAdapter extends EmptyStateRecyclerView.EmptyStateAdapter<Scope
                     installedList.add(application);
                 }
 
-                if (userId != module.userId) {
+                if (!packageName.equals("system") && userId != module.userId) {
                     return;
                 }
 


### PR DESCRIPTION
It remains to modify daemon/src/main/java/org/lsposed/lspd/service/ConfigManager.java, which ignores scope change of `system` if userId == 0.

Once finished, close #136 as completed.