### PR TITLE
Register the `serial` proxy service on Android 10 and below

### DIFF
--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ManagerService.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ManagerService.kt
@@ -158,22 +158,9 @@ object ManagerService : ILSPManagerService.Stub() {
   fun openManager(withData: Uri?) {
     val intent = getManagerIntent() ?: return
     val launchIntent = Intent(intent).apply { data = withData }
-    runCatching {
-          activityManager?.startActivityAsUserWithFeature(
-              SystemContext.appThread,
-              "android",
-              null,
-              launchIntent,
-              launchIntent.type,
-              null,
-              null,
-              0,
-              0,
-              null,
-              null,
-              0)
-        }
-        .onFailure { Log.e(TAG, "Failed to open manager", it) }
+    // Negative results are `ActivityManager.START_*` errors, the positive ones are all successes.
+    val result = activityManager?.startActivityAsUserCompat(launchIntent, 0) ?: -1
+    if (result < 0) Log.e(TAG, "Failed to open manager: $result")
   }
 
   /** Fixes permissions for the WebView cache. */
@@ -376,19 +363,7 @@ object ManagerService : ILSPManagerService.Stub() {
         wm?.lockNow(null)
       }
     }
-    return activityManager?.startActivityAsUserWithFeature(
-        SystemContext.appThread,
-        "android",
-        null,
-        intent,
-        intent.type,
-        null,
-        null,
-        0,
-        0,
-        null,
-        null,
-        userId) ?: -1
+    return activityManager?.startActivityAsUserCompat(intent, userId) ?: -1
   }
 
   override fun queryIntentActivitiesAsUser(

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/SystemServerService.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/SystemServerService.kt
@@ -24,6 +24,8 @@ object SystemServerService : ILSPSystemServerService.Stub(), IBinder.DeathRecipi
     // Register as the service name early to setup an IPC for `system_server`.
     Log.d(TAG, "Registering bridge service for `system_server` with name `$serviceName`.")
 
+    // `IServiceManager.registerForNotifications` is only available since Android R.
+    // On older platforms we simply let the real service replace our proxy in servicemanager.
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
       val callback =
           object : IServiceCallback.Stub() {
@@ -39,13 +41,17 @@ object SystemServerService : ILSPSystemServerService.Stub(), IBinder.DeathRecipi
 
             override fun asBinder(): IBinder = this
           }
-      runCatching {
-            getSystemServiceManager().registerForNotifications(serviceName, callback)
-            ServiceManager.addService(serviceName, this)
-            proxyServiceName = serviceName
-          }
+      runCatching { getSystemServiceManager().registerForNotifications(serviceName, callback) }
           .onFailure { Log.e(TAG, "Failed to register IServiceCallback", it) }
     }
+
+    // The Zygisk module polls this name during `system_server` specialization,
+    // so it must be claimed on every supported platform.
+    runCatching {
+          ServiceManager.addService(serviceName, this)
+          proxyServiceName = serviceName
+        }
+        .onFailure { Log.e(TAG, "Failed to register proxy service `$serviceName`", it) }
   }
 
   override fun requestApplicationService(

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/system/SystemExtensions.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/system/SystemExtensions.kt
@@ -309,6 +309,34 @@ fun IActivityManager.broadcastIntentCompat(intent: Intent) {
       .onFailure { Log.e(TAG, "broadcastIntent failed", it) }
 }
 
+// `startActivityAsUserWithFeature` only arrived in Android R: on older platforms the same call
+// exists without the calling feature id, and using the newer one throws `NoSuchMethodError`.
+fun IActivityManager.startActivityAsUserCompat(intent: Intent, userId: Int): Int {
+  val appThread = SystemContext.appThread
+  return runCatching {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+          startActivityAsUserWithFeature(
+              appThread,
+              "android",
+              null,
+              intent,
+              intent.type,
+              null,
+              null,
+              0,
+              0,
+              null,
+              null,
+              userId)
+        } else {
+          startActivityAsUser(
+              appThread, "android", intent, intent.type, null, null, 0, 0, null, null, userId)
+        }
+      }
+      .onFailure { Log.e(TAG, "startActivityAsUser failed", it) }
+      .getOrDefault(-1)
+}
+
 fun IUserManager.getUserName(userId: Int): String {
   return runCatching { getUserInfo(userId)?.name }.getOrNull() ?: userId.toString()
 }


### PR DESCRIPTION
On Android 10 the Zygisk module never finds the proxy that the daemon claims to have registered, as reported in #773:

```
[ 2026-06-24T20:42:05.732        0:  1651:  1651 D/VectorSystemServer ] Registering bridge service for `system_server` with name `serial`.
[ 2026-06-24T20:42:05.888     1000:  2202:  2202 W/VectorNative    ] Failed to get system server binder via serial, will retry in 1 second...
[ 2026-06-24T20:42:15.894     1000:  2202:  2202 E/VectorNative    ] Failed to get system server binder after 10 attempts. Aborting.
[ 2026-06-24T20:42:25.151        0:  1651:  1651 E/VectorDaemon    ] Failed to inject VectorService into system_server
```

The daemon prints `Waiting system service: package` on every second between those attempts, so it is alive: this is not the startup race of #648, the name is simply never registered. `registerProxyService` needs the version check only for `IServiceManager.registerForNotifications`, which arrived in Android R, and #648 moved `ServiceManager.addService` into that same branch, leaving API 27 to 29 without a proxy.

We keep only `registerForNotifications` behind the check. On pre-R we cannot capture the real service, but its own registration replaces our proxy in servicemanager anyway.

The reporter confirmed that the Manager now opens, but only once. The follow-up log in #773 shows a second pre-R gap behind that:

```
java.lang.NoSuchMethodError: No interface method startActivityAsUserWithFeature(...)
    at org.matrix.vector.daemon.ipc.ManagerService.startActivityAsUserWithFeature(ManagerService.kt:379)
    at org.lsposed.lspd.ILSPManagerService$Stub.onTransact(ILSPManagerService.java:377)
E/VectorDaemon: Uncaught exception in Daemon
I/lspd: System.exit called, status: 1
```

`IActivityManager.startActivityAsUserWithFeature` also arrived in Android R, and our stub already marks it `@RequiresApi(30)`, but both call sites used it unconditionally. `openManager` hid the error inside `runCatching`, while the binder override did not, so it escaped `onTransact` and killed the daemon. The Manager is then left in the shell host process with nothing to hand it an intent, which is the `BugreportWarningActivity` NPE further down the same log.

The second commit routes both call sites through `startActivityAsUserCompat`, shaped like the existing `registerReceiverCompat`: pick the signature the platform provides, and report a failure as a negative result instead of letting an unchecked error escape a binder transaction.

Close #773 as fixed.
