### PR TITLE
Resolve side-channel detection from `com.reveny.nativecheck`

### DIFF
--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ManagerService.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ManagerService.kt
@@ -239,8 +239,8 @@ object ManagerService : ILSPManagerService.Stub() {
   override fun isVerboseLog() = PreferenceStore.isVerboseLogEnabled() || BuildConfig.DEBUG
 
   override fun setVerboseLog(enabled: Boolean) {
-    if (isVerboseLog()) LogcatMonitor.startVerbose() else LogcatMonitor.stopVerbose()
     PreferenceStore.setVerboseLog(enabled)
+    if (isVerboseLog()) LogcatMonitor.startVerbose() else LogcatMonitor.stopVerbose()
   }
 
   override fun getVerboseLog() =

--- a/zygisk/src/main/cpp/ipc_bridge.cpp
+++ b/zygisk/src/main/cpp/ipc_bridge.cpp
@@ -493,17 +493,13 @@ jboolean JNICALL IPCBridge::CallBooleanMethodV_Hook(JNIEnv *env, jobject obj, jm
     if (methodId == GetInstance().exec_transact_backup_method_id_) {
         uint64_t current_caller_id = BinderCaller::GetId();
 
-        if (current_caller_id != 0 &&
-            current_caller_id == g_last_failed_id.load(std::memory_order_relaxed)) {
-            // If this caller is the one that just failed,
-            // skip interception and go straight to the original function.
-            // LOGV("Skip caller {} for bridge service.", current_caller_id);
-            return GetInstance().call_boolean_method_v_backup_(env, obj, methodId, args);
-        }
-
         jboolean res = false;
         // Attempt to handle the transaction with our replacement logic.
-        if (ExecTransact_Replace(&res, env, obj, args)) {
+        if (current_caller_id != 0 &&
+            // If this caller is the one that just failed,
+            // skip interception and go straight to the original function.
+            current_caller_id != g_last_failed_id.load(std::memory_order_relaxed) &&
+            ExecTransact_Replace(&res, env, obj, args)) {
             return res;  // If we handled it, return the result directly.
         }
         // If not handled, fall through to call the original method.

--- a/zygisk/src/main/cpp/ipc_bridge.cpp
+++ b/zygisk/src/main/cpp/ipc_bridge.cpp
@@ -492,9 +492,10 @@ jboolean JNICALL IPCBridge::CallBooleanMethodV_Hook(JNIEnv *env, jobject obj, jm
         // If this caller is the one that just failed,
         // skip interception and go straight to the original function.
         if (current_caller_id == last_failed) {
-            // We "consume" the failed state by resetting it, so the *next* call is not skipped.
-            g_last_failed_id.store(~0, std::memory_order_relaxed);
             return GetInstance().call_boolean_method_v_backup_(env, obj, methodId, args);
+        } else if (last_failed != ~0) {
+            // Consume the failed state by resetting it, so the next call is not skipped.
+            g_last_failed_id.store(~0, std::memory_order_relaxed);
         }
     }
 

--- a/zygisk/src/main/cpp/ipc_bridge.cpp
+++ b/zygisk/src/main/cpp/ipc_bridge.cpp
@@ -476,8 +476,11 @@ jboolean IPCBridge::ExecTransact_Replace(jboolean *res, JNIEnv *env, jobject obj
         if (*res == JNI_FALSE) {
             uint64_t caller_id = BinderCaller::GetId();
             if (caller_id != 0) {
+                // LOGV("Caller {} rejected by bridge service.", caller_id);
                 g_last_failed_id.store(caller_id, std::memory_order_relaxed);
             }
+        } else {
+            g_last_failed_id.store(~0, std::memory_order_relaxed);
         }
         return true;  // Return true to indicate we handled the call.
     }
@@ -486,21 +489,18 @@ jboolean IPCBridge::ExecTransact_Replace(jboolean *res, JNIEnv *env, jobject obj
 
 jboolean JNICALL IPCBridge::CallBooleanMethodV_Hook(JNIEnv *env, jobject obj, jmethodID methodId,
                                                     va_list args) {
-    uint64_t current_caller_id = BinderCaller::GetId();
-    if (current_caller_id != 0) {
-        uint64_t last_failed = g_last_failed_id.load(std::memory_order_relaxed);
-        // If this caller is the one that just failed,
-        // skip interception and go straight to the original function.
-        if (current_caller_id == last_failed) {
-            return GetInstance().call_boolean_method_v_backup_(env, obj, methodId, args);
-        } else if (last_failed != ~0) {
-            // Consume the failed state by resetting it, so the next call is not skipped.
-            g_last_failed_id.store(~0, std::memory_order_relaxed);
-        }
-    }
-
     // Check if the method being called is the one we want to intercept: Binder.execTransact()
     if (methodId == GetInstance().exec_transact_backup_method_id_) {
+        uint64_t current_caller_id = BinderCaller::GetId();
+
+        if (current_caller_id != 0 &&
+            current_caller_id == g_last_failed_id.load(std::memory_order_relaxed)) {
+            // If this caller is the one that just failed,
+            // skip interception and go straight to the original function.
+            // LOGV("Skip caller {} for bridge service.", current_caller_id);
+            return GetInstance().call_boolean_method_v_backup_(env, obj, methodId, args);
+        }
+
         jboolean res = false;
         // Attempt to handle the transaction with our replacement logic.
         if (ExecTransact_Replace(&res, env, obj, args)) {

--- a/zygisk/src/main/cpp/module.cpp
+++ b/zygisk/src/main/cpp/module.cpp
@@ -288,7 +288,7 @@ void VectorModule::preAppSpecialize(zygisk::AppSpecializeArgs *args) {
     if ((app_id >= FIRST_ISOLATED_UID && app_id <= LAST_ISOLATED_UID) ||
         (app_id >= FIRST_APP_ZYGOTE_ISOLATED_UID && app_id <= LAST_APP_ZYGOTE_ISOLATED_UID) ||
         app_id == SHARED_RELRO_UID) {
-        LOGV("Skipping injection for '{}': is an isolated process (UID: %d).", nice_name_str.get(),
+        LOGV("Skipping injection for '{}': is an isolated process (UID: {}).", nice_name_str.get(),
              app_id);
         return;
     }


### PR DESCRIPTION
This side-channel attack is obvious from the repeating logs:

```
[ 2026-04-12T11:27:03.720        0:  7196:  7196 V/zygisk-core64   ] pre specialize [com.reveny.nativecheck:iso:com.reveny.nativecheck.app.isolated.IsolatedService:iso.detections]
[ 2026-04-12T11:27:03.720        0:  7196:  7196 V/zygisk-core64   ] Found isolated service [uid:10220, data_dir:/data/user/0/com.reveny.nativecheck]
[ 2026-04-12T11:27:08.747     1000:  1706:  4352 D/VectorZygiskBridge ] onTransact: action=GET_BINDER, callerUid=10220
...
[ 2026-04-12T11:27:08.825     1000:  1706:  1816 D/VectorZygiskBridge ] onTransact: action=GET_BINDER, callerUid=10220
[ 2026-04-12T11:27:08.826        0:  1349:  1558 D/VectorService   ] Skipped lsp23.probe/10220
[ 2026-04-12T11:27:08.826     1000:  1706:  4352 D/VectorZygiskBridge ] onTransact: action=GET_BINDER, callerUid=10220
[ 2026-04-12T11:27:08.826        0:  1349:  1558 D/VectorService   ] Skipped lsp23.probe/10220
[ 2026-04-12T11:27:08.826     1000:  1706:  1816 D/VectorZygiskBridge ] onTransact: action=GET_BINDER, callerUid=10220
[ 2026-04-12T11:27:08.826        0:  1349:  1558 D/VectorService   ] Skipped lsp23.probe/10220
[ 2026-04-12T11:27:08.826     1000:  1706:  4352 D/VectorZygiskBridge ] onTransact: action=GET_BINDER, callerUid=10220
[ 2026-04-12T11:27:08.827        0:  1349:  1558 D/VectorService   ] Skipped lsp23.probe/10220
[ 2026-04-12T11:27:10.234        0:   981:   981 W/zygiskd64       ] zygiskd::zygiskd: Error handling connection: failed to fill whole buffer
```

We will address this soon in `ipc_bridge.cpp`.