### PR TITLE
Allow standalone launch via late inject

### DIFF
--- a/core/src/main/java/org/lsposed/lspd/core/Startup.java
+++ b/core/src/main/java/org/lsposed/lspd/core/Startup.java
@@ -24,6 +24,7 @@ import android.app.ActivityThread;
 import android.app.LoadedApk;
 import android.content.pm.ApplicationInfo;
 import android.content.res.CompatibilityInfo;
+import android.os.IBinder;
 
 import com.android.internal.os.ZygoteInit;
 
@@ -34,6 +35,7 @@ import org.lsposed.lspd.hooker.HandleSystemServerProcessHooker;
 import org.lsposed.lspd.hooker.LoadedApkCtorHooker;
 import org.lsposed.lspd.hooker.LoadedApkCreateCLHooker;
 import org.lsposed.lspd.hooker.OpenDexFileHooker;
+import org.lsposed.lspd.hooker.StartBootstrapServicesHooker;
 import org.lsposed.lspd.impl.LSPosedContext;
 import org.lsposed.lspd.impl.LSPosedHelper;
 import org.lsposed.lspd.service.ILSPApplicationService;
@@ -63,13 +65,30 @@ public class Startup {
         LSPosedHelper.hookAllMethods(AttachHooker.class, ActivityThread.class, "attach");
     }
 
