### PR TITLE
Fix original method invocation argument spreading

### DIFF
--- a/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/BaseInvoker.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/BaseInvoker.kt
@@ -30,7 +30,7 @@ internal abstract class BaseInvoker<T : Invoker<T, U>, U : Executable>(
         return when (val currentType = type) {
             is Invoker.Type.Origin -> {
                 try {
-                    HookBridge.invokeOriginalMethod(executable, thisObject, args)
+                    HookBridge.invokeOriginalMethod(executable, thisObject, *args)
                 } catch (e: InvocationTargetException) {
                     throw e.cause ?: e
                 }


### PR DESCRIPTION
 ## Summary

Fix `invokeOriginalMethod` argument forwarding in `BaseInvoker`.

## Crash
```
java.lang.IllegalArgumentException: Wrong number of arguments; expected 4, got 1
	at java.lang.reflect.Method.invoke(Native Method)
	at org.matrix.vector.nativebridge.HookBridge.invokeOriginalMethod(Native Method)
	at org.matrix.vector.impl.hooks.BaseInvoker.proceedInvocation(BaseInvoker.kt:33)
	at org.matrix.vector.impl.hooks.VectorMethodInvoker.invoke(BaseInvoker.kt:99)
```