### PR TITLE
Add daemon process watchdog with crash rate-limiting

### DIFF
--- a/zygisk/module/daemon
+++ b/zygisk/module/daemon
@@ -42,5 +42,5 @@ fi
 
 [ "$debug" = "true" ] && log -p d -t "Vector" "Starting daemon $*"
 
-# Launch the daemon
-exec /system/bin/app_process $java_options /system/bin --nice-name=lspd org.matrix.vector.daemon.VectorDaemon "$@" >/dev/null 2>&1
+# Launch the daemon (no exec so the watchdog loop in service.sh can restart it)
+/system/bin/app_process $java_options /system/bin --nice-name=lspd org.matrix.vector.daemon.VectorDaemon "$@" >/dev/null 2>&1

--- a/zygisk/module/service.sh
+++ b/zygisk/module/service.sh
@@ -1,6 +1,32 @@
-# Extract the directory path and change directory 
+# Extract the directory path and change directory
 MODDIR="${0%/*}"
 cd "$MODDIR" || exit 1
 
-# Start the daemon directly in the background within a private mount namespace
-unshare --propagation slave -m "$MODDIR/daemon" --system-server-max-retry=3 "$@" &
+# Watchdog loop: automatically restart the daemon if it crashes.
+# Each iteration creates a fresh mount namespace (unshare -m), so no stale
+# mount points accumulate.
+#
+# Rate-limiting: if the daemon crashes more than 3 times within any 60-second
+# window the watchdog enters a 3-minute cooldown before retrying, then resets
+# the counter.  Otherwise it restarts after a 5-second pause.
+fails=0
+window_start=$(date +%s)
+while true; do
+    unshare --propagation slave -m "$MODDIR/daemon" --system-server-max-retry=3 "$@"
+    # daemon exited (crashed)
+    now=$(date +%s)
+    fails=$((fails + 1))
+    if [ $((now - window_start)) -le 60 ] && [ $fails -gt 3 ]; then
+        # exceeded crash budget → cooldown
+        sleep 180
+        fails=0
+        window_start=$(date +%s)
+    elif [ $((now - window_start)) -gt 60 ]; then
+        # window expired, reset
+        fails=1
+        window_start=$now
+        sleep 5
+    else
+        sleep 5
+    fi
+done &


### PR DESCRIPTION
When the Vector daemon process crashes, all existing Binder connections
are permanently severed:

- The **manager app** calls `System.exit(0)` in its `DeathRecipient`.
- **Injected app processes** clear their `VectorServiceClient` service
  reference and never attempt to reconnect.
- **Newly forked apps** fail to obtain the IPC binder in `postAppSpecialize`
  and skip Xposed injection entirely.
- Only `system_server` can recover, because `VectorDaemon` re-injects
  into it on startup.

However, all persistent state (module configs, scopes, preferences, logs)
lives on disk and survives the crash.  If the daemon is restarted, new
processes can once again get a fresh binder and be injected — so an
automatic restart still restores meaningful functionality.

Changes
-------

### `zygisk/module/service.sh`

Wrap the `unshare` launch in a rate-limited watchdog loop:

- If the daemon crashes **more than 3 times within 60 seconds**, the
  watchdog enters a **3-minute cooldown** before retrying, then resets
  the counter.  This prevents tight crash-loops from burning CPU.
- Normal (infrequent) crashes use a **5-second** restart delay.
- The entire loop runs in the background (`done &`), so Magisk's
  `late_start` service handler returns immediately and is never blocked.
- Each iteration calls `unshare -m`, creating a fresh mount namespace;
  stale mounts from a previous crashed daemon do not accumulate.

### `zygisk/module/daemon`

Drop the `exec` keyword from the `app_process` invocation.  Without
`exec`, the `app_process` process runs as a child of the daemon script.
When it exits, control returns to the shell script, which finishes,
allowing the watchdog loop in `service.sh` to iterate.  (Previously
`exec` replaced the shell process, so when the daemon died there was
nothing left to restart it.)

Compatibility
-------------

No effect on the daemon's normal operation path.  When the daemon does
not crash, the watchdog loop is parked at `unshare` waiting for it to
exit — identical to the original behavior.