-    public static void bootstrapXposed() {
+    public static void bootstrapXposed(boolean systemServerStarted) {
         // Initialize the Xposed framework
         try {
             startBootstrapHook(XposedInit.startsSystemServer);
             XposedInit.loadLegacyModules();
         } catch (Throwable t) {
             Utils.logE("error during Xposed initialization", t);
+        }
+
+        if (systemServerStarted) {
+            Utils.logD("Manually triggering system_server module load for late injection");
+
+            IBinder activityService = android.os.ServiceManager.getService("activity");
+            if (activityService == null) {
+                Utils.logE("Activity service not found! Cannot get SystemServer ClassLoader.");
+                return;
+            }
+
+            // Maintain state consistency for the rest of the Vector framework
+            HandleSystemServerProcessHooker.systemServerCL = activityService.getClass().getClassLoader();
+            HandleSystemServerProcessHooker.after();
+            StartBootstrapServicesHooker.before();
+
+            Utils.logI("Late system_server injection successfully completed.");
         }
     }
 

--- a/core/src/main/java/org/lsposed/lspd/hooker/HandleSystemServerProcessHooker.java
+++ b/core/src/main/java/org/lsposed/lspd/hooker/HandleSystemServerProcessHooker.java
@@ -35,15 +35,17 @@ public class HandleSystemServerProcessHooker implements XposedInterface.Hooker {
         void onSystemServerLoaded(ClassLoader classLoader);
     }
 
-    public static volatile ClassLoader systemServerCL;
+    public static volatile ClassLoader systemServerCL = null;
     public static volatile Callback callback = null;
 
     @SuppressLint("PrivateApi")
     public static void after() {
         Hookers.logD("ZygoteInit#handleSystemServerProcess() starts");
         try {
-            // get system_server classLoader
-            systemServerCL = Thread.currentThread().getContextClassLoader();
+            if (systemServerCL == null) {
+                // get system_server classLoader
+                systemServerCL = Thread.currentThread().getContextClassLoader();
+            }
             // deopt methods in SYSTEMSERVERCLASSPATH
             PrebuiltMethodsDeopter.deoptSystemServerMethods(systemServerCL);
             var clazz = Class.forName("com.android.server.SystemServer", false, systemServerCL);

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPSystemServerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPSystemServerService.java
@@ -32,8 +32,7 @@ import android.util.Log;
 
 public class LSPSystemServerService extends ILSPSystemServerService.Stub implements IBinder.DeathRecipient {
 
-    public static final String PROXY_SERVICE_NAME = "serial";
-
+    private final String proxyServiceName;
     private IBinder originService = null;
     private int requested;
 
@@ -42,12 +41,13 @@ public class LSPSystemServerService extends ILSPSystemServerService.Stub impleme
     }
 
     public void putBinderForSystemServer() {
-        android.os.ServiceManager.addService(PROXY_SERVICE_NAME, this);
+        android.os.ServiceManager.addService(proxyServiceName, this);
         binderDied();
     }
 
-    public LSPSystemServerService(int maxRetry) {
+    public LSPSystemServerService(int maxRetry, String serviceName) {
         Log.d(TAG, "LSPSystemServerService::LSPSystemServerService");
+        proxyServiceName = serviceName;
         requested = -maxRetry;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             // Registers a callback when system is registering an authentic "serial" service
@@ -56,7 +56,7 @@ public class LSPSystemServerService extends ILSPSystemServerService.Stub impleme
                 @Override
                 public void onRegistration(String name, IBinder binder) {
                     Log.d(TAG, "LSPSystemServerService::LSPSystemServerService onRegistration: " + name + " " + binder);
-                    if (name.equals(PROXY_SERVICE_NAME) && binder != null && binder != LSPSystemServerService.this) {
+                    if (name.equals(proxyServiceName) && binder != null && binder != LSPSystemServerService.this) {
                         Log.d(TAG, "Register " + name + " " + binder);
                         originService = binder;
                         LSPSystemServerService.this.linkToDeath();
@@ -69,7 +69,7 @@ public class LSPSystemServerService extends ILSPSystemServerService.Stub impleme
                 }
             };
             try {
-                getSystemServiceManager().registerForNotifications(PROXY_SERVICE_NAME, serviceCallback);
+                getSystemServiceManager().registerForNotifications(proxyServiceName, serviceCallback);
             } catch (Throwable e) {
                 Log.e(TAG, "unregister: ", e);
             }

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPSystemServerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPSystemServerService.java
@@ -46,7 +46,7 @@ public class LSPSystemServerService extends ILSPSystemServerService.Stub impleme
     }
 
     public LSPSystemServerService(int maxRetry, String serviceName) {
-        Log.d(TAG, "LSPSystemServerService::LSPSystemServerService");
+        Log.d(TAG, "LSPSystemServerService::LSPSystemServerService with proxy " + serviceName);
         proxyServiceName = serviceName;
         requested = -maxRetry;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
@@ -479,6 +479,11 @@ public class LSPosedService extends ILSPosedService.Stub {
         registerOpenManagerReceiver();
         registerModuleScopeReceiver();
         registerUidObserver();
+
+        if (ServiceManager.isLateInject) {
+            Log.i(TAG, "System already booted during late injection. Manually triggering boot completed.");
+            dispatchBootCompleted(null);
+        }
     }
 
     @Override

--- a/daemon/src/main/java/org/lsposed/lspd/service/ServiceManager.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/ServiceManager.java
@@ -66,6 +66,9 @@ public class ServiceManager {
     private static LogcatService logcatService = null;
     private static Dex2OatService dex2OatService = null;
 
+    public static boolean isLateInject = false;
+    public static String proxyServiceName = "serial";
+
     private static final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
     @RequiresApi(Build.VERSION_CODES.Q)
@@ -104,9 +107,13 @@ public class ServiceManager {
                     systemServerMaxRetry = Integer.parseInt(arg.substring(arg.lastIndexOf('=') + 1));
                 } catch (Throwable ignored) {
                 }
+            } else if (arg.equals("--late-inject")) {
+                isLateInject = true;
+                proxyServiceName = "serial_vector";
             }
         }
-        Log.i(TAG, "starting server...");
+
+        Log.i(TAG, "Vector daemon started: lateInject: " + isLateInject);
         Log.i(TAG, String.format("version %s (%d)", BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE));
 
         Thread.setDefaultUncaughtExceptionHandler((t, e) -> {
@@ -136,7 +143,7 @@ public class ServiceManager {
         mainService = new LSPosedService();
         applicationService = new LSPApplicationService();
         managerService = new LSPManagerService();
-        systemServerService = new LSPSystemServerService(systemServerMaxRetry);
+        systemServerService = new LSPSystemServerService(systemServerMaxRetry, proxyServiceName);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             dex2OatService = new Dex2OatService();
             dex2OatService.start();

--- a/zygisk/proguard-rules.pro
+++ b/zygisk/proguard-rules.pro
@@ -1,5 +1,5 @@
 -keepclasseswithmembers class org.matrix.vector.core.Main {
-    public static void forkCommon(boolean, java.lang.String, java.lang.String, android.os.IBinder);
+    public static void forkCommon(boolean, boolean, java.lang.String, java.lang.String, android.os.IBinder);
 }
 -keepclasseswithmembers,includedescriptorclasses class * {
     native <methods>;

--- a/zygisk/src/main/cpp/include/ipc_bridge.h
+++ b/zygisk/src/main/cpp/include/ipc_bridge.h
@@ -49,9 +49,11 @@ public:
     /**
      * @brief Requests the system_server's dedicated Binder from the host service.
      * @param env JNI environment pointer.
+     * @param bridgeServiceName rendezvous point used by the system_server
      * @return A ScopedLocalRef to the Binder object, or nullptr on failure.
      */
-    lsplant::ScopedLocalRef<jobject> RequestSystemServerBinder(JNIEnv *env);
+    lsplant::ScopedLocalRef<jobject> RequestSystemServerBinder(JNIEnv *env,
+                                                               std::string bridgeServiceName);
 
     /**
      * @brief Asks the system_server binder for the application manager binder.

--- a/zygisk/src/main/cpp/ipc_bridge.cpp
+++ b/zygisk/src/main/cpp/ipc_bridge.cpp
@@ -313,11 +313,12 @@ lsplant::ScopedLocalRef<jobject> IPCBridge::RequestSystemServerBinder(
         binder = lsplant::JNI_CallStaticObjectMethod(env, service_manager_class_,
                                                      get_service_method_, service_name.get());
         if (binder) {
-            LOGI("Got system server binder on attempt {}.", i + 1);
+            LOGI("Got system server binder via {} on attempt {}.", bridgeServiceName.data(), i + 1);
             return binder;
         }
         if (i < 2) {
-            LOGW("Failed to get system server binder, will retry in 1 second...");
+            LOGW("Failed to get system server binder via {}, will retry in 1 second...",
+                 bridgeServiceName.data());
             std::this_thread::sleep_for(std::chrono::seconds(1));
         }
     }

--- a/zygisk/src/main/cpp/ipc_bridge.cpp
+++ b/zygisk/src/main/cpp/ipc_bridge.cpp
@@ -84,8 +84,6 @@ private:
 // The name of the system service we use as a rendezvous point to find our manager service.
 // Using "activity" is a common technique as it's always available.
 constexpr auto kBridgeServiceName = "activity"sv;
-// A different rendezvous point used only by the system_server.
-constexpr auto kSystemServerBridgeServiceName = "serial"sv;
 
 // Transaction codes for specific actions.
 constexpr jint kBridgeTransactionCode = ('_' << 24) | ('V' << 16) | ('E' << 8) | 'C';
@@ -299,14 +297,14 @@ lsplant::ScopedLocalRef<jobject> IPCBridge::RequestAppBinder(JNIEnv *env, jstrin
     return result_binder;
 }
 
-lsplant::ScopedLocalRef<jobject> IPCBridge::RequestSystemServerBinder(JNIEnv *env) {
+lsplant::ScopedLocalRef<jobject> IPCBridge::RequestSystemServerBinder(
+    JNIEnv *env, std::string bridgeServiceName) {
     if (!initialized_) {
         LOGE("RequestSystemServerBinder failed: IPCBridge not initialized.");
         return {env, nullptr};
     }
 
-    auto service_name =
-        lsplant::ScopedLocalRef(env, env->NewStringUTF(kSystemServerBridgeServiceName.data()));
+    auto service_name = lsplant::ScopedLocalRef(env, env->NewStringUTF(bridgeServiceName.data()));
     lsplant::ScopedLocalRef<jobject> binder = {env, nullptr};
 
     // The system_server might start its services slightly after Zygisk injects us.

--- a/zygisk/src/main/cpp/module.cpp
+++ b/zygisk/src/main/cpp/module.cpp
@@ -38,6 +38,11 @@ const char *const kHostPackageName = INJECTED_PACKAGE_NAME;
 const char *const kManagePackageName = MANAGER_PACKAGE_NAME;
 constexpr uid_t GID_INET = 3003;  // Android's Internet group ID.
 
+enum RuntimeFlags : uint32_t {
+    // Flags defined by NeoZygisk
+    LATE_INJECT = 1 << 30,
+};
+
 // A simply ConfigBridge implemnetation holding obfuscation maps in memory
 using obfuscation_map_t = std::map<std::string, std::string>;
 class ConfigImpl : public ConfigBridge {
@@ -338,9 +343,9 @@ void VectorModule::postAppSpecialize(const zygisk::AppSpecializeArgs *args) {
     this->SetupEntryClass(env_);
 
     // Hand off control to the Java side of the framework.
-    this->FindAndCall(env_, "forkCommon",
-                      "(ZLjava/lang/String;Ljava/lang/String;Landroid/os/IBinder;)V", JNI_FALSE,
-                      args->nice_name, args->app_data_dir, binder.get(), is_manager_app_);
+    this->FindAndCall(
+        env_, "forkCommon", "(ZZLjava/lang/String;Ljava/lang/String;Landroid/os/IBinder;)V",
+        JNI_FALSE, JNI_FALSE, args->nice_name, args->app_data_dir, binder.get(), is_manager_app_);
 
     LOGV("Injected Vector framework into '{}'.", nice_name_str.get());
     SetAllowUnload(false);  // We are injected, PREVENT module unloading.
@@ -385,7 +390,10 @@ void VectorModule::postServerSpecialize(const zygisk::ServerSpecializeArgs *args
 
     // --- Framework Injection for System Server ---
     auto &ipc_bridge = IPCBridge::GetInstance();
-    auto system_binder = ipc_bridge.RequestSystemServerBinder(env_);
+    std::string bridgeServiceName = "serial";
+    bool is_late_inject = (args->runtime_flags & RuntimeFlags::LATE_INJECT) != 0;
+    if (is_late_inject) bridgeServiceName = "serial_vector";
+    auto system_binder = ipc_bridge.RequestSystemServerBinder(env_, bridgeServiceName);
     if (!system_binder) {
         LOGE("Failed to get system server IPC binder. Aborting injection.");
         SetAllowUnload(true);  // Allow unload on failure.
@@ -423,8 +431,9 @@ void VectorModule::postServerSpecialize(const zygisk::ServerSpecializeArgs *args
 
     auto system_name = lsplant::ScopedLocalRef(env_, env_->NewStringUTF("system"));
     this->FindAndCall(env_, "forkCommon",
-                      "(ZLjava/lang/String;Ljava/lang/String;Landroid/os/IBinder;)V", JNI_TRUE,
-                      system_name.get(), nullptr, manager_binder.get(), is_manager_app_);
+                      "(ZZLjava/lang/String;Ljava/lang/String;Landroid/os/IBinder;)V", JNI_TRUE,
+                      is_late_inject, system_name.get(), nullptr, manager_binder.get(),
+                      is_manager_app_);
 
     LOGI("Injected Vector framework into system_server.");
     SetAllowUnload(false);  // We are injected, PREVENT module unloading.

--- a/zygisk/src/main/kotlin/org/matrix/vector/core/Main.kt
+++ b/zygisk/src/main/kotlin/org/matrix/vector/core/Main.kt
@@ -2,8 +2,15 @@ package org.matrix.vector.core
 
 import android.os.IBinder
 import android.os.Process
+import de.robv.android.xposed.XposedBridge
+import de.robv.android.xposed.XposedInit
+import de.robv.android.xposed.callbacks.XC_LoadPackage
+import io.github.libxposed.api.XposedModuleInterface
 import org.lsposed.lspd.core.ApplicationServiceClient.serviceClient
 import org.lsposed.lspd.core.Startup
+import org.lsposed.lspd.deopt.PrebuiltMethodsDeopter
+import org.lsposed.lspd.hooker.HandleSystemServerProcessHooker
+import org.lsposed.lspd.impl.LSPosedContext
 import org.lsposed.lspd.service.ILSPApplicationService
 import org.lsposed.lspd.util.Utils
 import org.matrix.vector.BuildConfig
@@ -17,12 +24,13 @@ object Main {
      * Shared initialization logic for both System Server and Application processes.
      *
      * @param isSystem True if this is the system_server process.
+     * @param isLateInject True if Zygisk APIs are not invoked via hooks
      * @param niceName The process name (e.g., package name or "system").
      * @param appDir The application's data directory.
      * @param binder The Binder token associated with the application service.
      */
     @JvmStatic
-    fun forkCommon(isSystem: Boolean, niceName: String, appDir: String?, binder: IBinder) {
+    fun forkCommon(isSystem: Boolean, isLateInject: Boolean, niceName: String, appDir: String?, binder: IBinder) {
         // Initialize system-specific resolution hooks if in system_server
         if (isSystem) {
             ParasiticManagerSystemHooker.start()
@@ -47,5 +55,56 @@ object Main {
         // Standard Xposed module loading for third-party apps
         Utils.logI("Loading Vector/Xposed for $niceName (UID: ${Process.myUid()})")
         Startup.bootstrapXposed()
+
+        if (isSystem && isLateInject) {
+            Utils.logD("Manually triggering system_server module load for late injection")
+            try {
+                // 1. Steal the correct SystemServer ClassLoader from a live service.
+                // Because we inject late via ptrace, ActivityManagerService is already fully
+                // loaded.
+                val activityService = android.os.ServiceManager.getService("activity")
+                if (activityService == null) {
+                    Utils.logE("Activity service not found! Cannot get SystemServer ClassLoader.")
+                    return
+                }
+                val systemServerCL = activityService.javaClass.classLoader
+
+                // Maintain state consistency for the rest of the Vector framework
+                HandleSystemServerProcessHooker.systemServerCL = systemServerCL
+
+                // Deopt system server methods (if required by LSPlant hooks)
+                runCatching { PrebuiltMethodsDeopter.deoptSystemServerMethods(systemServerCL) }
+                    .onFailure { Utils.logE("Failed to deopt system server methods", it) }
+
+                // 2. Trigger the callback to load the parasitic manager
+                HandleSystemServerProcessHooker.callback?.onSystemServerLoaded(systemServerCL)
+
+                // 3. Emulate StartBootstrapServicesHooker.before() payload synchronously
+                XposedInit.loadedPackagesInProcess.add("android")
+
+                val lpparam =
+                    XC_LoadPackage.LoadPackageParam(XposedBridge.sLoadedPackageCallbacks).apply {
+                        packageName = "android"
+                        processName = "android"
+                        classLoader = systemServerCL
+                        appInfo = null
+                        isFirstApplication = true
+                    }
+
+                Utils.logD("Firing XC_LoadPackage.callAll for android...")
+                XC_LoadPackage.callAll(lpparam)
+
+                // 4. Fire modern LibXposed callbacks
+                LSPosedContext.callOnSystemServerLoaded(
+                    object : XposedModuleInterface.SystemServerLoadedParam {
+                        override fun getClassLoader(): ClassLoader = systemServerCL!!
+                    }
+                )
+
+                Utils.logI("Late system_server injection successfully completed.")
+            } catch (t: Throwable) {
+                Utils.logE("Error during late system_server bootstrap", t)
+            }
+        }
     }
 }

--- a/zygisk/src/main/kotlin/org/matrix/vector/core/Main.kt
+++ b/zygisk/src/main/kotlin/org/matrix/vector/core/Main.kt
@@ -2,15 +2,8 @@ package org.matrix.vector.core
 
 import android.os.IBinder
 import android.os.Process
-import de.robv.android.xposed.XposedBridge
-import de.robv.android.xposed.XposedInit
-import de.robv.android.xposed.callbacks.XC_LoadPackage
-import io.github.libxposed.api.XposedModuleInterface
 import org.lsposed.lspd.core.ApplicationServiceClient.serviceClient
 import org.lsposed.lspd.core.Startup
-import org.lsposed.lspd.deopt.PrebuiltMethodsDeopter
-import org.lsposed.lspd.hooker.HandleSystemServerProcessHooker
-import org.lsposed.lspd.impl.LSPosedContext
 import org.lsposed.lspd.service.ILSPApplicationService
 import org.lsposed.lspd.util.Utils
 import org.matrix.vector.BuildConfig
@@ -30,7 +23,13 @@ object Main {
      * @param binder The Binder token associated with the application service.
      */
     @JvmStatic
-    fun forkCommon(isSystem: Boolean, isLateInject: Boolean, niceName: String, appDir: String?, binder: IBinder) {
+    fun forkCommon(
+        isSystem: Boolean,
+        isLateInject: Boolean,
+        niceName: String,
+        appDir: String?,
+        binder: IBinder,
+    ) {
         // Initialize system-specific resolution hooks if in system_server
         if (isSystem) {
             ParasiticManagerSystemHooker.start()
@@ -54,57 +53,6 @@ object Main {
 
         // Standard Xposed module loading for third-party apps
         Utils.logI("Loading Vector/Xposed for $niceName (UID: ${Process.myUid()})")
-        Startup.bootstrapXposed()
-
-        if (isSystem && isLateInject) {
-            Utils.logD("Manually triggering system_server module load for late injection")
-            try {
-                // 1. Steal the correct SystemServer ClassLoader from a live service.
-                // Because we inject late via ptrace, ActivityManagerService is already fully
-                // loaded.
-                val activityService = android.os.ServiceManager.getService("activity")
-                if (activityService == null) {
-                    Utils.logE("Activity service not found! Cannot get SystemServer ClassLoader.")
-                    return
-                }
-                val systemServerCL = activityService.javaClass.classLoader
-
-                // Maintain state consistency for the rest of the Vector framework
-                HandleSystemServerProcessHooker.systemServerCL = systemServerCL
-
-                // Deopt system server methods (if required by LSPlant hooks)
-                runCatching { PrebuiltMethodsDeopter.deoptSystemServerMethods(systemServerCL) }
-                    .onFailure { Utils.logE("Failed to deopt system server methods", it) }
-
-                // 2. Trigger the callback to load the parasitic manager
-                HandleSystemServerProcessHooker.callback?.onSystemServerLoaded(systemServerCL)
-
-                // 3. Emulate StartBootstrapServicesHooker.before() payload synchronously
-                XposedInit.loadedPackagesInProcess.add("android")
-
-                val lpparam =
-                    XC_LoadPackage.LoadPackageParam(XposedBridge.sLoadedPackageCallbacks).apply {
-                        packageName = "android"
-                        processName = "android"
-                        classLoader = systemServerCL
-                        appInfo = null
-                        isFirstApplication = true
-                    }
-
-                Utils.logD("Firing XC_LoadPackage.callAll for android...")
-                XC_LoadPackage.callAll(lpparam)
-
-                // 4. Fire modern LibXposed callbacks
-                LSPosedContext.callOnSystemServerLoaded(
-                    object : XposedModuleInterface.SystemServerLoadedParam {
-                        override fun getClassLoader(): ClassLoader = systemServerCL!!
-                    }
-                )
-
-                Utils.logI("Late system_server injection successfully completed.")
-            } catch (t: Throwable) {
-                Utils.logE("Error during late system_server bootstrap", t)
-            }
-        }
+        Startup.bootstrapXposed(isSystem && isLateInject)
     }
 }


### PR DESCRIPTION
In https://github.com/JingMatrix/NeoZygisk/pull/107, NeoZygisk is modified to support Zygisk initialization without relying on the early init phase hooks of Magisk. This commit adds support for Vector to operate under this late injection model.

Modifications include:
- Daemon: Added parsing for the --late-inject flag in ServiceManager. When active, the daemon uses "serial_vector" as the proxy service name and LSPosedService manually dispatches the boot completed event.
- IPC Bridge: Updated RequestSystemServerBinder to accept a dynamic rendezvous service name instead of hardcoding it.
- Native Module: VectorModule now reads RuntimeFlags::LATE_INJECT during server specialization, adjusts the bridge service name accordingly, and passes the state to the Java payload.
- Framework: Updated Main.forkCommon to manually bootstrap the system_server environment during late injection. This extracts the ClassLoader from the live activity service, deoptimizes system server methods, and synchronously fires Xposed and LibXposed load callbacks.