### PR TITLE
Allow server injection retry in service mode

### DIFF
--- a/magisk-loader/magisk_module/service.sh
+++ b/magisk-loader/magisk_module/service.sh
@@ -22,4 +22,4 @@ MODDIR=${0%/*}
 cd "$MODDIR"
 
 # To avoid delaying the normal mount timing of zygote, we start LSPosed service daemon in late_start service mode instead of post-fs-data mode
-unshare --propagation slave -m sh -c "$MODDIR/daemon $@&"
+unshare --propagation slave -m sh -c "$MODDIR/daemon --system-server-max-retry=3 $@&"


### PR DESCRIPTION
User reports that system server injection can still fail even started in service mode.

Hence, we add argument `--system-server-max-retry=3`.