### PR TITLE
Handle denied system DNS lookup in manager

### DIFF
--- a/app/src/main/java/org/lsposed/manager/util/CloudflareDNS.java
+++ b/app/src/main/java/org/lsposed/manager/util/CloudflareDNS.java
@@ -64,7 +64,9 @@ public final class CloudflareDNS implements Dns {
                 return SYSTEM.lookup(hostname);
             }
         } catch (SecurityException e) {
-            var unknownHost = new UnknownHostException(e.getMessage());
+            var message = e.getMessage();
+            var unknownHost = new UnknownHostException(
+                    message == null ? hostname : hostname + ": " + message);
             unknownHost.initCause(e);
             throw unknownHost;
         }

--- a/app/src/main/java/org/lsposed/manager/util/CloudflareDNS.java
+++ b/app/src/main/java/org/lsposed/manager/util/CloudflareDNS.java
@@ -57,10 +57,16 @@ public final class CloudflareDNS implements Dns {
     @NonNull
     @Override
     public List<InetAddress> lookup(@NonNull String hostname) throws UnknownHostException {
-        if (DoH && noProxy) {
-            return cloudflare.lookup(hostname);
-        } else {
-            return SYSTEM.lookup(hostname);
+        try {
+            if (DoH && noProxy) {
+                return cloudflare.lookup(hostname);
+            } else {
+                return SYSTEM.lookup(hostname);
+            }
+        } catch (SecurityException e) {
+            var unknownHost = new UnknownHostException(e.getMessage());
+            unknownHost.initCause(e);
+            throw unknownHost;
         }
     }
 }


### PR DESCRIPTION
Fixes #636

When DoH is disabled, or when the DoH resolver fails and falls back, the manager uses OkHttp's system DNS implementation through `CloudflareDNS.lookup()`. The crash log in #636 shows Android 11 can throw an unchecked `SecurityException` from that DNS lookup path:

- `FATAL EXCEPTION: OkHttp Dispatcher`
- `java.lang.SecurityException: Permission denied (missing INTERNET permission?)`
- `at org.lsposed.manager.util.CloudflareDNS.lookup(...)`

The manifest already declares `android.permission.INTERNET`, so this is not a manifest-permission fix. Instead, handle the denied lookup defensively around the final system resolver call by converting `SecurityException` into `UnknownHostException`, which is the checked failure type OkHttp expects from DNS implementations.

This keeps the DoH timeout, session-scoped disable flag, fallback log, and `UnknownHostException` fallback behavior added by #765 unchanged. Normal system-DNS `UnknownHostException` failures also continue to propagate unchanged.

## Validation

- `git diff --check`
- `./gradlew.bat --no-daemon :app:compileDebugJavaWithJavac`
- `./gradlew.bat --no-daemon :app:assembleDebug`
- Android 11 / API 30 emulator (`Vector_API30`), `doh=false`: manager UI launches and remains alive; no fatal crash in logcat.
- Android 11 / API 30 local-only fault injection against current `master`: base reproduces `FATAL EXCEPTION: OkHttp Dispatcher`; this branch converts the same denial to a hostname-bearing `UnknownHostException` with no fatal crash.
- Android 11 / API 30 local-only DoH-failure + system-denial injection: the #765 fallback log remains, and the system denial is converted without a fatal crash.

## Reproduction boundary

I could not reproduce the exact `EPERM` / `SecurityException` on a clean API 30 emulator. Attempts included Private DNS `off`, `opportunistic`, invalid hostname mode, Data Saver / app UID restrict-background blacklist, and a local-only no-`INTERNET` manifest build. These did not reproduce the reporter's environment-specific `android_getaddrinfo failed: EPERM` path.

To verify the fix still covers the reported failure mode, I used a local-only fault-injection comparison that was not included in this PR:

- On current `origin/master` after #765 (`2a633ef0`), injecting the same `SecurityException("Permission denied (missing INTERNET permission?)")` before its final system DNS call with `doh=false` reproduced `FATAL EXCEPTION: OkHttp Dispatcher` and `Process: org.lsposed.manager`.
- On this branch, injecting the same exception inside the system-resolver `try` block kept the app alive and converted request failures to hostname-bearing messages such as `java.net.UnknownHostException: api.github.com: Permission denied (missing INTERNET permission?)`, with no `AndroidRuntime` fatal crash.
- With `doh=true`, a second local-only injection forced the #765 DoH failure path before the same system denial. The existing `DoH resolver unreachable, falling back to system DNS for this session` log still appeared, and the system denial was converted with no fatal crash.

So the clean emulator cannot recreate the original device policy state, but the branch directly covers the exception class/message at the same method boundary shown in the issue stack. OnePlus 9 Pro / LE2120 was online but runs Android 14, so it was not used to claim coverage of this Android 11-specific boundary.
