### PR TITLE
Fix manager and modules tripping DCL protection on GrapheneOS

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,6 +64,7 @@ val versionNameProvider by extra(providers.of(GitLatestTagValueSource::class.jav
 val injectedPackageName by extra("com.android.shell")
 val injectedPackageUid by extra(2000)
 val defaultManagerPackageName by extra("org.lsposed.manager")
+val grapheneSettingsPackageName by extra("com.android.settings")
 
 val androidTargetSdkVersion by extra(36)
 val androidMinSdkVersion by extra(27)

--- a/daemon/build.gradle.kts
+++ b/daemon/build.gradle.kts
@@ -4,6 +4,7 @@ import java.io.PrintStream
 import java.util.UUID
 
 val defaultManagerPackageName: String by rootProject.extra
+val grapheneSettingsPackageName: String by rootProject.extra
 val injectedPackageName: String by rootProject.extra
 val injectedPackageUid: Int by rootProject.extra
 val versionCodeProvider: Provider<String> by rootProject.extra
@@ -21,6 +22,11 @@ android {
         "String",
         "DEFAULT_MANAGER_PACKAGE_NAME",
         """"$defaultManagerPackageName"""",
+    )
+    buildConfigField(
+        "String",
+        "GRAPHENE_SETTINGS_PACKAGE_NAME",
+        """"$grapheneSettingsPackageName"""",
     )
     buildConfigField("String", "FRAMEWORK_NAME", """"${rootProject.name}"""")
     buildConfigField("String", "MANAGER_INJECTED_PKG_NAME", """"$injectedPackageName"""")

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/VectorService.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/VectorService.kt
@@ -67,7 +67,7 @@ object VectorService : IDaemonService.Stub() {
     if (ApplicationService.hasRegister(uid, pid)) return null
 
     val scope = ProcessScope(processName, uid)
-    if (!ManagerService.tryRegisterManagerProcess(pid, uid, processName) &&
+    if (processName != "com.android.settings" && !ManagerService.tryRegisterManagerProcess(pid, uid, processName) &&
         ConfigCache.shouldSkipProcess(scope)) {
       Log.d(TAG, "Skipped $processName/$uid")
       return null

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/VectorService.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/VectorService.kt
@@ -67,7 +67,7 @@ object VectorService : IDaemonService.Stub() {
     if (ApplicationService.hasRegister(uid, pid)) return null
 
     val scope = ProcessScope(processName, uid)
-    if (processName != "com.android.settings" && !ManagerService.tryRegisterManagerProcess(pid, uid, processName) &&
+    if (processName != BuildConfig.GRAPHENE_SETTINGS_PACKAGE_NAME && !ManagerService.tryRegisterManagerProcess(pid, uid, processName) &&
         ConfigCache.shouldSkipProcess(scope)) {
       Log.d(TAG, "Skipped $processName/$uid")
       return null

--- a/hiddenapi/stubs/src/main/java/android/ext/settings/app/AswRestrictMemoryDynCodeLoading.java
+++ b/hiddenapi/stubs/src/main/java/android/ext/settings/app/AswRestrictMemoryDynCodeLoading.java
@@ -1,4 +1,0 @@
-package android.ext.settings.app;
-
-public class AswRestrictMemoryDynCodeLoading {
-}

--- a/hiddenapi/stubs/src/main/java/android/ext/settings/app/AswRestrictMemoryDynCodeLoading.java
+++ b/hiddenapi/stubs/src/main/java/android/ext/settings/app/AswRestrictMemoryDynCodeLoading.java
@@ -1,0 +1,4 @@
+package android.ext.settings.app;
+
+public class AswRestrictMemoryDynCodeLoading {
+}

--- a/zygisk/build.gradle.kts
+++ b/zygisk/build.gradle.kts
@@ -15,6 +15,7 @@ val versionNameProvider: Provider<String> by rootProject.extra
 val injectedPackageName: String by rootProject.extra
 val injectedPackageUid: Int by rootProject.extra
 val defaultManagerPackageName: String by rootProject.extra
+val grapheneSettingsPackageName: String by rootProject.extra
 
 android {
     namespace = "org.matrix.vector"
@@ -24,12 +25,14 @@ android {
         buildConfigField("int", "HostPackageUid", "${injectedPackageUid}")
         buildConfigField("String", "InjectedPackageName", """"${injectedPackageName}"""")
         buildConfigField("String", "ManagerPackageName", """"${defaultManagerPackageName}"""")
+        buildConfigField("String", "GrapheneSettingsPackageName", """"${grapheneSettingsPackageName}"""")
 
         val flags =
             listOf(
                 "-DINJECTED_PACKAGE_NAME='\"${injectedPackageName}\"'",
                 "-DINJECTED_PACKAGE_UID=${injectedPackageUid}",
                 "-DMANAGER_PACKAGE_NAME='\"${defaultManagerPackageName}\"'",
+                "-DGRAPHENE_SETTINGS_PACKAGE_NAME='\"${grapheneSettingsPackageName}\"'",
             )
 
         externalNativeBuild {

--- a/zygisk/src/main/kotlin/org/matrix/vector/ParasiticManagerHooker.kt
+++ b/zygisk/src/main/kotlin/org/matrix/vector/ParasiticManagerHooker.kt
@@ -441,6 +441,50 @@ object ParasiticManagerHooker {
         }
     }
 
+    @JvmStatic
+    fun patchGrapheneDCLRestriction() {
+        try {
+            // Force GrapheneOS to allow changing the restriction on Dynamic Code Loading, and
+            // force-disable it for the settings app and the shell
+            XposedBridge.hookAllMethods(
+                XposedHelpers.findClass(
+                    "android.ext.settings.app.AswRestrictMemoryDynCodeLoading",
+                    this.javaClass.classLoader
+                ),
+                "getImmutableValue",
+                object : XC_MethodReplacement() {
+                    override fun replaceHookedMethod(param: MethodHookParam<*>?): Any? {
+                        val appInfo = param?.args[2] as? ApplicationInfo?
+
+                        // Settings has to always be allowed so that it can be patched as well.
+                        // The parasitic host package is also allowed so that the manager functions correctly.
+                        if (appInfo != null && listOf(
+                                BuildConfig.GrapheneSettingsPackageName,
+                                BuildConfig.InjectedPackageName
+                            ).contains(appInfo.packageName)
+                        ) {
+                            return false
+                        }
+
+                        // All system apps are configurable (null)
+                        if (appInfo != null && (appInfo.flags and ApplicationInfo.FLAG_SYSTEM) != 0) {
+                            return null
+                        }
+
+                        // Defer to original implementation for other apps
+                        return XposedBridge.invokeOriginalMethod(
+                            param?.method, param?.thisObject, param?.args
+                        )
+                    }
+                }
+            )
+        } catch (_: XposedHelpers.ClassNotFoundError) {
+            // Ignore, assuming we are not on GrapheneOS
+        } catch (e: Exception) {
+            Utils.logE("Unknown error patching Graphene DCL", e)
+        }
+    }
+
     /** Entry point. Checks if the current process should host the parasitic manager. */
     @JvmStatic
     fun start(): Boolean {

--- a/zygisk/src/main/kotlin/org/matrix/vector/core/Main.kt
+++ b/zygisk/src/main/kotlin/org/matrix/vector/core/Main.kt
@@ -1,12 +1,7 @@
 package org.matrix.vector.core
 
-import android.content.pm.ApplicationInfo
-import android.ext.settings.app.AswRestrictMemoryDynCodeLoading
 import android.os.IBinder
 import android.os.Process
-import de.robv.android.xposed.XC_MethodReplacement
-import de.robv.android.xposed.XposedBridge
-import de.robv.android.xposed.XposedHelpers
 import org.lsposed.lspd.service.ILSPApplicationService
 import org.lsposed.lspd.util.Utils
 import org.matrix.vector.BuildConfig
@@ -40,43 +35,8 @@ object Main {
             ParasiticManagerSystemHooker.start()
         }
 
-        if (niceName == "system" || niceName == "com.android.settings") {
-            try {
-                // Force GrapheneOS to allow changing the restriction on Dynamic Code Loading, and
-                // force-disable it for the settings app and the shell
-                XposedBridge.hookAllMethods(
-                    AswRestrictMemoryDynCodeLoading::class.java,
-                    "getImmutableValue",
-                    object : XC_MethodReplacement() {
-                        override fun replaceHookedMethod(param: MethodHookParam<*>?): Any? {
-                            val appInfo = param?.args[2] as? ApplicationInfo?
-
-                            // Settings has to always be allowed so that it can be patched as well.
-                            if (appInfo != null && listOf(
-                                    "com.android.settings",
-                                    "com.android.shell"
-                                ).contains(appInfo.packageName)
-                            ) {
-                                return false
-                            }
-
-                            // All system apps are configurable (null)
-                            if (appInfo != null && (appInfo.flags and ApplicationInfo.FLAG_SYSTEM) != 0) {
-                                return null
-                            }
-
-                            // Defer to original implementation for other apps
-                            return XposedBridge.invokeOriginalMethod(
-                                param?.method, param?.thisObject, param?.args
-                            )
-                        }
-                    }
-                )
-            } catch (e: XposedHelpers.ClassNotFoundError) {
-                // Ignore, assuming we are not on GrapheneOS
-            } catch (e: Exception) {
-                Utils.logE("Unknown error patching Graphene", e)
-            }
+        if (isSystem || niceName == BuildConfig.GrapheneSettingsPackageName) {
+            ParasiticManagerHooker.patchGrapheneDCLRestriction()
         }
 
         // Initialize Xposed bridge components

--- a/zygisk/src/main/kotlin/org/matrix/vector/core/Main.kt
+++ b/zygisk/src/main/kotlin/org/matrix/vector/core/Main.kt
@@ -1,7 +1,12 @@
 package org.matrix.vector.core
 
+import android.content.pm.ApplicationInfo
+import android.ext.settings.app.AswRestrictMemoryDynCodeLoading
 import android.os.IBinder
 import android.os.Process
+import de.robv.android.xposed.XC_MethodReplacement
+import de.robv.android.xposed.XposedBridge
+import de.robv.android.xposed.XposedHelpers
 import org.lsposed.lspd.service.ILSPApplicationService
 import org.lsposed.lspd.util.Utils
 import org.matrix.vector.BuildConfig
@@ -33,6 +38,45 @@ object Main {
         // Initialize system-specific resolution hooks if in system_server
         if (isSystem) {
             ParasiticManagerSystemHooker.start()
+        }
+
+        if (niceName == "system" || niceName == "com.android.settings") {
+            try {
+                // Force GrapheneOS to allow changing the restriction on Dynamic Code Loading, and
+                // force-disable it for the settings app and the shell
+                XposedBridge.hookAllMethods(
+                    AswRestrictMemoryDynCodeLoading::class.java,
+                    "getImmutableValue",
+                    object : XC_MethodReplacement() {
+                        override fun replaceHookedMethod(param: MethodHookParam<*>?): Any? {
+                            val appInfo = param?.args[2] as? ApplicationInfo?
+
+                            // Settings has to always be allowed so that it can be patched as well.
+                            if (appInfo != null && listOf(
+                                    "com.android.settings",
+                                    "com.android.shell"
+                                ).contains(appInfo.packageName)
+                            ) {
+                                return false
+                            }
+
+                            // All system apps are configurable (null)
+                            if (appInfo != null && (appInfo.flags and ApplicationInfo.FLAG_SYSTEM) != 0) {
+                                return null
+                            }
+
+                            // Defer to original implementation for other apps
+                            return XposedBridge.invokeOriginalMethod(
+                                param?.method, param?.thisObject, param?.args
+                            )
+                        }
+                    }
+                )
+            } catch (e: XposedHelpers.ClassNotFoundError) {
+                // Ignore, assuming we are not on GrapheneOS
+            } catch (e: Exception) {
+                Utils.logE("Unknown error patching Graphene", e)
+            }
         }
 
         // Initialize Xposed bridge components


### PR DESCRIPTION
Things of note:

- I have not tested this on a non-grapheneos device 
- I have not tested this on old versions of grapheneos, but the patch seems very resilient to change
- I have been wondering if it's possible for modules to trigger Storage DCL but I have yet to see any so it is not patched here
- I think it'd be helpful/possible without increasing the complexity of the patch too much to force-allow DCL for apps that are selected as a scope in any enabled module, since the user would be doing that anyway. Just not sure how to do that in the simplest way, since all the data needed to calculate that seem to be in other places than the zygisk process.