### PR TITLE
Fix Re-optimize crash on Android 17 by using the ART Service

### DIFF
--- a/app/src/main/java/org/lsposed/manager/ui/fragment/CompileDialogFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/CompileDialogFragment.java
@@ -83,8 +83,7 @@ public class CompileDialogFragment extends AppCompatDialogFragment {
         @Override
         protected Throwable doInBackground(String... commands) {
             try {
-                LSPManagerServiceHolder.getService().clearApplicationProfileData(commands[0]);
-                if (LSPManagerServiceHolder.getService().performDexOptMode(commands[0])) {
+                if (LSPManagerServiceHolder.getService().optimizePackage(commands[0])) {
                     return null;
                 } else {
                     return new UnknownError();

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ManagerService.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ManagerService.kt
@@ -34,6 +34,7 @@ import org.matrix.vector.daemon.data.PreferenceStore
 import org.matrix.vector.daemon.env.Dex2OatServer
 import org.matrix.vector.daemon.env.LogcatMonitor
 import org.matrix.vector.daemon.system.*
+import org.matrix.vector.daemon.utils.PackageOptimizer
 import org.matrix.vector.daemon.utils.applyXspaceWorkaround
 import org.matrix.vector.daemon.utils.getRealUsers
 import rikka.parcelablelist.ParcelableListSlice
@@ -416,10 +417,6 @@ object ManagerService : ILSPManagerService.Stub() {
 
   override fun restartFor(intent: Intent) {} // No-op matching original
 
-  override fun clearApplicationProfileData(packageName: String) {
-    packageManager?.clearApplicationProfileData(packageName)
-  }
-
   override fun enableStatusNotification() = PreferenceStore.isStatusNotificationEnabled()
 
   override fun setEnableStatusNotification(enable: Boolean) {
@@ -433,8 +430,7 @@ object ManagerService : ILSPManagerService.Stub() {
     }
   }
 
-  override fun performDexOptMode(packageName: String) =
-      org.matrix.vector.daemon.utils.performDexOptMode(packageName)
+  override fun optimizePackage(packageName: String) = PackageOptimizer.optimize(packageName)
 
   override fun getDex2OatWrapperCompatibility() =
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) Dex2OatServer.compatibility else 0

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/utils/PackageOptimizer.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/utils/PackageOptimizer.kt
@@ -1,0 +1,106 @@
+package org.matrix.vector.daemon.utils
+
+import android.os.Build
+import android.util.Log
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import org.matrix.vector.daemon.system.packageManager
+
+/**
+ * Backs the manager's "Re-optimize" action: drops an app's stale ART profiles and rebuilds its
+ * `speed-profile` dexopt artifacts.
+ *
+ * Both steps were historically hidden `IPackageManager` binder calls (`clearApplicationProfileData`
+ * / `performDexOptMode`). They are present through Android 16 (the newest AOSP source available) but
+ * dropped from `framework.jar` on Android 17, where the binder calls throw `NoSuchMethodError` (see
+ * #781). Since Android 14, dexopt and profiles are handled by the ART Service, which exposes the
+ * same operations through its shell (`cmd package art clear-app-profiles` / `cmd package compile`)
+ * independently of those binder methods. We therefore use the shell on Android 14+, falling back to
+ * the binder call, and use the binder path directly on older releases.
+ */
+object PackageOptimizer {
+
+  private const val TAG = "VectorOptimizer"
+
+  private val backend: Backend =
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+          FallbackBackend(primary = ShellBackend, fallback = BinderBackend)
+      else BinderBackend
+
+  /**
+   * Re-optimizes [packageName]: clears its profiles, then forces a profile-guided recompile.
+   *
+   * `speed-profile` only AOT-compiles methods recorded in the app's reference profile, so clearing
+   * first prevents the recompile from re-baking a profile captured before the module set changed.
+   */
+  fun optimize(packageName: String): Boolean {
+    // Best-effort clear: on failure the recompile merely reuses an older profile, which still beats
+    // aborting the whole action.
+    runCatching { backend.clearProfiles(packageName) }
+        .onFailure { Log.e(TAG, "Failed to clear profiles for $packageName", it) }
+    return runCatching { backend.compile(packageName) }
+        .onFailure { Log.e(TAG, "Failed to optimize $packageName", it) }
+        .getOrDefault(false)
+  }
+
+  /** Each operation returns whether it succeeded. */
+  private interface Backend {
+    fun clearProfiles(packageName: String): Boolean
+
+    fun compile(packageName: String): Boolean
+  }
+
+  /**
+   * Runs [primary], falling back to [fallback] whenever an operation returns false or throws.
+   *
+   * On Android 14+ the primary is the ART Service shell and the fallback is the binder call. The
+   * binder methods are still present on Android 14/15/16, so the fallback is valid there; on 17 they
+   * are gone, but the shell succeeds so the fallback is never reached.
+   */
+  private class FallbackBackend(private val primary: Backend, private val fallback: Backend) :
+      Backend {
+    override fun clearProfiles(packageName: String): Boolean =
+        firstSuccess({ primary.clearProfiles(packageName) }, { fallback.clearProfiles(packageName) })
+
+    override fun compile(packageName: String): Boolean =
+        firstSuccess({ primary.compile(packageName) }, { fallback.compile(packageName) })
+
+    private fun firstSuccess(vararg attempts: () -> Boolean): Boolean =
+        attempts.any { runCatching(it).getOrDefault(false) }
+  }
+
+  /** Android 14+: dexopt and profiles are owned by the ART Service, reachable through its shell. */
+  private object ShellBackend : Backend {
+    override fun clearProfiles(packageName: String): Boolean =
+        exec("cmd package art clear-app-profiles $packageName").first == 0
+
+    override fun compile(packageName: String): Boolean {
+      val (exitCode, output) = exec("cmd package compile -m speed-profile -f $packageName")
+      return exitCode == 0 && output.contains("Success")
+    }
+
+    private fun exec(command: String): Pair<Int, String> {
+      val process = Runtime.getRuntime().exec(command)
+      val output = BufferedReader(InputStreamReader(process.inputStream)).use { it.readText() }
+      return process.waitFor() to output
+    }
+  }
+
+  /** Pre-14, and the Android 14+ fallback: the hidden `IPackageManager` binder calls. */
+  private object BinderBackend : Backend {
+    override fun clearProfiles(packageName: String): Boolean {
+      val pm = packageManager ?: return false
+      pm.clearApplicationProfileData(packageName)
+      return true
+    }
+
+    override fun compile(packageName: String): Boolean =
+        packageManager?.performDexOptMode(
+            packageName,
+            false, // useJitProfiles
+            "speed-profile",
+            true,
+            true,
+            null) == true
+  }
+}

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/utils/Workarounds.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/utils/Workarounds.kt
@@ -9,8 +9,6 @@ import android.content.pm.UserInfo
 import android.os.Build
 import android.os.IUserManager
 import android.util.Log
-import java.io.BufferedReader
-import java.io.InputStreamReader
 import java.lang.ClassNotFoundException
 import org.matrix.vector.daemon.system.*
 
@@ -62,36 +60,6 @@ fun applyNotificationWorkaround() {
           Log.e(TAG, "Failed to build dummy notification", it)
         }
       }
-}
-
-/**
- * UpsideDownCake (Android 14) requires executing a shell command for dexopt, whereas older versions
- * use reflection/IPC.
- */
-fun performDexOptMode(packageName: String): Boolean {
-  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-    return runCatching {
-          val process =
-              Runtime.getRuntime().exec("cmd package compile -m speed-profile -f $packageName")
-          val output = BufferedReader(InputStreamReader(process.inputStream)).use { it.readText() }
-          val exitCode = process.waitFor()
-          exitCode == 0 && output.contains("Success")
-        }
-        .onFailure { Log.e(TAG, "Failed to exectute dexopt via cmd", it) }
-        .getOrDefault(false)
-  } else {
-    return runCatching {
-          packageManager?.performDexOptMode(
-              packageName,
-              false, // useJitProfiles
-              "speed-profile",
-              true,
-              true,
-              null) == true
-        }
-        .onFailure { Log.e(TAG, "Failed to invoke IPackageManager.performDexOptMode", it) }
-        .getOrDefault(false)
-  }
 }
 
 fun applyXspaceWorkaround(connection: IServiceConnection) {

--- a/services/manager-service/src/main/aidl/org/lsposed/lspd/ILSPManagerService.aidl
+++ b/services/manager-service/src/main/aidl/org/lsposed/lspd/ILSPManagerService.aidl
@@ -68,11 +68,9 @@ interface ILSPManagerService {
 
     void restartFor(in Intent intent) = 35;
 
-    boolean performDexOptMode(String packageName) = 40;
+    boolean optimizePackage(String packageName) = 40;
 
     int getDex2OatWrapperCompatibility() = 44;
-
-    void clearApplicationProfileData(in String packageName) = 45;
 
     boolean enableStatusNotification() = 47;
 


### PR DESCRIPTION
The manager's "Re-optimize" action cleared an app's profile and recompiled it through two hidden IPackageManager binder calls, clearApplicationProfileData() and performDexOptMode(). Android 17 removes both from framework.jar, so the daemon crashed with NoSuchMethodError.

Dexopt and profiles have been owned by the ART Service since Android 14, which exposes the same operations through the package shell (cmd package art clear-app-profiles / cmd package compile). Route through the shell on Android 14+ and keep the binder calls for older releases; when a shell command fails, fall back to the binder call, which is still available on Android 14 through 16.

Both steps now live in a single PackageOptimizer.optimize() that clears the profile before the speed-profile recompile, since a stale profile would otherwise constrain what the profile-guided compile rebuilds. The two service methods collapse into one AIDL entry point, optimizePackage(), so the manager triggers the whole operation in a single IPC.