### PR TITLE
Fix bugs introduced in #658

### DIFF
--- a/daemon/src/main/jni/logcat.cpp
+++ b/daemon/src/main/jni/logcat.cpp
@@ -34,8 +34,8 @@ constexpr std::array<char, ANDROID_LOG_SILENT + 1> kLogChar = {
 
 // Module tags are sorted for O(log N) binary search.
 // These always route to the 'modules' (Xposed) log stream.
-constexpr auto kModuleTags =
-    std::array{"VectorContext"sv, "VectorLegacyBridge"sv, "XSharedPreferences"sv};
+constexpr auto kModuleTags = std::array{"VectorContext"sv, "VectorLegacyBridge"sv,
+                                        "VectorModuleManager"sv, "XSharedPreferences"sv};
 
 // These route to the 'verbose' stream only.
 constexpr auto kExactTags = std::array{"APatchD"sv, "Dobby"sv,  "KernelSU"sv, "LSPlant"sv,

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/VectorChain.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/VectorChain.kt
@@ -44,27 +44,28 @@ class VectorChain(
 
     override fun proceed(): Any? = internalProceed(thisObj, args)
 
-    override fun proceed(args: Array<Any?>): Any? = internalProceed(thisObj, args)
+    override fun proceed(currentArgs: Array<Any?>): Any? = internalProceed(thisObj, currentArgs)
 
     override fun proceedWith(thisObject: Any): Any? = internalProceed(thisObject, args)
 
-    override fun proceedWith(thisObject: Any, args: Array<Any?>): Any? = internalProceed(thisObject, args)
+    override fun proceedWith(thisObject: Any, currentArgs: Array<Any?>): Any? =
+        internalProceed(thisObject, currentArgs)
 
     private fun internalProceed(thisObject: Any?, currentArgs: Array<Any?>): Any? {
         proceedCalled = true
 
         // Reached the end of the modern hooks; trigger the original executable (and legacy hooks)
         if (index >= hooks.size) {
-            return executeDownstream { terminal(thisObject, args) }
+            return executeDownstream { terminal(thisObject, currentArgs) }
         }
 
         val record = hooks[index]
-        val nextChain = VectorChain(executable, thisObject, args, hooks, index + 1, terminal)
+        val nextChain = VectorChain(executable, thisObject, currentArgs, hooks, index + 1, terminal)
 
         return try {
             executeDownstream { record.hooker.intercept(nextChain) }
         } catch (t: Throwable) {
-            handleInterceptorException(t, record, nextChain, thisObject, args)
+            handleInterceptorException(t, record, nextChain, thisObject, currentArgs)
         }
     }
 


### PR DESCRIPTION
We should name the arguments correctly, to not mix with private fields.

Moreover, expand `kModuleTags` to include `VectorModuleManager`, which handles `libxposed` API module loading.