### PR TITLE
Start service daemon in `post-fs-data` mode

### DIFF
--- a/daemon/src/main/java/org/lsposed/lspd/service/ServiceManager.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/ServiceManager.java
@@ -99,7 +99,9 @@ public class ServiceManager {
 
         int systemServerMaxRetry = 1;
         for (String arg : args) {
-            if (arg.startsWith("--system-server-max-retry=")) {
+            if (arg.equals("--from-service")) {
+                Log.w(TAG, "LSPosed daemon is not started properly. Try for a late start...");
+            } else if (arg.startsWith("--system-server-max-retry=")) {
                 try {
                     systemServerMaxRetry = Integer.parseInt(arg.substring(arg.lastIndexOf('=') + 1));
                 } catch (Throwable ignored) {

--- a/magisk-loader/magisk_module/post-fs-data.sh
+++ b/magisk-loader/magisk_module/post-fs-data.sh
@@ -21,4 +21,6 @@ MODDIR=${0%/*}
 
 rm -f "/data/local/tmp/daemon.apk"
 rm -f "/data/local/tmp/manager.apk"
+cd "$MODDIR"
 
+unshare --propagation slave -m sh -c "$MODDIR/daemon $@&"

--- a/magisk-loader/magisk_module/service.sh
+++ b/magisk-loader/magisk_module/service.sh
@@ -18,8 +18,6 @@
 #
 
 MODDIR=${0%/*}
-
 cd "$MODDIR"
-
-# To avoid breaking Play Integrity in certain cases, we start LSPosed service daemon in late_start service mode instead of post-fs-data mode
-unshare --propagation slave -m sh -c "$MODDIR/daemon $@&"
+# post-fs-data.sh may be blocked by other modules. retry to start this
+unshare --propagation slave -m sh -c "$MODDIR/daemon --from-service $@&"


### PR DESCRIPTION
For trace cleaning modules to work properly, such as the DenyList feature of NeoZygisk, it is better to execute modules mount (`dex2oat` for the case of LSPosed) at `post-fs-data.sh`, which ensures them to observe these mount at the moment of cleaning.

Moreover, the `logd` daemon of LSPosed should start as early as possible.

This reverts commit 92cbed418edf2d845374492981b195017bcff7a5 (pull-request #57). The original pull-request claimed a `PlayIntegrityFix` break, but was not reproducible on other devices.