### PR TITLE
Clarify modern modules loading process

### DIFF
--- a/daemon/src/main/jni/logcat.cpp
+++ b/daemon/src/main/jni/logcat.cpp
@@ -34,8 +34,8 @@ constexpr std::array<char, ANDROID_LOG_SILENT + 1> kLogChar = {
 
 // Module tags are sorted for O(log N) binary search.
 // These always route to the 'modules' (Xposed) log stream.
-constexpr auto kModuleTags =
-    std::array{"VectorContext"sv, "VectorLegacyBridge"sv, "XSharedPreferences"sv};
+constexpr auto kModuleTags = std::array{"VectorContext"sv, "VectorLegacyBridge"sv,
+                                        "VectorModuleManager"sv, "XSharedPreferences"sv};
 
 // These route to the 'verbose' stream only.
 constexpr auto kExactTags = std::array{"APatchD"sv, "Dobby"sv,  "KernelSU"sv, "LSPlant"sv,

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/di/VectorBootstrap.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/di/VectorBootstrap.kt
@@ -22,7 +22,7 @@ fun interface OriginalInvoker {
  * methods at the appropriate lifecycle moments.
  */
 interface LegacyFrameworkDelegate {
-    /** Instructs the legacy bridge to load legacy modules. */
+    /** Instructs the legacy bridge to load modern modules. */
     fun loadModules(activityThread: Any)
 
     /** Dispatches a package load event to legacy XC_LoadPackage callbacks. */

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/hookers/AppAttachHooker.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/hookers/AppAttachHooker.kt
@@ -5,7 +5,7 @@ import org.matrix.vector.impl.di.VectorBootstrap
 
 /**
  * Intercepts the early ApplicationThread attachment phase. Triggers the legacy compatibility layer
- * to load modules into the process.
+ * to load modern modules into the process.
  */
 object AppAttachHooker : XposedInterface.Hooker {
     override fun intercept(chain: XposedInterface.Chain): Any? {

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/VectorChain.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/VectorChain.kt
@@ -22,7 +22,7 @@ class VectorChain(
     private val thisObj: Any?,
     private val args: Array<Any?>,
     private val hooks: Array<VectorHookRecord>,
-    private val index: Int,
+    private val hookIndex: Int,
     private val terminal: (thisObj: Any?, args: Array<Any?>) -> Any?,
 ) : Chain {
 
@@ -55,12 +55,13 @@ class VectorChain(
         proceedCalled = true
 
         // Reached the end of the modern hooks; trigger the original executable (and legacy hooks)
-        if (index >= hooks.size) {
+        if (hookIndex >= hooks.size) {
             return executeDownstream { terminal(thisObject, currentArgs) }
         }
 
-        val record = hooks[index]
-        val nextChain = VectorChain(executable, thisObject, currentArgs, hooks, index + 1, terminal)
+        val record = hooks[hookIndex]
+        val nextChain =
+            VectorChain(executable, thisObject, currentArgs, hooks, hookIndex + 1, terminal)
 
         return try {
             executeDownstream { record.hooker.intercept(nextChain) }


### PR DESCRIPTION
Both legacy and modern modules are loaded in `XposedInit.java`. However, to facilitate context fetching and resource loading, modern modules are loaded after an activity thread is attached (`AppAttachHooker.kt`).

We thus correct docs in comments, and add `VectorModuleManager` into `kModuleTags` to monitor modern module loading.

Moreover, the private field of `VectorChain` is renamed to improve readability.