### PR TITLE
Fix LSPATCH compile error

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -56,9 +56,9 @@ copy {
 }
 
 dependencies {
-    api(projects.xposed)
-    implementation(projects.external.apache)
-    implementation(projects.external.axml)
+    api(project(":xposed"))
+    implementation(project(":external:apache"))
+    implementation(project(":external:axml"))
     implementation(projects.hiddenapi.bridge)
     implementation(projects.services.daemonService)
     implementation(projects.services.managerService)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -56,7 +56,7 @@ copy {
 }
 
 dependencies {
-    api(project(":xposed"))
+    implementation(project(":xposed"))
     implementation(project(":external:apache"))
     implementation(project(":external:axml"))
     implementation(projects.hiddenapi.bridge)


### PR DESCRIPTION
please fix LSPATCH ERROR

```
Script compilation errors:

  Line 31:         androidResources = false
                   ^ 'androidResources: Boolean?' is deprecated. Use android.androidResources.enable = true/false instead to enable or disable android resource processing. This API will be removed in AGP 10.0

  Line 59:     api(projects.xposed)
                            ^ Unresolved reference: xposed

  Line 60:     implementation(projects.external.apache)
                                       ^ Unresolved reference: external

  Line 61:     implementation(projects.external.axml)
                                       ^ Unresolved reference: external

4 errors
```

there errors affected my [fork](https://github.com/Lobanokivan11/LSPatch-UNITE)