### PR TITLE
Add execmem SELinux rule for system_server

### DIFF
--- a/zygisk/module/sepolicy.rule
+++ b/zygisk/module/sepolicy.rule
@@ -1,6 +1,8 @@
 allow dex2oat dex2oat_exec file execute_no_trans
 allow dex2oat system_linker_exec file execute_no_trans
 
+allow system_server system_server process execmem
+
 allow shell shell dir write
 
 type xposed_file file_type


### PR DESCRIPTION
In commit 3d11c2f0f7754201c6b5ec4213b77ab26b711d26, the rule execmem is removed without explanation, possibly because that it is by default allowed for nearly all devices.

However, from user bug report, this rule is missing on `Realme X7 Max 5G` (realme/RMX3031/RMX3031L1:13/TP1A.220905.001/R.ead5d5-5fba), causing the function `shouldSkipSystemServer` in `ConfigManager.java` returning true.

We add it back to support our IPC bridge injection into system_server.