### PR TITLE
Fix miscPath initialization order in daemon cache bootstrap

### DIFF
--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/data/ConfigCache.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/data/ConfigCache.kt
@@ -83,6 +83,8 @@ object ConfigCache {
   }
 
   private fun setupMiscPath() {
+    if (state.miscPath != null) return
+
     val pathStr = PreferenceStore.getModulePrefs("lspd", 0, "config")["misc_path"] as? String
     val path =
         if (pathStr == null) {
@@ -423,7 +425,7 @@ object ConfigCache {
   }
 
   fun getPrefsPath(packageName: String, uid: Int): String {
-    ensureCacheReady()
+    setupMiscPath()
     val basePath = state.miscPath ?: throw IllegalStateException("Fatal: miscPath not initialized!")
 
     val userId = uid / PER_USER_RANGE


### PR DESCRIPTION
I hit this issue while testing CorePatch on Pixel 7, build CP1A.260305.018 (Android 16), and I also saw similar behavior on older ROMs / older LSPosed versions.

This is specifically related to XSharedPreferences path resolution in hooked processes.

The module process itself could read/update settings and correctly wrote XML into /data/misc/<uuid>.
But when a hooked process initialized XSharedPreferences, getPrefsPath() could return an uninitialized/invalid path state (effectively null path behavior), so preferences failed to load.
So the problem is initialization order around miscPath availability at the time XSharedPreferences requests preference path resolution.