### PR TITLE
Disable dex obfuscation for debug builds

### DIFF
--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/data/DaemonState.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/data/DaemonState.kt
@@ -2,6 +2,7 @@ package org.matrix.vector.daemon.data
 
 import java.nio.file.Path
 import org.lsposed.lspd.models.Module
+import org.matrix.vector.daemon.BuildConfig
 
 data class ProcessScope(val processName: String, val uid: Int)
 
@@ -11,7 +12,7 @@ data class ProcessScope(val processName: String, val uid: Int)
  */
 data class DaemonState(
     // State non configurable for users
-    val isDexObfuscateEnabled: Boolean = true,
+    val isDexObfuscateEnabled: Boolean = !BuildConfig.DEBUG,
     // States initialized after system services are ready
     val isCacheReady: Boolean = false,
     val managerUid: Int = -1,


### PR DESCRIPTION
Modules such as `io.github.mhmrdd.libxposed.ps.passit` [PlayStrong](https://t.me/meetstrong/125) call methods with `libxposed` API signatures via JNI during its initialization, which is bounded to fail if dex obfuscation is always enabled.

Vector has removed the user configuration of `Xposed API Protection` (toggling the dex obfuscation option) during its daemon refactoring in #597, for the reason that this option is too technical for most users.

Ideally, module developers should extend their module compatibility with dex obfuscation mode, by for example, inheriting Xposed APIs. In any case, we now disable dex obfuscation for debug builds, so that Vector users could test out these modules.

P.S.: strong integrity is obtained on my local test with community shared RKA token.