### PR TITLE
Add SELinux rule for `serial` service discovery

### DIFF
--- a/zygisk/module/sepolicy.rule
+++ b/zygisk/module/sepolicy.rule
@@ -1,4 +1,4 @@
-allow system_server default_android_hwservice hwservice_manager find 
+allow system_server default_android_service service_manager find 
 
 allow dex2oat dex2oat_exec file execute_no_trans
 allow dex2oat system_linker_exec file execute_no_trans

--- a/zygisk/module/sepolicy.rule
+++ b/zygisk/module/sepolicy.rule
@@ -1,3 +1,5 @@
+allow system_server default_android_hwservice hwservice_manager find 
+
 allow dex2oat dex2oat_exec file execute_no_trans
 allow dex2oat system_linker_exec file execute_no_trans
 


### PR DESCRIPTION
On Xiaomi Android 12 [Xiaomi/toco_ru/toco:12/RKQ1.210614.002/V13.0.4.0.SFNRUXM:user/release-keys], the following SELinux rule is stopping daemon from discovering the `serial` service for system_servce IPC initialization:

```
avc:  denied  { find } for pid=... uid=1000 name=... scontext=u:r:system_server:s0 tcontext=u:object_r:default_android_service:s0 tclass=service_manager permissive=0
```