### PR TITLE
Fix Vector update metadata and version checks

### DIFF
--- a/app/src/main/java/org/lsposed/manager/util/UpdateUtil.java
+++ b/app/src/main/java/org/lsposed/manager/util/UpdateUtil.java
@@ -29,13 +29,11 @@ import com.google.gson.JsonParser;
 
 import org.lsposed.manager.App;
 import org.lsposed.manager.BuildConfig;
-import org.lsposed.manager.ConfigManager;
 
 import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.util.Locale;
+import java.util.regex.Pattern;
 
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -44,9 +42,11 @@ import okhttp3.Response;
 import okio.Okio;
 
 public class UpdateUtil {
+    private static final Pattern VERSION_CODE_PATTERN = Pattern.compile("-(\\d+)(?=[-.])");
+
     public static void loadRemoteVersion() {
         var request = new Request.Builder()
-                .url("https://api.github.com/repos/JingMatrix/LSPosed/releases/latest")
+                .url("https://api.github.com/repos/JingMatrix/Vector/releases/latest")
                 .addHeader("Accept", "application/vnd.github.v3+json")
                 .build();
         var callback = new Callback() {
@@ -81,9 +81,10 @@ public class UpdateUtil {
     private static void checkAssets(JsonObject assets, String releaseNotes) {
         var pref = App.getPreferences();
         var name = assets.get("name").getAsString();
-        var splitName = name.split("-");
+        var versionCode = parseVersionCode(name);
+        if (versionCode == null) return;
         pref.edit()
-                .putInt("latest_version", Integer.parseInt(splitName[2]))
+                .putInt("latest_version", versionCode)
                 .putLong("latest_check", Instant.now().getEpochSecond())
                 .putString("release_notes", releaseNotes)
                 .putString("zip_file", null)
@@ -107,17 +108,18 @@ public class UpdateUtil {
     public static boolean needUpdate() {
         var pref = App.getPreferences();
         if (!pref.getBoolean("checked", false)) return false;
-        var now = Instant.now();
-        var buildTime = Instant.ofEpochSecond(BuildConfig.BUILD_TIME);
-        var check = pref.getLong("latest_check", 0);
-        if (check > 0) {
-            var checkTime = Instant.ofEpochSecond(check);
-            if (checkTime.atOffset(ZoneOffset.UTC).plusDays(30).toInstant().isBefore(now))
-                return true;
-            var code = pref.getInt("latest_version", 0);
-            return code > BuildConfig.VERSION_CODE;
+        var code = pref.getInt("latest_version", 0);
+        return code > BuildConfig.VERSION_CODE;
+    }
+
+    @Nullable
+    private static Integer parseVersionCode(String name) {
+        var matcher = VERSION_CODE_PATTERN.matcher(name);
+        Integer versionCode = null;
+        while (matcher.find()) {
+            versionCode = Integer.parseInt(matcher.group(1));
         }
-        return buildTime.atOffset(ZoneOffset.UTC).plusDays(30).toInstant().isBefore(now);
+        return versionCode;
     }
 
     @Nullable

--- a/app/src/main/java/org/lsposed/manager/util/UpdateUtil.java
+++ b/app/src/main/java/org/lsposed/manager/util/UpdateUtil.java
@@ -83,17 +83,18 @@ public class UpdateUtil {
         var name = assets.get("name").getAsString();
         var versionCode = parseVersionCode(name);
         if (versionCode == null) return;
+        var updatedAt = Instant.parse(assets.get("updated_at").getAsString());
+        var downloadUrl = assets.get("browser_download_url").getAsString();
+        var zipTime = pref.getLong("zip_time", 0);
+        var hasNewAsset = !updatedAt.equals(Instant.ofEpochSecond(zipTime));
         pref.edit()
                 .putInt("latest_version", versionCode)
                 .putLong("latest_check", Instant.now().getEpochSecond())
                 .putString("release_notes", releaseNotes)
-                .putString("zip_file", null)
                 .putBoolean("checked", true)
                 .apply();
-        var updatedAt = Instant.parse(assets.get("updated_at").getAsString());
-        var downloadUrl = assets.get("browser_download_url").getAsString();
-        var zipTime = pref.getLong("zip_time", 0);
-        if (!updatedAt.equals(Instant.ofEpochSecond(zipTime))) {
+        if (hasNewAsset) {
+            pref.edit().putString("zip_file", null).apply();
             var zip = downloadNewZipSync(downloadUrl, name);
             var size = assets.get("size").getAsLong();
             if (zip != null && zip.length() == size) {

--- a/app/src/main/java/org/lsposed/manager/util/UpdateUtil.java
+++ b/app/src/main/java/org/lsposed/manager/util/UpdateUtil.java
@@ -118,7 +118,11 @@ public class UpdateUtil {
         var matcher = VERSION_CODE_PATTERN.matcher(name);
         Integer versionCode = null;
         while (matcher.find()) {
-            versionCode = Integer.parseInt(matcher.group(1));
+            try {
+                versionCode = Integer.parseInt(matcher.group(1));
+            } catch (NumberFormatException e) {
+                return null;
+            }
         }
         return versionCode;
     }

--- a/app/src/main/res/values/strings_untranslatable.xml
+++ b/app/src/main/res/values/strings_untranslatable.xml
@@ -19,7 +19,7 @@
 
 <resources>
     <string name="app_name" translatable="false">LSPosed</string>
-    <string name="install_url" translatable="false">https://github.com/JingMatrix/LSPosed#install</string>
-    <string name="latest_url" translatable="false">https://github.com/JingMatrix/LSPosed/releases/latest</string>
+    <string name="install_url" translatable="false">https://github.com/JingMatrix/Vector#install</string>
+    <string name="latest_url" translatable="false">https://github.com/JingMatrix/Vector/releases/latest</string>
     <string name="settings_group_repo" translatable="false">@string/module_repo</string>
 </resources>

--- a/app/src/main/res/values/strings_untranslatable.xml
+++ b/app/src/main/res/values/strings_untranslatable.xml
@@ -19,7 +19,7 @@
 
 <resources>
     <string name="app_name" translatable="false">LSPosed</string>
-    <string name="install_url" translatable="false">https://github.com/JingMatrix/Vector#install</string>
+    <string name="install_url" translatable="false">https://github.com/JingMatrix/Vector#installation</string>
     <string name="latest_url" translatable="false">https://github.com/JingMatrix/Vector/releases/latest</string>
     <string name="settings_group_repo" translatable="false">@string/module_repo</string>
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,16 +99,12 @@ subprojects {
                     versionName = versionNameProvider.get()
                 }
 
-                val flags =
-                    listOf(
-                        "-DVERSION_CODE=${versionCodeProvider.get()}",
-                        "-DVERSION_NAME='\"${versionNameProvider.get()}\"'",
-                    )
-
                 val args =
                     listOf(
                         "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
                         "-DVECTOR_ROOT=${rootDir.absolutePath}",
+                        "-DVECTOR_VERSION_CODE=${versionCodeProvider.get()}",
+                        "-DVECTOR_VERSION_NAME=${versionNameProvider.get()}",
                         // Enforce 16 KB page size alignment for Android 15+ compatibility
                         "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,-z,max-page-size=16384",
                         "-DCMAKE_EXE_LINKER_FLAGS=-Wl,-z,max-page-size=16384",
@@ -116,8 +112,6 @@ subprojects {
 
                 externalNativeBuild {
                     cmake {
-                        cFlags.addAll(flags)
-                        cppFlags.addAll(flags)
                         arguments.addAll(args)
                     }
                 }

--- a/magisk-loader/update/zygisk.json
+++ b/magisk-loader/update/zygisk.json
@@ -1,6 +1,6 @@
 {
 	"version": "v2.0",
 	"versionCode": 3021,
-	"zipUrl": "https://github.com/JingMatrix/LSPosed/releases/download/v2.0/Vector-v2.0-Release.zip",
-	"changelog": "https://raw.githubusercontent.com/JingMatrix/LSPosed/master/zygisk/changelog.md"
+	"zipUrl": "https://github.com/JingMatrix/Vector/releases/download/v2.0/Vector-v2.0-3021-Release.zip",
+	"changelog": "https://raw.githubusercontent.com/JingMatrix/Vector/master/zygisk/changelog.md"
 }

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -9,6 +9,11 @@ add_subdirectory(${VECTOR_ROOT}/external external)
 file(GLOB_RECURSE NATIVE_SOURCES "src/*.cpp")
 add_library(${PROJECT_NAME} STATIC ${NATIVE_SOURCES})
 
+target_compile_definitions(${PROJECT_NAME} PUBLIC
+    VERSION_CODE=${VECTOR_VERSION_CODE}
+    VERSION_NAME="${VECTOR_VERSION_NAME}"
+)
+
 set(IGNORED_WARNINGS
     -Wno-c99-extensions
     -Wno-extra-semi

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -9,6 +9,15 @@ add_subdirectory(${VECTOR_ROOT}/external external)
 file(GLOB_RECURSE NATIVE_SOURCES "src/*.cpp")
 add_library(${PROJECT_NAME} STATIC ${NATIVE_SOURCES})
 
+# Fall back to neutral defaults when the build is invoked outside Gradle
+# (e.g. direct cmake calls). Gradle always supplies VECTOR_VERSION_*.
+if(NOT DEFINED VECTOR_VERSION_CODE)
+    set(VECTOR_VERSION_CODE 0)
+endif()
+if(NOT DEFINED VECTOR_VERSION_NAME)
+    set(VECTOR_VERSION_NAME "unknown")
+endif()
+
 target_compile_definitions(${PROJECT_NAME} PUBLIC
     VERSION_CODE=${VECTOR_VERSION_CODE}
     VERSION_NAME="${VECTOR_VERSION_NAME}"

--- a/zygisk/build.gradle.kts
+++ b/zygisk/build.gradle.kts
@@ -25,17 +25,15 @@ android {
         buildConfigField("String", "InjectedPackageName", """"${injectedPackageName}"""")
         buildConfigField("String", "ManagerPackageName", """"${defaultManagerPackageName}"""")
 
-        val flags =
-            listOf(
-                "-DINJECTED_PACKAGE_NAME='\"${injectedPackageName}\"'",
-                "-DINJECTED_PACKAGE_UID=${injectedPackageUid}",
-                "-DMANAGER_PACKAGE_NAME='\"${defaultManagerPackageName}\"'",
-            )
-
         externalNativeBuild {
             cmake {
-                cFlags.addAll(flags)
-                cppFlags.addAll(flags)
+                arguments.addAll(
+                    listOf(
+                        "-DVECTOR_INJECTED_PACKAGE_NAME=${injectedPackageName}",
+                        "-DVECTOR_INJECTED_PACKAGE_UID=${injectedPackageUid}",
+                        "-DVECTOR_MANAGER_PACKAGE_NAME=${defaultManagerPackageName}",
+                    )
+                )
             }
         }
     }

--- a/zygisk/module/module.prop
+++ b/zygisk/module/module.prop
@@ -4,4 +4,4 @@ version=${versionName} (${versionCode})
 versionCode=${versionCode}
 author=JingMatrix
 description=A modern, Xposed-compatible framework for Android application hooking. (Android 8.1 ~ 16)
-updateJson=https://raw.githubusercontent.com/JingMatrix/LSPosed/master/zygisk/update.json
+updateJson=https://raw.githubusercontent.com/JingMatrix/Vector/master/zygisk/update.json

--- a/zygisk/src/main/cpp/CMakeLists.txt
+++ b/zygisk/src/main/cpp/CMakeLists.txt
@@ -9,6 +9,11 @@ add_subdirectory(${VECTOR_ROOT}/native native)
 
 add_library(${PROJECT_NAME} SHARED module.cpp ipc_bridge.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC include)
+target_compile_definitions(${PROJECT_NAME} PRIVATE
+        INJECTED_PACKAGE_NAME="${VECTOR_INJECTED_PACKAGE_NAME}"
+        INJECTED_PACKAGE_UID=${VECTOR_INJECTED_PACKAGE_UID}
+        MANAGER_PACKAGE_NAME="${VECTOR_MANAGER_PACKAGE_NAME}"
+)
 
 target_link_libraries(${PROJECT_NAME} native log)
 

--- a/zygisk/update.json
+++ b/zygisk/update.json
@@ -1,6 +1,6 @@
 {
 	"version": "v2.0",
 	"versionCode": 3021,
-	"zipUrl": "https://github.com/JingMatrix/LSPosed/releases/download/v2.0/Vector-v2.0-Release.zip",
-	"changelog": "https://raw.githubusercontent.com/JingMatrix/LSPosed/master/zygisk/changelog.md"
+	"zipUrl": "https://github.com/JingMatrix/Vector/releases/download/v2.0/Vector-v2.0-3021-Release.zip",
+	"changelog": "https://raw.githubusercontent.com/JingMatrix/Vector/master/zygisk/changelog.md"
 }


### PR DESCRIPTION
## Summary

- Point manager update checks and update/install metadata at `JingMatrix/Vector` instead of the old `JingMatrix/LSPosed` URLs.
- Parse release asset version codes with a regex so current asset names such as `Vector-v2.0-3021-Release.zip` are handled robustly.
- Only show the manager update prompt when the confirmed latest release version code is greater than the installed build.
- Move native compile-time macro values from Gradle `cFlags`/`cppFlags` string injection into CMake `target_compile_definitions`, avoiding Windows quoting issues for string macros.

## Why

The manager could report that Vector needed an update even when the installed build was newer than the latest published release. This happened because the update check still targeted the old LSPosed release endpoint and because the stale/failed-check fallback treated old check timestamps as an update condition.

## Validation

- Confirmed the latest `JingMatrix/Vector` release assets are named `Vector-v2.0-3021-Debug.zip` and `Vector-v2.0-3021-Release.zip`.
- Ran `git diff --check origin/master..HEAD`.
- Ran `./gradlew.bat --no-daemon :app:assembleDebug :app:compileDebugJavaWithJavac :zygisk:zipDebug`.
- Installed and verified the patched debug module on a OnePlus 12 / PJD110 through KernelSU:
  - Vector module: `v2.0 (3043)`
  - KernelSU module state: `enabled=true`, `update=false`
  - Manager overview: framework `2.0 (3043)`, API `101`
  - Existing modules such as LuckyTool and Scene remained visible.

`./gradlew.bat --no-daemon check` was also attempted, but it failed before project checks ran because Gradle could not download lint dependencies from Google Maven / Maven Central due to TLS handshake failures in this local network environment.