### PR TITLE
Fix dex2oat wrapper SELinux check on Android 14+

### DIFF
--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/env/Dex2OatServer.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/env/Dex2OatServer.kt
@@ -119,6 +119,23 @@ object Dex2OatServer {
             "u:r:untrusted_app:s0", "u:object_r:dex2oat_exec:s0", "file", "execute_no_trans")
   }
 
+  /**
+   * Android 14 moved dex2oat invocation behind artd.  artd is allowed to
+   * transition through dex2oat_exec, while the old dex2oat domain used the
+   * execute_no_trans check.  Checking the old tuple on Android 14+ falsely
+   * selects the xposed_file fallback and leaves artd unable to execute the
+   * bind-mounted wrapper.
+   */
+  private fun canUseDex2OatExec(): Boolean {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+      SELinux.checkSELinuxAccess(
+          "u:r:artd:s0", "u:object_r:dex2oat_exec:s0", "file", "execute")
+    } else {
+      SELinux.checkSELinuxAccess(
+          "u:r:dex2oat:s0", "u:object_r:dex2oat_exec:s0", "file", "execute_no_trans")
+    }
+  }
+
   private fun openDex2oat(id: Int, path: String) {
     runCatching {
       fdArray[id] = Os.open(path, OsConstants.O_RDONLY, 0)
@@ -207,7 +224,7 @@ object Dex2OatServer {
     val xposedFile = "u:object_r:xposed_file:s0"
     val dex2oatExec = "u:object_r:dex2oat_exec:s0"
 
-    if (SELinux.checkSELinuxAccess("u:r:dex2oat:s0", dex2oatExec, "file", "execute_no_trans")) {
+    if (canUseDex2OatExec()) {
       SELinux.setFileContext(WRAPPER32, dex2oatExec)
       SELinux.setFileContext(WRAPPER64, dex2oatExec)
       setSockCreateContext("u:r:dex2oat:s0")


### PR DESCRIPTION
## Summary

- detect the Android 14+ `artd` to `dex2oat_exec` transition when selecting the wrapper file context
- keep the existing `dex2oat` `execute_no_trans` check for Android versions before 14

## Root cause

Android 14 introduced the `artd` service path for dex2oat. The previous check queried `dex2oat` with `execute_no_trans`; on Android 16 this check fails because the supported path is the `artd` -> `dex2oat_exec` -> `dex2oat` domain transition. Vector therefore selected the `xposed_file` fallback for its bind-mounted wrapper. `artd` then failed to execute the wrapper because the module policy only grants `xposed_file` access to the older domains.

The fix uses the platform transition already defined by AOSP, so it does not broaden the module policy with an `artd` access rule for `xposed_file`.

## Validation

- Reproduced on a Redmi Note 13 4G running an Android 16 user build: the old path mounted `dex2oat64` with `xposed_file`, and `artd` logged `Permission denied`.
- Confirmed the installed AOSP Android 16 policy defines `domain_auto_trans(artd, dex2oat_exec, dex2oat)`.
- `git diff --check` passes.
- No full build was run.