### PR TITLE
feat(elf_util): Added Step 3(r--p) fallback lookup mechanism .Fix the problem that the address cannot be obtained on Android 10

### DIFF
--- a/core/src/main/jni/src/elf_util.cpp
+++ b/core/src/main/jni/src/elf_util.cpp
@@ -454,6 +454,18 @@ bool ElfImg::findModuleBase() {
         }
     }
 
+    // Step 3 (Fallback): If the pattern was not found, find the first `r--p` entry.
+    if (!found_block) {
+        LOGD("`r-xp` pattern not found. Falling back to first `r--p` entry.");
+        for (const auto &entry : filtered_list) {
+            if (strcmp(entry.perms, "r--p") == 0) {
+                found_block = &entry;
+                LOGD("Found first `r--p` block at {:#x}", found_block->start_addr);
+                break;  // Fallback found, exit loop.
+            }
+        }
+    }
+
     if (!found_block) {
         LOGE("Fatal: Could not determine a base address for {}", elf.data());
         return false;


### PR DESCRIPTION
- When the Step 2 (r-xp) mode is not found, implement the lookup logic to fall back to the first r--p segment
- On android 10 Step 1 to Step 2 doesn't match any pattern, but r--p does have a libart.so address

- Log findModuleBase(): Found 4 filtered map entries for libart.so:
findModuleBase():   0x70991e8000 r--p /apex/com.android.runtime/lib64/libart.so
findModuleBase():   0x7099327000 --xp /apex/com.android.runtime/lib64/libart.so
findModuleBase():   0x70997de000 rw-p /apex/com.android.runtime/lib64/libart.so
findModuleBase():   0x70997e1000 r--p /apex/com.android.runtime/lib64/libart.so
findModuleBase(): `r--p` -> `r-xp` pattern not found. Falling back to first `r-xp` entry.
findModuleBase(): `r-xp` pattern not found. Falling back to first `r--p` entry.
findModuleBase(): Found first `r--p` block at 0x70991e8000
findModuleBase(): get module base /apex/com.android.runtime/lib64/libart.so: 0x70991e8000
findModuleBase(): update path: /apex/com.android.runtime/lib64/libart.so