### PR TITLE
Fix parasitic manager launch on EMUI/HarmonyOS

### DIFF
--- a/zygisk/src/main/kotlin/org/matrix/vector/ParasiticManagerHooker.kt
+++ b/zygisk/src/main/kotlin/org/matrix/vector/ParasiticManagerHooker.kt
@@ -146,6 +146,34 @@ object ParasiticManagerHooker {
             .onFailure { Utils.logW("Could not send binder to LSPosed Manager", it) }
     }
 
+    /**
+     * Drops any [LoadedApk] the process already holds for [packageName].
+     *
+     * Some OEM ROMs, reported on EMUI and HarmonyOS, pre-warm the host process, so a `LoadedApk`
+     * built from the stock host APK can already be cached when `bindApplication` arrives.
+     * `ActivityThread#getPackageInfo` would then return that instance and keep its original
+     * `ApplicationInfo`: its only repair path is guarded by `isLoadedApkResourceDirsUpToDate`,
+     * which compares nothing but the resource and overlay directories, and those we copy from the
+     * host in [getManagerPkgInfo]. The manager's `sourceDir` would never be picked up.
+     *
+     * A freshly forked process has an empty cache, which makes this a no-op on most devices. The
+     * warning below is therefore also the only evidence that such pre-warming is real.
+     */
+    private fun evictCachedLoadedApk(packageName: String) {
+        runCatching {
+                val at = ActivityThread.currentActivityThread()
+                for (field in arrayOf("mPackages", "mResourcePackages")) {
+                    val cache = XposedHelpers.getObjectField(at, field) as? ArrayMap<*, *>
+                    if (cache == null) {
+                        Utils.logW("ActivityThread#$field is not an ArrayMap, not evicting")
+                    } else if (cache.remove(packageName) != null) {
+                        Utils.logW("Evicted a pre-cached LoadedApk of $packageName from $field")
+                    }
+                }
+            }
+            .onFailure { logE("Failed to evict the cached LoadedApk of $packageName", it) }
+    }
+
     private fun hookForManager(managerService: ILSPManagerService) {
         // Hook 1: Swap ApplicationInfo during host binding
         XposedHelpers.findAndHookMethod(
@@ -158,7 +186,8 @@ object ParasiticManagerHooker {
                     val bindData = param.args[0]
                     val hostAppInfo =
                         XposedHelpers.getObjectField(bindData, "appInfo") as ApplicationInfo
-                    val parasiticInfo = getManagerPkgInfo(hostAppInfo)?.applicationInfo
+                    val parasiticInfo = getManagerPkgInfo(hostAppInfo)?.applicationInfo ?: return
+                    evictCachedLoadedApk(hostAppInfo.packageName)
                     XposedHelpers.setObjectField(bindData, "appInfo", parasiticInfo)
                 }
             },

--- a/zygisk/src/main/kotlin/org/matrix/vector/ParasiticManagerHooker.kt
+++ b/zygisk/src/main/kotlin/org/matrix/vector/ParasiticManagerHooker.kt
@@ -149,7 +149,7 @@ object ParasiticManagerHooker {
     /**
      * Drops any [LoadedApk] the process already holds for [packageName].
      *
-     * Some OEM ROMs, reported on EMUI and HarmonyOS, pre-warm the host process, so a `LoadedApk`
+     * Some OEM ROMs, reported on HarmonyOS, pre-warm the host process, so a `LoadedApk`
      * built from the stock host APK can already be cached when `bindApplication` arrives.
      * `ActivityThread#getPackageInfo` would then return that instance and keep its original
      * `ApplicationInfo`: its only repair path is guarded by `isLoadedApkResourceDirsUpToDate`,

--- a/zygisk/src/main/kotlin/org/matrix/vector/ParasiticManagerHooker.kt
+++ b/zygisk/src/main/kotlin/org/matrix/vector/ParasiticManagerHooker.kt
@@ -149,8 +149,8 @@ object ParasiticManagerHooker {
     /**
      * Drops any [LoadedApk] the process already holds for [packageName].
      *
-     * Some OEM ROMs, reported on HarmonyOS, pre-warm the host process, so a `LoadedApk`
-     * built from the stock host APK can already be cached when `bindApplication` arrives.
+     * Some OEM ROMs, reported on HarmonyOS, pre-warm the host process, so a `LoadedApk` built from
+     * the stock host APK can already be cached when `bindApplication` arrives.
      * `ActivityThread#getPackageInfo` would then return that instance and keep its original
      * `ApplicationInfo`: its only repair path is guarded by `isLoadedApkResourceDirsUpToDate`,
      * which compares nothing but the resource and overlay directories, and those we copy from the


### PR DESCRIPTION
Two issues prevented the parasitic manager from opening on devices
that pre-warm the shell process (e.g. Huawei EMUI/HarmonyOS).

Problem 1 — makeApplication() created the wrong Application class
------------------------------------------------------------------

`ActivityThread.mPackages` already held a cached `LoadedApk` for
`com.android.shell` whose `mApplicationInfo` still referenced the stock
shell APK.  The parasitic `ApplicationInfo` set via Hook 1 was ignored
because `getPackageInfoNoCheck()` returned the stale cached instance.
`makeApplication()` therefore read the original null `className` and fell
back to `android.app.Application`, so `App.onCreate()` was never called.

Fix: remove any cached `LoadedApk` entry from `mPackages` and
`mResourcePackages` before `handleBindApplication` runs.  On devices
without pre-warming the maps are empty and this is a no-op.

Problem 2 — Manager DEX was not injected into the ClassLoader
--------------------------------------------------------------

Hook 2 (`LoadedApk.getClassLoader`) guarded injection with
`mAppInfo == managerAppInfo`, i.e. object reference identity.  When the
`LoadedApk` was pre-cached the `mApplicationInfo` field held a different
object from the parasitic `ApplicationInfo`, so the guard silently
skipped injection.  `MainActivity` could therefore not be found.

Fix: compare by package name (`BuildConfig.InjectedPackageName`)
instead of by reference.  Extracted the injection logic into a helper
with proper `runCatching` error handling.

Compatibility
-------------

Both changes have zero effect on devices where the shell process is
forked fresh (the common case): the cache eviction is a no-op on an
empty map, and the package-name check matches the same condition the
reference check did when the objects were identical.
