### PR TITLE
Fix libxposed API 101 conformance

### DIFF
--- a/app/src/main/java/org/lsposed/manager/adapters/ScopeAdapter.java
+++ b/app/src/main/java/org/lsposed/manager/adapters/ScopeAdapter.java
@@ -554,9 +554,10 @@ public class ScopeAdapter extends EmptyStateRecyclerView.EmptyStateAdapter<Scope
                     synchronized (tmpRecList) {
                         tmpRecList.add(application);
                     }
-                } else if (module.staticScope) {
+                } else if (module.staticScope && !tmpChkList.contains(application)) {
                     // The module says its scope list is the whole of it, so nothing outside that
-                    // list is offered in the first place.
+                    // list is offered. An app already enabled outside it still has to be shown, or
+                    // it would keep the module loaded from a row nobody can see to switch off.
                     return;
                 } else if (shouldHideApp(info, application, tmpChkList)) {
                     return;

--- a/app/src/main/java/org/lsposed/manager/adapters/ScopeAdapter.java
+++ b/app/src/main/java/org/lsposed/manager/adapters/ScopeAdapter.java
@@ -69,6 +69,7 @@ import org.lsposed.manager.ConfigManager;
 import org.lsposed.manager.R;
 import org.lsposed.manager.databinding.ItemMasterSwitchBinding;
 import org.lsposed.manager.databinding.ItemModuleBinding;
+import org.lsposed.manager.databinding.ItemScopeFooterBinding;
 import org.lsposed.manager.ui.dialog.BlurBehindDialogBuilder;
 import org.lsposed.manager.ui.fragment.AppListFragment;
 import org.lsposed.manager.ui.fragment.CompileDialogFragment;
@@ -123,6 +124,28 @@ public class ScopeAdapter extends EmptyStateRecyclerView.EmptyStateAdapter<Scope
         @Override
         public int getItemCount() {
             return 1;
+        }
+    };
+
+    /**
+     * staticScope says the module's scope list is the whole of it, so the list above shows only the
+     * apps it claims and this rules it off. Nothing follows for a module that does not claim one.
+     */
+    public RecyclerView.Adapter<RecyclerView.ViewHolder> footerAdaptor = new RecyclerView.Adapter<>() {
+        @NonNull
+        @Override
+        public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+            return new RecyclerView.ViewHolder(ItemScopeFooterBinding.inflate(activity.getLayoutInflater(), parent, false).getRoot()) {
+            };
+        }
+
+        @Override
+        public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
+        }
+
+        @Override
+        public int getItemCount() {
+            return module.staticScope ? 1 : 0;
         }
     };
 
@@ -531,6 +554,10 @@ public class ScopeAdapter extends EmptyStateRecyclerView.EmptyStateAdapter<Scope
                     synchronized (tmpRecList) {
                         tmpRecList.add(application);
                     }
+                } else if (module.staticScope) {
+                    // The module says its scope list is the whole of it, so nothing outside that
+                    // list is offered in the first place.
+                    return;
                 } else if (shouldHideApp(info, application, tmpChkList)) {
                     return;
                 }

--- a/app/src/main/java/org/lsposed/manager/ui/fragment/AppListFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/AppListFragment.java
@@ -93,6 +93,7 @@ public class AppListFragment extends BaseFragment implements MenuProvider {
         var concatAdapter = new ConcatAdapter();
         concatAdapter.addAdapter(scopeAdapter.switchAdaptor);
         concatAdapter.addAdapter(scopeAdapter);
+        concatAdapter.addAdapter(scopeAdapter.footerAdaptor);
         binding.recyclerView.setAdapter(concatAdapter);
         binding.recyclerView.setHasFixedSize(true);
         binding.recyclerView.setLayoutManager(new LinearLayoutManager(requireActivity()));

--- a/app/src/main/java/org/lsposed/manager/ui/fragment/ModulesFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/ModulesFragment.java
@@ -34,6 +34,7 @@ import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.text.style.ForegroundColorSpan;
+import android.text.style.RelativeSizeSpan;
 import android.text.style.StyleSpan;
 import android.text.style.TypefaceSpan;
 import android.util.SparseArray;
@@ -51,6 +52,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.SearchView;
+import androidx.appcompat.widget.TooltipCompat;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.view.MenuProvider;
@@ -558,6 +560,7 @@ public class ModulesFragment extends BaseFragment implements ModuleUtil.ModuleLi
             sb = new SpannableStringBuilder();
 
             int installXposedVersion = ConfigManager.getXposedApiVersion();
+            bindApiBadge(holder.apiBadge, item, installXposedVersion);
             String warningText = null;
             if (item.minVersion == 0) {
                 warningText = getString(R.string.no_min_version_specified);
@@ -748,12 +751,84 @@ public class ModulesFragment extends BaseFragment implements ModuleUtil.ModuleLi
             return isLoaded && moduleUtil.isModulesLoaded();
         }
 
+        /**
+         * The API version a module targets, printed under its icon. The word stays in the ordinary
+         * secondary colour and the version itself carries the colour, so the eye lands on the one
+         * part that differs between modules. The whole statement goes in the content description
+         * and the tooltip, so the colour is never the only thing carrying it.
+         */
+        private void bindApiBadge(TextView badge, ModuleUtil.InstalledModule item, int frameworkApi) {
+            final String label;
+            final String status;
+            final String version;
+            final int color;
+
+            if (item.legacy) {
+                // A legacy module reports the original Xposed API, which is numbered separately
+                // from the one this framework implements, so it is never compared against it.
+                version = item.minVersion > 0 ? String.valueOf(item.minVersion) : null;
+                label = version != null
+                        ? getString(R.string.module_api_badge_legacy, item.minVersion)
+                        : getString(R.string.module_api_badge_legacy_unknown);
+                status = getString(R.string.module_api_status_legacy);
+                color = android.R.attr.textColorSecondary;
+            } else if (item.minVersion <= 0 || item.targetVersion <= 0 || frameworkApi <= 0) {
+                // Both keys are required of a module. Reporting the one it did declare would put a
+                // version on screen for a module that never stated which API it was built for.
+                version = null;
+                label = getString(R.string.module_api_badge_unknown);
+                status = getString(R.string.module_api_status_unknown);
+                color = android.R.attr.textColorSecondary;
+            } else {
+                version = String.valueOf(item.targetVersion);
+                label = getString(R.string.module_api_badge, item.targetVersion);
+                if (item.minVersion > frameworkApi) {
+                    // It declares it needs more than we have, whatever it targets.
+                    status = getString(R.string.module_api_status_unsupported, item.minVersion, frameworkApi);
+                    color = com.google.android.material.R.attr.colorError;
+                } else if (item.targetVersion == frameworkApi) {
+                    status = getString(R.string.module_api_status_current);
+                    color = androidx.appcompat.R.attr.colorPrimary;
+                } else {
+                    status = getString(item.targetVersion > frameworkApi
+                                    ? R.string.module_api_status_newer
+                                    : R.string.module_api_status_older,
+                            item.targetVersion, frameworkApi);
+                    color = android.R.attr.textColorSecondary;
+                }
+            }
+
+            final int resolved = ResourceUtils.resolveColor(requireActivity().getTheme(), color);
+            final SpannableStringBuilder text = new SpannableStringBuilder(label);
+            final int at = version == null ? -1 : label.lastIndexOf(version);
+            if (at > 0) {
+                // Small caps: the capitals of the word set smaller than the version beside them, so
+                // the word reads as a label and the version reads as the value.
+                text.setSpan(new RelativeSizeSpan(0.78f), 0, at, Spannable.SPAN_INCLUSIVE_EXCLUSIVE);
+                text.setSpan(new StyleSpan(Typeface.BOLD), at, label.length(),
+                        Spannable.SPAN_INCLUSIVE_INCLUSIVE);
+                text.setSpan(new ForegroundColorSpan(resolved), at, label.length(),
+                        Spannable.SPAN_INCLUSIVE_INCLUSIVE);
+            } else {
+                text.setSpan(new RelativeSizeSpan(0.78f), 0, label.length(),
+                        Spannable.SPAN_INCLUSIVE_INCLUSIVE);
+                text.setSpan(new ForegroundColorSpan(resolved), 0, label.length(),
+                        Spannable.SPAN_INCLUSIVE_INCLUSIVE);
+            }
+
+            badge.setText(text);
+            badge.setContentDescription(status);
+            TooltipCompat.setTooltipText(badge, status);
+            badge.setVisibility(View.VISIBLE);
+        }
+
         static class ViewHolder extends RecyclerView.ViewHolder {
             ConstraintLayout root;
             ImageView appIcon;
             TextView appName;
             TextView appDescription;
             TextView appVersion;
+            TextView apiBadge;
             TextView hint;
             MaterialCheckBox checkBox;
 
@@ -764,6 +839,7 @@ public class ModulesFragment extends BaseFragment implements ModuleUtil.ModuleLi
                 appName = binding.appName;
                 appDescription = binding.description;
                 appVersion = binding.versionName;
+                apiBadge = binding.apiBadge;
                 hint = binding.hint;
                 checkBox = binding.checkbox;
             }

--- a/app/src/main/java/org/lsposed/manager/util/ModuleUtil.java
+++ b/app/src/main/java/org/lsposed/manager/util/ModuleUtil.java
@@ -298,11 +298,20 @@ public final class ModuleUtil {
                 try (modernModuleApk) {
                     var propEntry = modernModuleApk.getEntry("META-INF/xposed/module.prop");
                     if (propEntry != null) {
-                        var prop = new Properties();
-                        prop.load(modernModuleApk.getInputStream(propEntry));
-                        minVersion = extractIntPart(prop.getProperty("minApiVersion"));
-                        targetVersion = extractIntPart(prop.getProperty("targetApiVersion"));
-                        staticScope = TextUtils.equals(prop.getProperty("staticScope"), "true");
+                        try {
+                            var prop = new Properties();
+                            prop.load(modernModuleApk.getInputStream(propEntry));
+                            minVersion = extractIntPart(prop.getProperty("minApiVersion"));
+                            targetVersion = extractIntPart(prop.getProperty("targetApiVersion"));
+                            staticScope = TextUtils.equals(prop.getProperty("staticScope"), "true");
+                        } catch (IllegalArgumentException e) {
+                            // Properties.load rejects a malformed unicode escape, and nothing read
+                            // out of the file before that point can be trusted either, so the
+                            // module reports no version rather than the defaults above.
+                            minVersion = 0;
+                            targetVersion = 0;
+                            Log.e(App.TAG, "Malformed module.prop in " + pkg.packageName, e);
+                        }
                     }
                     var scopeEntry = modernModuleApk.getEntry("META-INF/xposed/scope.list");
                     if (scopeEntry != null) {
@@ -312,8 +321,11 @@ public final class ModuleUtil {
                     } else {
                         scopeList = Collections.emptyList();
                     }
-                } catch (IOException | OutOfMemoryError e) {
-                    Log.e(App.TAG, "Error while closing modern module APK", e);
+                } catch (IOException | OutOfMemoryError | IllegalArgumentException e) {
+                    // Properties.load is documented to throw IllegalArgumentException for a
+                    // malformed unicode escape. Uncaught, one such module.prop leaves the user
+                    // with an empty module list instead of one unreadable entry.
+                    Log.e(App.TAG, "Error while reading modern module APK", e);
                 }
                 this.minVersion = minVersion;
                 this.targetVersion = targetVersion;

--- a/app/src/main/java/org/lsposed/manager/util/ModuleUtil.java
+++ b/app/src/main/java/org/lsposed/manager/util/ModuleUtil.java
@@ -307,20 +307,13 @@ public final class ModuleUtil {
                     var scopeEntry = modernModuleApk.getEntry("META-INF/xposed/scope.list");
                     if (scopeEntry != null) {
                         try (var reader = new BufferedReader(new InputStreamReader(modernModuleApk.getInputStream(scopeEntry)))) {
-                            // Scope entries are matched by exact string, so normalise the way the
-                            // daemon normalises its init lists.
-                            scopeList = reader.lines()
-                                    .map(String::trim)
-                                    .filter(s -> !s.isEmpty() && !s.startsWith("#"))
-                                    .collect(Collectors.toList());
+                            scopeList = reader.lines().collect(Collectors.toList());
                         }
                     } else {
                         scopeList = Collections.emptyList();
                     }
-                } catch (Throwable e) {
-                    // A single malformed module must not abort reloadInstalledModules and leave
-                    // the user with an empty list.
-                    Log.e(App.TAG, "Error while reading modern module APK", e);
+                } catch (IOException | OutOfMemoryError e) {
+                    Log.e(App.TAG, "Error while closing modern module APK", e);
                 }
                 this.minVersion = minVersion;
                 this.targetVersion = targetVersion;

--- a/app/src/main/java/org/lsposed/manager/util/ModuleUtil.java
+++ b/app/src/main/java/org/lsposed/manager/util/ModuleUtil.java
@@ -86,6 +86,9 @@ public final class ModuleUtil {
     }
 
     public static int extractIntPart(String str) {
+        // minApiVersion and targetApiVersion are required of a module, but a third-party module
+        // omitting one must not take down the module list.
+        if (str == null) return 0;
         int result = 0, length = str.length();
         for (int offset = 0; offset < length; offset++) {
             char c = str.charAt(offset);
@@ -304,13 +307,20 @@ public final class ModuleUtil {
                     var scopeEntry = modernModuleApk.getEntry("META-INF/xposed/scope.list");
                     if (scopeEntry != null) {
                         try (var reader = new BufferedReader(new InputStreamReader(modernModuleApk.getInputStream(scopeEntry)))) {
-                            scopeList = reader.lines().collect(Collectors.toList());
+                            // Scope entries are matched by exact string, so normalise the way the
+                            // daemon normalises its init lists.
+                            scopeList = reader.lines()
+                                    .map(String::trim)
+                                    .filter(s -> !s.isEmpty() && !s.startsWith("#"))
+                                    .collect(Collectors.toList());
                         }
                     } else {
                         scopeList = Collections.emptyList();
                     }
-                } catch (IOException | OutOfMemoryError e) {
-                    Log.e(App.TAG, "Error while closing modern module APK", e);
+                } catch (Throwable e) {
+                    // A single malformed module must not abort reloadInstalledModules and leave
+                    // the user with an empty list.
+                    Log.e(App.TAG, "Error while reading modern module APK", e);
                 }
                 this.minVersion = minVersion;
                 this.targetVersion = targetVersion;

--- a/app/src/main/res/layout/item_module.xml
+++ b/app/src/main/res/layout/item_module.xml
@@ -40,11 +40,31 @@
             android:id="@+id/app_icon"
             android:layout_width="@dimen/app_icon_size"
             android:layout_height="@dimen/app_icon_size"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/api_badge"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="packed"
             tools:ignore="ContentDescription"
             tools:srcCompat="@tools:sample/backgrounds/scenic" />
+
+        <!-- Under the icon, out of the way of the name, the version and the description. -->
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/api_badge"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:singleLine="true"
+            android:textAppearance="?android:attr/textAppearanceListItemSecondary"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textIsSelectable="false"
+            android:textSize="11sp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/app_icon"
+            app:layout_constraintStart_toStartOf="@id/app_icon"
+            app:layout_constraintTop_toBottomOf="@id/app_icon"
+            tools:text="api 101"
+            tools:visibility="visible" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/app_name"

--- a/app/src/main/res/layout/item_scope_footer.xml
+++ b/app/src/main/res/layout/item_scope_footer.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ This file is part of LSPosed.
+  ~
+  ~ LSPosed is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ LSPosed is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with LSPosed.  If not, see <https://www.gnu.org/licenses/>.
+  ~
+  ~ Copyright (C) 2026 LSPosed Contributors
+  -->
+
+<!-- Closes the list of a module that claims a fixed scope, since nothing else can follow it. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingHorizontal="24dp"
+    android:paddingVertical="24dp">
+
+    <View
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:layout_weight="1"
+        android:background="?attr/colorOutlineVariant" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/scope_note"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="12dp"
+        android:text="@string/module_scope_static"
+        android:textAppearance="?android:attr/textAppearanceListItemSecondary"
+        android:textColor="?android:attr/textColorSecondary" />
+
+    <View
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:layout_weight="1"
+        android:background="?attr/colorOutlineVariant" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,6 +105,17 @@
     <string name="warning_xposed_min_version">This module requires a newer Xposed version (%d) and thus cannot be activated</string>
     <string name="warning_target_version_higher">This module is designed for a newer Xposed version (%d) and thus some functionalities may not work</string>
     <string name="no_min_version_specified">This module does not specify the Xposed version it needs.</string>
+    <string name="module_api_badge">API %1$d</string>
+    <string name="module_api_badge_unknown">API ?</string>
+    <string name="module_api_badge_legacy">Xposed %1$d</string>
+    <string name="module_api_badge_legacy_unknown">Xposed ?</string>
+    <string name="module_api_status_current">Targets the API this framework implements</string>
+    <string name="module_api_status_older">Targets API %1$d, older than the API this framework implements (%2$d)</string>
+    <string name="module_api_status_newer">Targets API %1$d, newer than the API this framework implements (%2$d)</string>
+    <string name="module_api_status_unsupported">Needs API %1$d, more than this framework implements (%2$d)</string>
+    <string name="module_api_status_legacy">Uses the original Xposed API through the legacy bridge</string>
+    <string name="module_api_status_unknown">The targeted API version is unknown</string>
+    <string name="module_scope_static">Static Scope</string>
     <string name="warning_min_version_too_low">This module was created for Xposed version %1$d, but due to incompatible changes in version %2$d, it has been disabled</string>
     <string name="warning_installed_on_external_storage">This module cannot be loaded because it\'s installed on the SD card, please move it to internal storage</string>
     <string name="module_uninstall">Uninstall</string>

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/VectorService.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/VectorService.kt
@@ -396,7 +396,8 @@ object VectorService : IDaemonService.Stub() {
             }
           }
         }
-        .onFailure { runCatching { iCallback.onScopeRequestFailed(it.message) } }
+        // onScopeRequestFailed declares @NonNull, and Throwable.message is frequently null.
+        .onFailure { runCatching { iCallback.onScopeRequestFailed(it.message ?: it.toString()) } }
 
     NotificationManager.cancelNotification(
         NotificationManager.SCOPE_CHANNEL_ID, packageName, userId)

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/data/ConfigCache.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/data/ConfigCache.kt
@@ -34,6 +34,13 @@ object ConfigCache {
 
   val dbHelper = Database() // Kept public for PreferenceStore and ModuleDatabase
 
+  // Module package -> the packages it claims, for modules whose module.prop fixes the scope.
+  // Absent means the module places no restriction on its scope.
+  @Volatile private var staticScopes: Map<String, Set<String>> = emptyMap()
+
+  /** The packages [modulePackage] claims, or null when it does not fix its scope. */
+  fun staticScopeOf(modulePackage: String): Set<String>? = staticScopes[modulePackage]
+
   private val cacheUpdateChannel = Channel<Unit>(Channel.CONFLATED)
 
   init {
@@ -123,6 +130,7 @@ object ConfigCache {
     val oldState = state
 
     val newModules = mutableMapOf<String, Module>()
+    val newStaticScopes = mutableMapOf<String, Set<String>>()
     val obsoleteModules = mutableSetOf<String>()
     val obsoletePaths = mutableMapOf<String, String>()
 
@@ -166,6 +174,9 @@ object ConfigCache {
                 File(appInfo.sourceDir).parent == File(apkPath).parent) {
 
               if (oldModule.appId == -1) oldModule.applicationInfo = appInfo
+              // This path skips re-reading the APK, so what the module claims has to be carried
+              // over; the new map replaces the old one wholesale and would otherwise lose it.
+              staticScopes[pkgName]?.let { newStaticScopes[pkgName] = it }
               newModules[pkgName] = oldModule
               continue
             }
@@ -179,6 +190,8 @@ object ConfigCache {
               apkPath = realApkPath
               obsoletePaths[pkgName] = realApkPath
             }
+
+            FileSystem.readStaticScope(apkPath)?.let { newStaticScopes[pkgName] = it }
 
             val preLoadedApk = FileSystem.loadModule(apkPath, state.isDexObfuscateEnabled)
             if (preLoadedApk != null) {
@@ -202,6 +215,17 @@ object ConfigCache {
     if (packageManager?.asBinder()?.isBinderAlive == true) {
       obsoleteModules.forEach { ModuleDatabase.removeModule(it) }
       obsoletePaths.forEach { (pkg, path) -> ModuleDatabase.updateModuleApkPath(pkg, path, true) }
+    }
+
+    staticScopes = newStaticScopes
+    // Rows can predate the module declaring a fixed scope, or come from an older build that let
+    // them in. Dropping them here is what makes the scope actually fixed rather than merely
+    // unreachable through the manager, and it runs before the scope table is read below.
+    newStaticScopes.forEach { (modulePkg, claimed) ->
+      val dropped = ModuleDatabase.pruneScopeToClaimed(modulePkg, claimed)
+      if (dropped > 0) {
+        Log.i(TAG, "Dropped $dropped app(s) outside the static scope of $modulePkg")
+      }
     }
 
     val newScopes = mutableMapOf<ProcessScope, MutableList<Module>>()

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/data/FileSystem.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/data/FileSystem.kt
@@ -175,6 +175,7 @@ object FileSystem {
     val moduleClassNames = mutableListOf<String>()
     val moduleLibraryNames = mutableListOf<String>()
     var isLegacy = false
+    var exceptionPassthrough = false
 
     runCatching {
           ZipFile(file).use { zip ->
@@ -196,6 +197,12 @@ object FileSystem {
             // Leading-digit parsing, matching ModuleUtil.extractIntPart in the manager, so the two
             // sides cannot disagree about a value like "101.0".
             val targetApi = leadingInt(props.getProperty("targetApiVersion"))
+            // The module-wide mode ExceptionMode.DEFAULT resolves to. Anything that is not
+            // "passthrough" - absent, misspelled, or an explicit "protective" - keeps the
+            // protective default the API specifies.
+            exceptionPassthrough =
+                props.getProperty("exceptionMode")?.trim().equals("passthrough", true)
+
             val hasLegacyFile = zip.getEntry("assets/xposed_init") != null
 
             // Determine Loading Strategy based on Priority: API 101+ > Legacy > API 100
@@ -272,6 +279,7 @@ object FileSystem {
       this.moduleClassNames = moduleClassNames
       this.moduleLibraryNames = moduleLibraryNames
       this.legacy = isLegacy
+      this.exceptionPassthrough = exceptionPassthrough
     }
 
     return preLoadedApk

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/data/FileSystem.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/data/FileSystem.kt
@@ -27,6 +27,7 @@ import java.nio.file.attribute.PosixFilePermissions
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.util.Properties
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
@@ -160,6 +161,10 @@ object FileSystem {
     return memory
   }
 
+  /** Reads the leading integer of a module.prop value, as the manager's extractIntPart does. */
+  private fun leadingInt(value: String?): Int =
+      value?.trim()?.takeWhile { it.isDigit() }?.toIntOrNull() ?: 0
+
   /** Parses the module APK, extracts init lists, and loads DEXes into SharedMemory. */
   fun loadModule(apkPath: String, obfuscate: Boolean): PreLoadedApk? {
     val file = File(apkPath)
@@ -173,20 +178,24 @@ object FileSystem {
 
     runCatching {
           ZipFile(file).use { zip ->
-            // Parse module.prop to get targetApiVersion
+            // module.prop is specified as Java Properties format. Parsing it by hand mishandles
+            // ':' as a separator, '!' comments, escapes and line continuations, and the manager
+            // app already reads the same file with Properties.load.
             val props =
-                zip.getEntry("META-INF/xposed/module.prop")?.let { entry ->
-                  zip.getInputStream(entry).bufferedReader().useLines { lines ->
-                    lines
-                        .filter { it.contains("=") }
-                        .associate {
-                          val parts = it.split("=", limit = 2)
-                          parts[0].trim() to parts[1].trim()
-                        }
+                Properties().apply {
+                  zip.getEntry("META-INF/xposed/module.prop")?.let { entry ->
+                    // Properties.load rejects a malformed \uXXXX escape, which the old hand-rolled
+                    // parser tolerated. Keep that tolerance: a bad module.prop must not make the
+                    // APK unloadable, not least because a legacy module is selected by
+                    // assets/xposed_init and needs no module.prop at all.
+                    runCatching { zip.getInputStream(entry).use { load(it) } }
+                        .onFailure { Log.w(TAG, "Malformed module.prop in $apkPath", it) }
                   }
-                } ?: emptyMap()
+                }
 
-            val targetApi = props["targetApiVersion"]?.toIntOrNull() ?: 0
+            // Leading-digit parsing, matching ModuleUtil.extractIntPart in the manager, so the two
+            // sides cannot disagree about a value like "101.0".
+            val targetApi = leadingInt(props.getProperty("targetApiVersion"))
             val hasLegacyFile = zip.getEntry("assets/xposed_init") != null
 
             // Determine Loading Strategy based on Priority: API 101+ > Legacy > API 100

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/data/FileSystem.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/data/FileSystem.kt
@@ -161,6 +161,34 @@ object FileSystem {
     return memory
   }
 
+  /**
+   * The packages a module claims, when its module.prop fixes the scope. Null when it does not, so
+   * a caller can tell "claims nothing" from "claims no restriction".
+   *
+   * staticScope is documented as "the module scope is fixed and users should not apply the module
+   * on apps outside the scope list". Enforcing that in the manager alone leaves the socket CLI, a
+   * backup restore and the module's own requestScope walking straight past it, so the daemon has
+   * to know about it too.
+   */
+  fun readStaticScope(apkPath: String): Set<String>? =
+      runCatching {
+            ZipFile(File(apkPath)).use { zip ->
+              val props =
+                  Properties().apply {
+                    zip.getEntry("META-INF/xposed/module.prop")?.let { entry ->
+                      runCatching { zip.getInputStream(entry).use { load(it) } }
+                    }
+                  }
+              if (!props.getProperty("staticScope").toBoolean()) return@use null
+              val entry = zip.getEntry("META-INF/xposed/scope.list") ?: return@use emptySet()
+              zip.getInputStream(entry).bufferedReader().useLines { lines ->
+                lines.filter { it.isNotEmpty() }.toSet()
+              }
+            }
+          }
+          .onFailure { Log.w(TAG, "Cannot read the scope list of $apkPath", it) }
+          .getOrNull()
+
   /** Parses the module APK, extracts init lists, and loads DEXes into SharedMemory. */
   fun loadModule(apkPath: String, obfuscate: Boolean): PreLoadedApk? {
     val file = File(apkPath)

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/data/FileSystem.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/data/FileSystem.kt
@@ -161,10 +161,6 @@ object FileSystem {
     return memory
   }
 
-  /** Reads the leading integer of a module.prop value, as the manager's extractIntPart does. */
-  private fun leadingInt(value: String?): Int =
-      value?.trim()?.takeWhile { it.isDigit() }?.toIntOrNull() ?: 0
-
   /** Parses the module APK, extracts init lists, and loads DEXes into SharedMemory. */
   fun loadModule(apkPath: String, obfuscate: Boolean): PreLoadedApk? {
     val file = File(apkPath)
@@ -194,9 +190,7 @@ object FileSystem {
                   }
                 }
 
-            // Leading-digit parsing, matching ModuleUtil.extractIntPart in the manager, so the two
-            // sides cannot disagree about a value like "101.0".
-            val targetApi = leadingInt(props.getProperty("targetApiVersion"))
+            val targetApi = props.getProperty("targetApiVersion")?.trim()?.toIntOrNull() ?: 0
             // The module-wide mode ExceptionMode.DEFAULT resolves to. Anything that is not
             // "passthrough" - absent, misspelled, or an explicit "protective" - keeps the
             // protective default the API specifies.

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/data/ModuleDatabase.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/data/ModuleDatabase.kt
@@ -48,6 +48,15 @@ object ModuleDatabase {
   }
 
   fun setModuleScope(packageName: String, scope: MutableList<Application>): Boolean {
+    // Last line of defence for staticScope. The manager, the socket CLI, a backup restore and a
+    // module's own requestScope all end up here, so refusing here covers every one of them.
+    ConfigCache.staticScopeOf(packageName)?.let { claimed ->
+      val beyond = scope.map { it.packageName }.distinct().filterNot { claimed.contains(it) }
+      if (beyond.isNotEmpty()) {
+        Log.w(TAG, "$packageName fixes its scope; refusing to add ${beyond.joinToString()}")
+        return false
+      }
+    }
     enableModule(packageName)
     val db = ConfigCache.dbHelper.writableDatabase
     db.beginTransaction()
@@ -74,6 +83,33 @@ object ModuleDatabase {
     }
     ConfigCache.requestCacheUpdate()
     return true
+  }
+
+  /**
+   * Drops every scope row of [packageName] outside [claimed]. Called from within a cache update, so
+   * it deliberately does not ask for another one.
+   *
+   * @return how many rows went.
+   */
+  fun pruneScopeToClaimed(packageName: String, claimed: Set<String>): Int {
+    val db = ConfigCache.dbHelper.writableDatabase
+    return runCatching {
+          val mid =
+              db.compileStatement("SELECT mid FROM modules WHERE module_pkg_name = ?")
+                  .apply { bindString(1, packageName) }
+                  .simpleQueryForLong()
+          val placeholders = claimed.joinToString(",") { "?" }
+          if (claimed.isEmpty()) {
+            db.delete("scope", "mid = ?", arrayOf(mid.toString()))
+          } else {
+            db.delete(
+                "scope",
+                "mid = ? AND app_pkg_name NOT IN ($placeholders)",
+                arrayOf(mid.toString()) + claimed.toTypedArray())
+          }
+        }
+        .onFailure { Log.e(TAG, "Failed to prune the scope of $packageName", it) }
+        .getOrDefault(0)
   }
 
   fun removeModuleScope(packageName: String, scopePackageName: String, userId: Int): Boolean {

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/CliHandler.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/CliHandler.kt
@@ -106,6 +106,18 @@ object CliHandler {
     val modulePkg = request.targets[0]
     val apps = request.targets.drop(1)
 
+    // staticScope fixes the scope, so the CLI may still read it and take apps out of it, but not
+    // put new ones in. Checked here as well as in the database so the answer names the packages.
+    fun rejectBeyondStaticScope(apps: List<String>) {
+      val claimed = ConfigCache.staticScopeOf(modulePkg) ?: return
+      val beyond = apps.map { it.substringBefore('/') }.filterNot { claimed.contains(it) }
+      if (beyond.isNotEmpty()) {
+        throw IllegalArgumentException(
+            "$modulePkg fixes its scope in module.prop, so ${beyond.joinToString()} cannot be " +
+                "added. It claims: ${claimed.sorted().joinToString().ifEmpty { "nothing" }}.")
+      }
+    }
+
     return when (request.action) {
       "ls" -> {
         val scope =
@@ -115,6 +127,7 @@ object CliHandler {
       }
       "add" -> {
         if (apps.isEmpty()) throw IllegalArgumentException("No target apps provided.")
+        rejectBeyondStaticScope(apps)
         val scope = ConfigCache.getModuleScope(modulePkg) ?: mutableListOf()
 
         apps.forEach { appStr ->
@@ -135,6 +148,7 @@ object CliHandler {
       "set" -> {
         if (apps.isEmpty())
             throw IllegalArgumentException("No target apps provided for scope overwrite.")
+        rejectBeyondStaticScope(apps)
         val scope = mutableListOf<Application>()
         apps.forEach { appStr ->
           val parts = appStr.split("/")

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/InjectedModuleService.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/InjectedModuleService.kt
@@ -19,8 +19,11 @@ private const val TAG = "VectorInjectedModuleService"
 
 class InjectedModuleService(private val packageName: String) : ILSPInjectedModuleService.Stub() {
 
-  // Tracks active RemotePreferenceCallbacks linked by config group
-  private val callbacks = ConcurrentHashMap<String, MutableSet<IRemotePreferenceCallback>>()
+  // Tracks active RemotePreferenceCallbacks linked by config group. Preferences are stored per
+  // Android user, so a registration is only interested in updates made by its own user.
+  private data class Subscriber(val userId: Int, val callback: IRemotePreferenceCallback)
+
+  private val callbacks = ConcurrentHashMap<String, MutableSet<Subscriber>>()
 
   override fun getFrameworkProperties(): Long {
     var prop = IXposedService.PROP_CAP_SYSTEM or IXposedService.PROP_CAP_REMOTE
@@ -41,8 +44,9 @@ class InjectedModuleService(private val packageName: String) : ILSPInjectedModul
 
     if (callback != null) {
       val groupCallbacks = callbacks.getOrPut(group) { ConcurrentHashMap.newKeySet() }
-      groupCallbacks.add(callback)
-      runCatching { callback.asBinder().linkToDeath({ groupCallbacks.remove(callback) }, 0) }
+      val subscriber = Subscriber(userId, callback)
+      groupCallbacks.add(subscriber)
+      runCatching { callback.asBinder().linkToDeath({ groupCallbacks.remove(subscriber) }, 0) }
           .onFailure { Log.w(TAG, "requestRemotePreferences linkToDeath failed", it) }
     }
     return bundle
@@ -71,11 +75,13 @@ class InjectedModuleService(private val packageName: String) : ILSPInjectedModul
         .getOrElse { throw RemoteException(it.message) }
   }
 
-  // Called by ModuleService when prefs are updated globally
-  fun onUpdateRemotePreferences(group: String, diff: Bundle) {
+  // Called by ModuleService when the module app has changed the group for one Android user.
+  fun onUpdateRemotePreferences(group: String, userId: Int, diff: Bundle) {
     val groupCallbacks = callbacks[group] ?: return
-    for (callback in groupCallbacks) {
-      runCatching { callback.onUpdate(diff) }.onFailure { groupCallbacks.remove(callback) }
+    for (subscriber in groupCallbacks) {
+      if (subscriber.userId != userId) continue
+      runCatching { subscriber.callback.onUpdate(diff) }
+          .onFailure { groupCallbacks.remove(subscriber) }
     }
   }
 }

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/InjectedModuleService.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/InjectedModuleService.kt
@@ -48,14 +48,18 @@ class InjectedModuleService(private val packageName: String) : ILSPInjectedModul
     return bundle
   }
 
-  override fun openRemoteFile(path: String): ParcelFileDescriptor {
-    FileSystem.ensureModuleFilePath(path)
+  override fun openRemoteFile(path: String): ParcelFileDescriptor? {
+    // XposedInterface#openRemoteFile documents FileNotFoundException for a missing *or* forbidden
+    // path. Returning null lets VectorContext raise exactly that; throwing here surfaced a
+    // RemoteException for a missing file and an IllegalArgumentException for a rejected path.
     val userId = Binder.getCallingUid() / PER_USER_RANGE
     return runCatching {
+          FileSystem.ensureModuleFilePath(path)
           val dir = FileSystem.resolveModuleDir(packageName, "files", userId, -1)
           ParcelFileDescriptor.open(dir.resolve(path).toFile(), ParcelFileDescriptor.MODE_READ_ONLY)
         }
-        .getOrElse { throw RemoteException(it.message) }
+        .onFailure { Log.w(TAG, "Cannot open remote file $path for $packageName: ${it.message}") }
+        .getOrNull()
   }
 
   override fun getRemoteFileList(): Array<String> {

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ModuleService.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ModuleService.kt
@@ -177,17 +177,19 @@ class ModuleService(private val loadedModule: Module) : IXposedService.Stub() {
 
     runCatching {
           PreferenceStore.updateModulePrefs(loadedModule.packageName, userId, group, values)
-          (loadedModule.service as? InjectedModuleService)?.onUpdateRemotePreferences(group, diff)
+          (loadedModule.service as? InjectedModuleService)
+              ?.onUpdateRemotePreferences(group, userId, diff)
         }
         .getOrElse { throw RemoteException(it.message) }
   }
 
   override fun deleteRemotePreferences(group: String) {
-    PreferenceStore.deleteModulePrefs(loadedModule.packageName, ensureModule(), group)
+    val userId = ensureModule()
+    PreferenceStore.deleteModulePrefs(loadedModule.packageName, userId, group)
     // Hooked processes hold an in-process cache of the group; without this they keep serving the
     // deleted values until their process restarts.
     (loadedModule.service as? InjectedModuleService)
-        ?.onUpdateRemotePreferences(group, Bundle().apply { putBoolean("clear", true) })
+        ?.onUpdateRemotePreferences(group, userId, Bundle().apply { putBoolean("clear", true) })
   }
 
   override fun listRemoteFiles(): Array<String> {

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ModuleService.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ModuleService.kt
@@ -131,6 +131,16 @@ class ModuleService(private val loadedModule: Module) : IXposedService.Stub() {
       callback.onScopeRequestApproved(emptyList())
       return
     }
+    // A module that fixed its own scope in module.prop does not get to ask for more of it at
+    // runtime. Prompting the user here would make "fixed" mean nothing.
+    ConfigCache.staticScopeOf(loadedModule.packageName)?.let { claimed ->
+      val beyond = packages.filterNot { claimed.contains(it) }
+      if (beyond.isNotEmpty()) {
+        callback.onScopeRequestFailed(
+            "This module declares a static scope, so ${beyond.joinToString()} cannot be added")
+        return
+      }
+    }
     if (!PreferenceStore.isScopeRequestBlocked(loadedModule.packageName)) {
       packages.forEach { pkg ->
         NotificationManager.requestModuleScope(loadedModule.packageName, userId, pkg, callback)

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ModuleService.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ModuleService.kt
@@ -154,6 +154,12 @@ class ModuleService(private val loadedModule: Module) : IXposedService.Stub() {
     val userId = ensureModule()
     val values = mutableMapOf<String, Any?>()
 
+    // RemotePreferences.Editor always writes this key, and sets it for edit().clear(). Ignoring it
+    // left every key the module app just cleared in place.
+    if (diff.getBoolean("clear", false)) {
+      PreferenceStore.deleteModulePrefs(loadedModule.packageName, userId, group)
+    }
+
     diff.getSerializable("delete")?.let { deletes ->
       (deletes as Set<*>).forEach { values[it as String] = null }
     }
@@ -170,6 +176,10 @@ class ModuleService(private val loadedModule: Module) : IXposedService.Stub() {
 
   override fun deleteRemotePreferences(group: String) {
     PreferenceStore.deleteModulePrefs(loadedModule.packageName, ensureModule(), group)
+    // Hooked processes hold an in-process cache of the group; without this they keep serving the
+    // deleted values until their process restarts.
+    (loadedModule.service as? InjectedModuleService)
+        ?.onUpdateRemotePreferences(group, Bundle().apply { putBoolean("clear", true) })
   }
 
   override fun listRemoteFiles(): Array<String> {

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ModuleService.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ModuleService.kt
@@ -123,6 +123,12 @@ class ModuleService(private val loadedModule: Module) : IXposedService.Stub() {
 
   override fun requestScope(packages: List<String>, callback: IXposedScopeCallback) {
     val userId = ensureModule()
+    if (packages.isEmpty()) {
+      // Nothing was asked for, so the request is trivially satisfied. Returning without touching
+      // the callback would leave the module waiting forever.
+      callback.onScopeRequestApproved(emptyList())
+      return
+    }
     if (!PreferenceStore.isScopeRequestBlocked(loadedModule.packageName)) {
       packages.forEach { pkg ->
         NotificationManager.requestModuleScope(loadedModule.packageName, userId, pkg, callback)

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ModuleService.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ModuleService.kt
@@ -117,7 +117,9 @@ class ModuleService(private val loadedModule: Module) : IXposedService.Stub() {
 
   override fun getScope(): List<String> {
     ensureModule()
-    return ConfigCache.getModuleScope(loadedModule.packageName)?.map { it.packageName }
+    // The scope table has one row per (app, user), so a module enabled for several users saw the
+    // same package repeatedly. A scope is a set of package names.
+    return ConfigCache.getModuleScope(loadedModule.packageName)?.map { it.packageName }?.distinct()
         ?: emptyList()
   }
 

--- a/legacy/src/main/java/de/robv/android/xposed/XposedInit.java
+++ b/legacy/src/main/java/de/robv/android/xposed/XposedInit.java
@@ -216,7 +216,14 @@ public final class XposedInit {
         });
     }
 
+    private static final AtomicBoolean modulesLoaded = new AtomicBoolean(false);
+
     public static void loadModules(ActivityThread at) {
+        // A late-injected system server calls this directly because its ActivityThread.attach
+        // already ran; guard so the normal path cannot load a second generation on top.
+        if (!modulesLoaded.compareAndSet(false, true)) {
+            return;
+        }
         var packages = (ArrayMap<?, ?>) XposedHelpers.getObjectField(at, "mPackages");
         VectorServiceClient.INSTANCE.getModulesList().forEach(module -> {
             loadedModules.put(module.packageName, Optional.empty());

--- a/native/src/jni/hook_bridge.cpp
+++ b/native/src/jni/hook_bridge.cpp
@@ -1,9 +1,12 @@
 #include <alloca.h>
 #include <parallel_hashmap/phmap.h>
 
+#include <algorithm>
 #include <lsplant.hpp>
+#include <limits>
 #include <memory>
 #include <shared_mutex>
+#include <vector>
 
 #include "jni/jni_bridge.h"
 #include "jni/jni_hooks.h"
@@ -558,6 +561,80 @@ VECTOR_DEF_NATIVE_METHOD(jobjectArray, HookBridge, callbackSnapshot, jclass call
  * @param target_class The class to inspect.
  * @return A Method object for the static initializer, or null if it doesn't exist.
  */
+/**
+ * @brief Finds a class's static initializer without initializing the class.
+ *
+ * GetStaticMethodID cannot be used: JNI specifies that resolving a method id initializes the
+ * class, which is exactly the event a <clinit> hook exists to observe. Java reflection cannot be
+ * used either, because it hides <clinit> entirely.
+ *
+ * ART stores a class's ArtMethods in one contiguous array, direct methods first, ordered by dex
+ * method id. Dex method ids are ordered by name and "<clinit>" sorts before "<init>", so a class
+ * that has a static initializer keeps it in the first slot - one stride below the lowest method
+ * ordinary reflection can see.
+ *
+ * The caller passes ArtMethod addresses read from java.lang.reflect.Executable.artMethod rather
+ * than jmethodIDs, because a Java-debuggable process hands out index based ids instead of
+ * pointers.
+ *
+ * A class with no static initializer has something else in that slot, so the candidate is checked
+ * by two plain word reads before anything dereferences it: its declaring class must match its
+ * neighbour's, and its access flags must say static constructor.
+ *
+ * @return The reflected static initializer, or nullptr if the class has none or the layout is not
+ *         what this relies on.
+ */
+VECTOR_DEF_NATIVE_METHOD(jobject, HookBridge, findStaticInitializer, jclass target_class,
+                         jlongArray art_methods) {
+    const jsize count = art_methods ? env->GetArrayLength(art_methods) : 0;
+    // One member anchors the array, a second gives its element size.
+    if (count < 2) return nullptr;
+
+    std::vector<uintptr_t> ids(count);
+    {
+        std::vector<jlong> raw(count);
+        env->GetLongArrayRegion(art_methods, 0, count, raw.data());
+        for (jsize i = 0; i < count; ++i) {
+            auto id = static_cast<uintptr_t>(raw[i]);
+            if (id < 0x1000 || (id % alignof(void *)) != 0) return nullptr;
+            ids[i] = id;
+        }
+    }
+
+    std::sort(ids.begin(), ids.end());
+    uintptr_t stride = std::numeric_limits<uintptr_t>::max();
+    for (size_t i = 1; i < ids.size(); ++i) {
+        uintptr_t delta = ids[i] - ids[i - 1];
+        if (delta > 0 && delta < stride) stride = delta;
+    }
+    // An ArtMethod is a few dozen bytes on every supported release; refuse rather than guess when
+    // the spacing is not what a contiguous method array looks like.
+    if (stride < 16 || stride > 128 || (stride % alignof(void *)) != 0) return nullptr;
+    for (size_t i = 1; i < ids.size(); ++i) {
+        if ((ids[i] - ids[i - 1]) % stride != 0) return nullptr;
+    }
+
+    const uintptr_t anchor = ids.front();
+    const uintptr_t candidate = anchor - stride;
+
+    // ArtMethod starts with GcRoot<mirror::Class> declaring_class_ followed by uint32_t
+    // access_flags_. Both are plain words in the same allocation as the anchor, so reading them
+    // cannot fault where reading the anchor would not.
+    const auto declaring_of = [](uintptr_t m) { return *reinterpret_cast<const uint32_t *>(m); };
+    const auto flags_of = [](uintptr_t m) {
+        return *reinterpret_cast<const uint32_t *>(m + sizeof(uint32_t));
+    };
+
+    if (declaring_of(candidate) != declaring_of(anchor)) return nullptr;
+
+    constexpr uint32_t kAccStatic = 0x0008;
+    constexpr uint32_t kAccConstructor = 0x00010000;
+    const uint32_t flags = flags_of(candidate);
+    if ((flags & kAccStatic) == 0 || (flags & kAccConstructor) == 0) return nullptr;
+
+    return env->ToReflectedMethod(target_class, reinterpret_cast<jmethodID>(candidate), JNI_TRUE);
+}
+
 VECTOR_DEF_NATIVE_METHOD(jobject, HookBridge, getStaticInitializer, jclass target_class) {
     // <clinit> is the internal name for a static initializer.
     // Its signature is always ()V (no arguments, void return).
@@ -595,6 +672,8 @@ static JNINativeMethod gMethods[] = {
                          "Executable;)[[Ljava/lang/Object;"),
     VECTOR_NATIVE_METHOD(HookBridge, getStaticInitializer,
                          "(Ljava/lang/Class;)Ljava/lang/reflect/Executable;"),
+    VECTOR_NATIVE_METHOD(HookBridge, findStaticInitializer,
+                         "(Ljava/lang/Class;[J)Ljava/lang/reflect/Executable;"),
 };
 
 /**

--- a/native/src/jni/hook_bridge.cpp
+++ b/native/src/jni/hook_bridge.cpp
@@ -635,21 +635,6 @@ VECTOR_DEF_NATIVE_METHOD(jobject, HookBridge, findStaticInitializer, jclass targ
     return env->ToReflectedMethod(target_class, reinterpret_cast<jmethodID>(candidate), JNI_TRUE);
 }
 
-VECTOR_DEF_NATIVE_METHOD(jobject, HookBridge, getStaticInitializer, jclass target_class) {
-    // <clinit> is the internal name for a static initializer.
-    // Its signature is always ()V (no arguments, void return).
-    jmethodID mid = env->GetStaticMethodID(target_class, "<clinit>", "()V");
-    if (!mid) {
-        // If GetStaticMethodID fails, it throws an exception.
-        // We clear it and return null to let the Java side handle it gracefully.
-        env->ExceptionClear();
-        return nullptr;
-    }
-    // Convert the method ID to a java.lang.reflect.Method object.
-    // The last parameter must be JNI_TRUE because it's a static method.
-    return env->ToReflectedMethod(target_class, mid, JNI_TRUE);
-}
-
 // Array of native method descriptors for JNI registration.
 static JNINativeMethod gMethods[] = {
     VECTOR_NATIVE_METHOD(HookBridge, hookMethod,
@@ -670,8 +655,6 @@ static JNINativeMethod gMethods[] = {
     VECTOR_NATIVE_METHOD(HookBridge, callbackSnapshot,
                          "(Ljava/lang/Class;Ljava/lang/reflect/"
                          "Executable;)[[Ljava/lang/Object;"),
-    VECTOR_NATIVE_METHOD(HookBridge, getStaticInitializer,
-                         "(Ljava/lang/Class;)Ljava/lang/reflect/Executable;"),
     VECTOR_NATIVE_METHOD(HookBridge, findStaticInitializer,
                          "(Ljava/lang/Class;[J)Ljava/lang/reflect/Executable;"),
 };

--- a/native/src/jni/hook_bridge.cpp
+++ b/native/src/jni/hook_bridge.cpp
@@ -1,5 +1,7 @@
 #include <alloca.h>
 #include <parallel_hashmap/phmap.h>
+#include <sys/mman.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <lsplant.hpp>
@@ -557,10 +559,19 @@ VECTOR_DEF_NATIVE_METHOD(jobjectArray, HookBridge, callbackSnapshot, jclass call
 }
 
 /**
- * @brief  Retrieves the static initializer (<clinit>) of a class as a Method object.
- * @param target_class The class to inspect.
- * @return A Method object for the static initializer, or null if it doesn't exist.
+ * @brief Reports whether the pages spanning [addr, addr + len) are mapped.
+ *
+ * msync on an unmapped range fails with ENOMEM, which turns a read that would raise SIGSEGV into
+ * an answer. Used for the one candidate below that cannot be bracketed by known-good members.
  */
+static bool IsMapped(uintptr_t addr, size_t len) {
+    static const size_t page = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    if (page == 0) return false;
+    const uintptr_t start = addr & ~(page - 1);
+    const size_t span = ((addr + len) - start + page - 1) & ~(page - 1);
+    return msync(reinterpret_cast<void *>(start), span, MS_ASYNC) == 0;
+}
+
 /**
  * @brief Finds a class's static initializer without initializing the class.
  *
@@ -568,27 +579,39 @@ VECTOR_DEF_NATIVE_METHOD(jobjectArray, HookBridge, callbackSnapshot, jclass call
  * class, which is exactly the event a <clinit> hook exists to observe. Java reflection cannot be
  * used either, because it hides <clinit> entirely.
  *
- * ART stores a class's ArtMethods in one contiguous array, direct methods first, ordered by dex
- * method id. Dex method ids are ordered by name and "<clinit>" sorts before "<init>", so a class
- * that has a static initializer keeps it in the first slot - one stride below the lowest method
- * ordinary reflection can see.
+ * ART stores a class's ArtMethods in one contiguous array: direct methods, then declared virtual
+ * methods, then methods copied in from interfaces. Reflection reports every one of the first two
+ * groups except <clinit>, so the addresses the caller passes are a run of evenly spaced slots with
+ * <clinit> missing from it. Finding the hole finds the method, and a hole is bracketed by two
+ * members that are known to be inside the array, so nothing has to be assumed about where the
+ * array begins.
+ *
+ * The hole is only at the very start - below every address the caller can see - when no declared
+ * direct method sorts ahead of "<clinit>". Dex method ids are ordered by name, and while "<init>"
+ * does sort after it, '$' and '-' do not: an enum's $values, and the -$$Nest$ accessors javac
+ * emits for nestmates, both take the first slot instead. So the slot below the run is one
+ * possibility among several rather than the answer, and it is the only one that can fall outside
+ * the array, which is what a class with no static initializer looks like. It is checked last and
+ * only once its page is known to be mapped.
+ *
+ * Every candidate is then confirmed by two plain word reads before anything dereferences it: its
+ * declaring class must match the run's, and its access flags must say static constructor.
  *
  * The caller passes ArtMethod addresses read from java.lang.reflect.Executable.artMethod rather
  * than jmethodIDs, because a Java-debuggable process hands out index based ids instead of
  * pointers.
  *
- * A class with no static initializer has something else in that slot, so the candidate is checked
- * by two plain word reads before anything dereferences it: its declaring class must match its
- * neighbour's, and its access flags must say static constructor.
- *
- * @return The reflected static initializer, or nullptr if the class has none or the layout is not
- *         what this relies on.
+ * @return The static initializer as a reflected object, or nullptr if the class has none or the
+ *         layout is not what this relies on.
  */
 VECTOR_DEF_NATIVE_METHOD(jobject, HookBridge, findStaticInitializer, jclass target_class,
-                         jlongArray art_methods) {
+                         jlongArray art_methods, jlong art_method_size) {
     const jsize count = art_methods ? env->GetArrayLength(art_methods) : 0;
-    // One member anchors the array, a second gives its element size.
-    if (count < 2) return nullptr;
+    // One member is enough to anchor the run; the element size is a property of the runtime, so
+    // the caller derives it once elsewhere. A class whose only members are <clinit> and an
+    // implicit constructor leaves exactly one member visible to reflection, and that is the
+    // commonest shape for wanting this hook.
+    if (count < 1) return nullptr;
 
     std::vector<uintptr_t> ids(count);
     {
@@ -602,37 +625,48 @@ VECTOR_DEF_NATIVE_METHOD(jobject, HookBridge, findStaticInitializer, jclass targ
     }
 
     std::sort(ids.begin(), ids.end());
-    uintptr_t stride = std::numeric_limits<uintptr_t>::max();
-    for (size_t i = 1; i < ids.size(); ++i) {
-        uintptr_t delta = ids[i] - ids[i - 1];
-        if (delta > 0 && delta < stride) stride = delta;
-    }
+    const auto stride = static_cast<uintptr_t>(art_method_size);
     // An ArtMethod is a few dozen bytes on every supported release; refuse rather than guess when
-    // the spacing is not what a contiguous method array looks like.
+    // the size is not one a contiguous method array could have.
     if (stride < 16 || stride > 128 || (stride % alignof(void *)) != 0) return nullptr;
-    for (size_t i = 1; i < ids.size(); ++i) {
-        if ((ids[i] - ids[i - 1]) % stride != 0) return nullptr;
-    }
 
-    const uintptr_t anchor = ids.front();
-    const uintptr_t candidate = anchor - stride;
+    // Slots the caller cannot see. Interior ones come first because each is bracketed by a member
+    // on either side, so it is inside the array whatever the class turns out to look like. A class
+    // may have more than one hole: reflection also hides members the hidden API policy blocks.
+    constexpr size_t kMaxCandidates = 64;
+    std::vector<uintptr_t> candidates;
+    for (size_t i = 1; i < ids.size(); ++i) {
+        const uintptr_t delta = ids[i] - ids[i - 1];
+        // Uneven spacing means these are not one run of ArtMethods and none of this holds.
+        if (delta == 0 || (delta % stride) != 0) return nullptr;
+        for (uintptr_t slot = ids[i - 1] + stride; slot < ids[i]; slot += stride) {
+            if (candidates.size() >= kMaxCandidates) return nullptr;
+            candidates.push_back(slot);
+        }
+    }
+    // The slot below the run, which may be outside the array altogether.
+    const uintptr_t below = ids.front() - stride;
+    if (IsMapped(below, 2 * sizeof(uint32_t))) candidates.push_back(below);
 
     // ArtMethod starts with GcRoot<mirror::Class> declaring_class_ followed by uint32_t
-    // access_flags_. Both are plain words in the same allocation as the anchor, so reading them
-    // cannot fault where reading the anchor would not.
+    // access_flags_, so both live in the first eight bytes of a slot.
     const auto declaring_of = [](uintptr_t m) { return *reinterpret_cast<const uint32_t *>(m); };
     const auto flags_of = [](uintptr_t m) {
         return *reinterpret_cast<const uint32_t *>(m + sizeof(uint32_t));
     };
 
-    if (declaring_of(candidate) != declaring_of(anchor)) return nullptr;
-
     constexpr uint32_t kAccStatic = 0x0008;
     constexpr uint32_t kAccConstructor = 0x00010000;
-    const uint32_t flags = flags_of(candidate);
-    if ((flags & kAccStatic) == 0 || (flags & kAccConstructor) == 0) return nullptr;
+    const uint32_t declaring = declaring_of(ids.front());
 
-    return env->ToReflectedMethod(target_class, reinterpret_cast<jmethodID>(candidate), JNI_TRUE);
+    for (const uintptr_t candidate : candidates) {
+        if (declaring_of(candidate) != declaring) continue;
+        const uint32_t flags = flags_of(candidate);
+        if ((flags & kAccStatic) == 0 || (flags & kAccConstructor) == 0) continue;
+        return env->ToReflectedMethod(target_class, reinterpret_cast<jmethodID>(candidate),
+                                      JNI_TRUE);
+    }
+    return nullptr;
 }
 
 // Array of native method descriptors for JNI registration.
@@ -656,7 +690,7 @@ static JNINativeMethod gMethods[] = {
                          "(Ljava/lang/Class;Ljava/lang/reflect/"
                          "Executable;)[[Ljava/lang/Object;"),
     VECTOR_NATIVE_METHOD(HookBridge, findStaticInitializer,
-                         "(Ljava/lang/Class;[J)Ljava/lang/reflect/Executable;"),
+                         "(Ljava/lang/Class;[JJ)Ljava/lang/reflect/Executable;"),
 };
 
 /**

--- a/native/src/jni/hook_bridge.cpp
+++ b/native/src/jni/hook_bridge.cpp
@@ -594,7 +594,7 @@ static JNINativeMethod gMethods[] = {
                          "(Ljava/lang/Class;Ljava/lang/reflect/"
                          "Executable;)[[Ljava/lang/Object;"),
     VECTOR_NATIVE_METHOD(HookBridge, getStaticInitializer,
-                         "(Ljava/lang/Class;)Ljava/lang/reflect/Method;"),
+                         "(Ljava/lang/Class;)Ljava/lang/reflect/Executable;"),
 };
 
 /**

--- a/services/daemon-service/src/main/aidl/org/lsposed/lspd/models/PreLoadedApk.aidl
+++ b/services/daemon-service/src/main/aidl/org/lsposed/lspd/models/PreLoadedApk.aidl
@@ -5,4 +5,7 @@ parcelable PreLoadedApk {
     List<String> moduleClassNames;
     List<String> moduleLibraryNames;
     boolean legacy;
+    // module.prop 'exceptionMode', normalised by the daemon. false, the value an absent key
+    // parses to, is PROTECTIVE - what ExceptionMode.DEFAULT is specified to fall back to.
+    boolean exceptionPassthrough;
 }

--- a/services/daemon-service/src/main/aidl/org/lsposed/lspd/service/ILSPInjectedModuleService.aidl
+++ b/services/daemon-service/src/main/aidl/org/lsposed/lspd/service/ILSPInjectedModuleService.aidl
@@ -7,7 +7,7 @@ interface ILSPInjectedModuleService {
 
     Bundle requestRemotePreferences(String group, IRemotePreferenceCallback callback);
 
-    ParcelFileDescriptor openRemoteFile(String path);
+    @nullable ParcelFileDescriptor openRemoteFile(String path);
 
     String[] getRemoteFileList();
 }

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/VectorContext.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/VectorContext.kt
@@ -21,6 +21,28 @@ import org.matrix.vector.nativebridge.HookBridge
 
 private const val TAG = "VectorContext"
 
+/** Smallest positive gap between the sorted addresses, i.e. one ArtMethod. */
+private fun strideOf(addresses: LongArray): Long {
+    val sorted = addresses.sorted()
+    var stride = Long.MAX_VALUE
+    for (i in 1 until sorted.size) {
+        val delta = sorted[i] - sorted[i - 1]
+        if (delta in 1 until stride) stride = delta
+    }
+    return if (stride == Long.MAX_VALUE) 0L else stride
+}
+
+/**
+ * The size of one ArtMethod, which is a property of the runtime rather than of any class. Derived
+ * once from a class with plenty of members so that a class showing only one member to reflection
+ * can still be measured against it.
+ */
+private val artMethodSize: Long by lazy {
+    val field = artMethodField ?: return@lazy 0L
+    runCatching { strideOf(Any::class.java.declaredMethods.map { field.getLong(it) }.toLongArray()) }
+        .getOrDefault(0L)
+}
+
 /** ART keeps the ArtMethod address of a reflected member in this field. */
 private val artMethodField: Field? by lazy {
     runCatching {
@@ -78,7 +100,10 @@ class VectorContext(
                 members.addAll(origin.declaredConstructors)
                 members.addAll(origin.declaredMethods)
                 val addresses = LongArray(members.size) { field.getLong(members[it]) }
-                HookBridge.findStaticInitializer(origin, addresses)
+                // Prefer the class's own spacing; fall back to the runtime-wide size for a class
+                // that shows fewer than two members.
+                val stride = strideOf(addresses).takeIf { it > 0 } ?: artMethodSize
+                HookBridge.findStaticInitializer(origin, addresses, stride)
             }
             .onFailure { Log.w(TAG, "Static initializer lookup failed for ${origin.name}", it) }
             .getOrNull()

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/VectorContext.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/VectorContext.kt
@@ -9,6 +9,7 @@ import io.github.libxposed.api.XposedModuleInterface.*
 import java.io.FileNotFoundException
 import java.lang.reflect.Constructor
 import java.lang.reflect.Executable
+import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.util.concurrent.ConcurrentHashMap
 import org.lsposed.lspd.service.ILSPInjectedModuleService
@@ -17,6 +18,16 @@ import org.matrix.vector.impl.hooks.VectorCtorInvoker
 import org.matrix.vector.impl.hooks.VectorHookBuilder
 import org.matrix.vector.impl.hooks.VectorMethodInvoker
 import org.matrix.vector.nativebridge.HookBridge
+
+private const val TAG = "VectorContext"
+
+/** ART keeps the ArtMethod address of a reflected member in this field. */
+private val artMethodField: Field? by lazy {
+    runCatching {
+            Executable::class.java.getDeclaredField("artMethod").apply { isAccessible = true }
+        }
+        .getOrNull()
+}
 
 /**
  * Main framework context implementation. Provides modules with capabilities to hook executables,
@@ -48,10 +59,29 @@ class VectorContext(
 
     override fun hookClassInitializer(origin: Class<*>): XposedInterface.HookBuilder {
         val clinit =
-            HookBridge.getStaticInitializer(origin)
+            findStaticInitializer(origin)
                 ?: throw IllegalArgumentException("Class ${origin.name} has no static initializer")
         return VectorHookBuilder(clinit, defaultExceptionMode)
     }
+
+    /**
+     * Resolving <clinit> through JNI runs the class's static initializer, which is the event a hook
+     * on it exists to observe, so locate it from the method layout instead. Reflection over
+     * declared members does not initialize the class, and ArtMethod addresses are read from the
+     * reflected objects rather than through jmethodIDs, which a debuggable process hands out as
+     * indices.
+     */
+    private fun findStaticInitializer(origin: Class<*>): Executable? =
+        runCatching {
+                val field = artMethodField ?: return null
+                val members = ArrayList<Executable>()
+                members.addAll(origin.declaredConstructors)
+                members.addAll(origin.declaredMethods)
+                val addresses = LongArray(members.size) { field.getLong(members[it]) }
+                HookBridge.findStaticInitializer(origin, addresses)
+            }
+            .onFailure { Log.w(TAG, "Static initializer lookup failed for ${origin.name}", it) }
+            .getOrNull()
 
     override fun deoptimize(executable: Executable): Boolean {
         return HookBridge.deoptimizeMethod(executable)

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/VectorContext.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/VectorContext.kt
@@ -4,6 +4,7 @@ import android.content.SharedPreferences
 import android.content.pm.ApplicationInfo
 import android.os.ParcelFileDescriptor
 import io.github.libxposed.api.XposedInterface
+import io.github.libxposed.api.XposedInterface.ExceptionMode
 import io.github.libxposed.api.XposedModuleInterface.*
 import java.io.FileNotFoundException
 import java.lang.reflect.Constructor
@@ -25,6 +26,8 @@ class VectorContext(
     private val packageName: String,
     private val applicationInfo: ApplicationInfo,
     private val service: ILSPInjectedModuleService,
+    // What ExceptionMode.DEFAULT resolves to for this module, from module.prop.
+    private val defaultExceptionMode: ExceptionMode = ExceptionMode.PROTECTIVE,
 ) : XposedInterface {
 
     private val remotePrefs = ConcurrentHashMap<String, SharedPreferences>()
@@ -40,14 +43,14 @@ class VectorContext(
     }
 
     override fun hook(origin: Executable): XposedInterface.HookBuilder {
-        return VectorHookBuilder(origin)
+        return VectorHookBuilder(origin, defaultExceptionMode)
     }
 
     override fun hookClassInitializer(origin: Class<*>): XposedInterface.HookBuilder {
         val clinit =
             HookBridge.getStaticInitializer(origin)
                 ?: throw IllegalArgumentException("Class ${origin.name} has no static initializer")
-        return VectorHookBuilder(clinit)
+        return VectorHookBuilder(clinit, defaultExceptionMode)
     }
 
     override fun deoptimize(executable: Executable): Boolean {

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/VectorContext.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/VectorContext.kt
@@ -11,6 +11,7 @@ import java.lang.reflect.Constructor
 import java.lang.reflect.Executable
 import java.lang.reflect.Field
 import java.lang.reflect.Method
+import java.lang.reflect.Modifier
 import java.util.concurrent.ConcurrentHashMap
 import org.lsposed.lspd.service.ILSPInjectedModuleService
 import org.lsposed.lspd.util.Utils.Log
@@ -83,7 +84,32 @@ class VectorContext(
         val clinit =
             findStaticInitializer(origin)
                 ?: throw IllegalArgumentException("Class ${origin.name} has no static initializer")
-        return VectorHookBuilder(clinit, defaultExceptionMode)
+        return VectorHookBuilder(asSyntheticMethod(clinit), defaultExceptionMode)
+    }
+
+    /**
+     * hookClassInitializer documents Chain#getExecutable as "a synthetic Method representing the
+     * static initializer", but ART reflects <clinit> as a Constructor because it carries
+     * ACC_CONSTRUCTOR. A Method is allocated without running a constructor and given the same
+     * Executable state, so it names the same ArtMethod while presenting the documented type.
+     */
+    private fun asSyntheticMethod(clinit: Executable): Executable {
+        if (clinit is Method) return clinit
+        return runCatching {
+                val method = HookBridge.allocateObject(Method::class.java)
+                for (field in Executable::class.java.declaredFields) {
+                    if (Modifier.isStatic(field.modifiers)) continue
+                    field.isAccessible = true
+                    field.set(method, field.get(clinit))
+                }
+                method as Executable
+            }
+            .onFailure {
+                // Falling back keeps the hook working, at the cost of handing the hooker the type
+                // ART produced instead of the one the interface promises.
+                Log.w(TAG, "Cannot present <clinit> of ${'$'}{clinit.declaringClass.name} as a Method", it)
+            }
+            .getOrDefault(clinit)
     }
 
     /**

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/VectorRemotePreferences.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/VectorRemotePreferences.kt
@@ -33,6 +33,13 @@ internal class VectorRemotePreferences(service: ILSPInjectedModuleService, group
             override fun onUpdate(bundle: Bundle) {
                 val changes = ArraySet<String>()
 
+                // Sent for edit().clear() and for deleteRemotePreferences. Without this the cache
+                // keeps serving values the module app already removed.
+                if (bundle.getBoolean("clear", false)) {
+                    changes.addAll(map.keys)
+                    map.clear()
+                }
+
                 if (bundle.containsKey("delete")) {
                     val deletes =
                         bundle.getSerializableCompat<Set<String>>("delete") as? Set<String>

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/core/VectorModuleManager.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/core/VectorModuleManager.kt
@@ -2,6 +2,7 @@ package org.matrix.vector.impl.core
 
 import android.os.Build
 import android.os.Process
+import io.github.libxposed.api.XposedInterface.ExceptionMode
 import io.github.libxposed.api.XposedModule
 import io.github.libxposed.api.XposedModuleInterface.ModuleLoadedParam
 import java.io.File
@@ -62,6 +63,9 @@ object VectorModuleManager {
                     packageName = module.packageName,
                     applicationInfo = module.applicationInfo,
                     service = module.service, // Our IPC client
+                    defaultExceptionMode =
+                        if (module.file.exceptionPassthrough) ExceptionMode.PASSTHROUGH
+                        else ExceptionMode.PROTECTIVE,
                 )
 
             // Instantiate the module entry classes

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/core/VectorStartup.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/core/VectorStartup.kt
@@ -1,9 +1,12 @@
 package org.matrix.vector.impl.core
 
+import android.app.ActivityThread
 import android.os.Build
 import android.os.IBinder
 import dalvik.system.DexFile
+import org.lsposed.lspd.util.Utils
 import org.lsposed.lspd.service.ILSPApplicationService
+import org.matrix.vector.impl.di.VectorBootstrap
 import org.matrix.vector.impl.hookers.*
 import org.matrix.vector.impl.hooks.VectorHookBuilder
 
@@ -82,6 +85,27 @@ object VectorStartup {
                 if (classLoader != null) {
                     // Manually trigger the routines that the hooks normally would
                     HandleSystemServerProcessHooker.initSystemServer(classLoader, isLate = true)
+
+                    // ActivityThread.attach ran before we were injected, so AppAttachHooker will
+                    // never fire here and nothing else instantiates modules. Without this,
+                    // dispatchSystemServerLoaded below would notify an empty module set.
+                    val activityThread = ActivityThread.currentActivityThread()
+                    if (activityThread != null) {
+                        VectorBootstrap.withLegacy { it.loadModules(activityThread) }
+                    } else {
+                        Utils.logW(
+                            "Late system server injection: no current ActivityThread, modules cannot be loaded"
+                        )
+                    }
+
+                    // Say plainly what this is. onSystemServerStarting is documented as "system
+                    // server is ready to start critical services", which is no longer true here -
+                    // the services are already running. Modules that key off it should treat a
+                    // late dispatch as best effort.
+                    Utils.logW(
+                        "Late system server injection: dispatching onSystemServerStarting after " +
+                            "system server has already started; critical services are live"
+                    )
                     StartBootstrapServicesHooker.dispatchSystemServerLoaded(classLoader)
                 }
             }

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/hookers/LoadedApkHookers.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/hookers/LoadedApkHookers.kt
@@ -39,25 +39,42 @@ private object PackageContextHelper {
 
     data class ContextInfo(
         val packageName: String,
+        val legacyPackageName: String,
         val processName: String,
         val isFirstPackage: Boolean,
     )
 
     fun resolve(loadedApk: Any, apkPackageName: String): ContextInfo {
-        var packageName = currentPkgMethod.invoke(null) as? String
-        var processName = currentProcMethod.invoke(null) as? String
+        val boundPackage = currentPkgMethod.invoke(null) as? String
+        val boundProcess = currentProcMethod.invoke(null) as? String
 
         val isFirstPackage =
-            packageName != null && processName != null && packageName == apkPackageName
+            boundPackage != null && boundProcess != null && boundPackage == apkPackageName
 
-        if (!isFirstPackage) {
+        val packageName: String
+        val processName: String
+        if (isFirstPackage) {
+            packageName = boundPackage!!
+            processName = boundProcess!!
+        } else {
             packageName = apkPackageName
-            processName = currentPkgMethod.invoke(null) as? String ?: apkPackageName
-        } else if (packageName == "android") {
-            packageName = "system"
+            processName = boundPackage ?: apkPackageName
         }
 
-        return ContextInfo(packageName, processName, isFirstPackage)
+        // The two APIs name this process differently, so keep both names.
+        //
+        // de.robv modules identify system server by lpparam.packageName == "android", so the
+        // android:ui process has always been handed "system" to keep the two apart. The modern
+        // API says the reverse: "system" is the virtual name for system server, while "android"
+        // stays a real scope target precisely because some of its components declare
+        // android:process=":ui". Reporting android:ui as "system" there hid the real package.
+        //
+        // In system server itself currentPackageName() is null, so isFirstPackage is false and
+        // both names are already "android"; only android:ui is affected.
+        val legacyPackageName =
+            if (isFirstPackage && packageName == "android") "system" else packageName
+
+        return ContextInfo(packageName, legacyPackageName, processName, isFirstPackage)
     }
 }
 
@@ -172,7 +189,7 @@ object LoadedApkCreateCLHooker : XposedInterface.Hooker {
                     VectorBootstrap.withLegacy { delegate ->
                         delegate.onPackageLoaded(
                             LegacyPackageInfo(
-                                ctx.packageName,
+                                ctx.legacyPackageName,
                                 ctx.processName,
                                 classLoader,
                                 appInfo,

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/BaseInvoker.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/BaseInvoker.kt
@@ -28,16 +28,14 @@ internal abstract class BaseInvoker<T : Invoker<T, U>, U : Executable>(
     /** Resolves the current [type] and executes the underlying method. */
     protected fun proceedInvocation(thisObject: Any?, args: Array<out Any?>): Any? {
         return when (val currentType = type) {
-            is Invoker.Type.Origin -> {
-                try {
-                    HookBridge.invokeOriginalMethod(executable, thisObject, *args)
-                } catch (e: InvocationTargetException) {
-                    throw e.cause ?: e
-                }
-            }
+            is Invoker.Type.Origin -> invokeOriginal(thisObject, args)
             is Invoker.Type.Chain -> {
                 val snapshots =
                     HookBridge.callbackSnapshot(VectorHookRecord::class.java, executable)
+                        // The executable carries no hooks, so there is no chain to enter. Invokers
+                        // default to Type.Chain.FULL, so this is the ordinary case for a module
+                        // that obtains an invoker for a method it has not hooked.
+                        ?: return invokeOriginal(thisObject, args)
 
                 @Suppress("UNCHECKED_CAST")
                 val allModernHooks = snapshots[0] as Array<VectorHookRecord>
@@ -62,6 +60,15 @@ internal abstract class BaseInvoker<T : Invoker<T, U>, U : Executable>(
                     VectorChain(executable, thisObject, arrayOf(*args), filteredHooks, 0, terminal)
                 chain.proceed()
             }
+        }
+    }
+
+    /** Invokes the original executable, unwrapping the reflective wrapper exception. */
+    private fun invokeOriginal(thisObject: Any?, args: Array<out Any?>): Any? {
+        return try {
+            HookBridge.invokeOriginalMethod(executable, thisObject, *args)
+        } catch (e: InvocationTargetException) {
+            throw e.cause ?: e
         }
     }
 

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/BaseInvoker.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/BaseInvoker.kt
@@ -49,10 +49,10 @@ internal abstract class BaseInvoker<T : Invoker<T, U>, U : Executable>(
                     val delegate = VectorBootstrap.delegate
                     if (legacyHooks.isNotEmpty() && delegate != null) {
                         delegate.processLegacyHook(executable, tObj, tArgs, legacyHooks) {
-                            HookBridge.invokeOriginalMethod(executable, tObj, *tArgs)
+                            invokeOriginal(tObj, tArgs)
                         }
                     } else {
-                        HookBridge.invokeOriginalMethod(executable, tObj, *tArgs)
+                        invokeOriginal(tObj, tArgs)
                     }
                 }
 

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/BaseInvoker.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/BaseInvoker.kt
@@ -28,14 +28,16 @@ internal abstract class BaseInvoker<T : Invoker<T, U>, U : Executable>(
     /** Resolves the current [type] and executes the underlying method. */
     protected fun proceedInvocation(thisObject: Any?, args: Array<out Any?>): Any? {
         return when (val currentType = type) {
-            is Invoker.Type.Origin -> invokeOriginal(thisObject, args)
+            // Both paths below already report a target exception wrapped and their own argument
+            // failures unwrapped, which is what Invoker#invoke documents.
+            is Invoker.Type.Origin -> dispatchOriginal(thisObject, args)
             is Invoker.Type.Chain -> {
                 val snapshots =
                     HookBridge.callbackSnapshot(VectorHookRecord::class.java, executable)
                         // The executable carries no hooks, so there is no chain to enter. Invokers
                         // default to Type.Chain.FULL, so this is the ordinary case for a module
                         // that obtains an invoker for a method it has not hooked.
-                        ?: return invokeOriginal(thisObject, args)
+                        ?: return dispatchOriginal(thisObject, args)
 
                 @Suppress("UNCHECKED_CAST")
                 val allModernHooks = snapshots[0] as Array<VectorHookRecord>
@@ -58,13 +60,23 @@ internal abstract class BaseInvoker<T : Invoker<T, U>, U : Executable>(
 
                 val chain =
                     VectorChain(executable, thisObject, arrayOf(*args), filteredHooks, 0, terminal)
-                chain.proceed()
+                // Chain#proceed is documented to hand hookers the exception itself, while
+                // Invoker#invoke is documented against Method#invoke, which reports it wrapped, so
+                // the wrapping belongs at this boundary rather than inside the chain. The paths
+                // that skip the chain get this from the dispatch itself and are not re-wrapped.
+                try {
+                    chain.proceed()
+                } catch (e: InvocationTargetException) {
+                    throw e
+                } catch (e: Throwable) {
+                    throw InvocationTargetException(e)
+                }
             }
         }
     }
 
-    /** Invokes the original executable, unwrapping the reflective wrapper exception. */
-    private fun invokeOriginal(thisObject: Any?, args: Array<out Any?>): Any? {
+    /** Invokes the original executable, reporting a target exception as Method#invoke does. */
+    private fun dispatchOriginal(thisObject: Any?, args: Array<out Any?>): Any? {
         // invokeOriginalMethod dispatches through a cached Method.invoke id. For a hooked
         // executable that is applied to lsplant's backup Method, which is correct. For an
         // executable with no hook item at all it is applied to the reflected object we passed in
@@ -85,12 +97,19 @@ internal abstract class BaseInvoker<T : Invoker<T, U>, U : Executable>(
                 *args,
             )
         }
-        return try {
-            HookBridge.invokeOriginalMethod(executable, thisObject, *args)
+        return HookBridge.invokeOriginalMethod(executable, thisObject, *args)
+    }
+
+    /**
+     * The chain terminal. Chain#proceed is documented to throw whatever the original executable
+     * threw, so the reflective wrapper comes off here rather than at the public boundary.
+     */
+    private fun invokeOriginal(thisObject: Any?, args: Array<out Any?>): Any? =
+        try {
+            dispatchOriginal(thisObject, args)
         } catch (e: InvocationTargetException) {
             throw e.cause ?: e
         }
-    }
 
     /** Helper to generate the JNI shorty for non-virtual special invocations. */
     protected fun getExecutableShorty(): CharArray {

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/BaseInvoker.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/BaseInvoker.kt
@@ -65,6 +65,26 @@ internal abstract class BaseInvoker<T : Invoker<T, U>, U : Executable>(
 
     /** Invokes the original executable, unwrapping the reflective wrapper exception. */
     private fun invokeOriginal(thisObject: Any?, args: Array<out Any?>): Any? {
+        // invokeOriginalMethod dispatches through a cached Method.invoke id. For a hooked
+        // executable that is applied to lsplant's backup Method, which is correct. For an
+        // executable with no hook item at all it is applied to the reflected object we passed in
+        // — and if that is a Constructor, the id belongs to a different class. Route those
+        // through the non-virtual path instead, which is what invokeSpecial already uses.
+        if (
+            executable is Constructor<*> &&
+                HookBridge.callbackSnapshot(VectorHookRecord::class.java, executable) == null
+        ) {
+            requireNotNull(thisObject) {
+                "A constructor invoked as a method needs a receiver: $executable"
+            }
+            return HookBridge.invokeSpecialMethod(
+                executable,
+                getExecutableShorty(),
+                executable.declaringClass,
+                thisObject,
+                *args,
+            )
+        }
         return try {
             HookBridge.invokeOriginalMethod(executable, thisObject, *args)
         } catch (e: InvocationTargetException) {

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/VectorChain.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/VectorChain.kt
@@ -4,6 +4,7 @@ import io.github.libxposed.api.XposedInterface
 import io.github.libxposed.api.XposedInterface.Chain
 import io.github.libxposed.api.XposedInterface.ExceptionMode
 import java.lang.reflect.Executable
+import java.util.Collections
 import org.lsposed.lspd.util.Utils
 
 /** Represents a registered hook configuration, stored natively by [HookBridge]. */
@@ -38,7 +39,8 @@ class VectorChain(
 
     override fun getThisObject(): Any? = thisObj
 
-    override fun getArgs(): List<Any?> = args.toList()
+    // The API documents this list as immutable; toList() hands back a mutable ArrayList.
+    override fun getArgs(): List<Any?> = Collections.unmodifiableList(args.asList())
 
     override fun getArg(index: Int): Any? = args[index]
 
@@ -66,20 +68,31 @@ class VectorChain(
         return try {
             executeDownstream { record.hooker.intercept(nextChain) }
         } catch (t: Throwable) {
-            handleInterceptorException(t, record, nextChain, thisObject, currentArgs)
+            // Recording the recovery keeps this node's cached state consistent: once the hooker's
+            // exception has been suppressed, parent nodes must observe the recovered outcome and
+            // not the exception we just swallowed.
+            executeDownstream {
+                handleInterceptorException(t, record, nextChain, thisObject, currentArgs)
+            }
         }
     }
 
     /**
      * Executes the block and caches the downstream state so parent chains can recover it if the
      * current interceptor crashes during post-processing.
+     *
+     * Exactly one of [downstreamResult] and [downstreamThrowable] is meaningful after this returns,
+     * so both are always written; leaving a stale value behind would let a parent node resurrect an
+     * exception this node already handled.
      */
     private inline fun executeDownstream(block: () -> Any?): Any? {
         return try {
             val result = block()
             downstreamResult = result
+            downstreamThrowable = null
             result
         } catch (t: Throwable) {
+            downstreamResult = null
             downstreamThrowable = t
             throw t
         }

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/VectorChain.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/VectorChain.kt
@@ -39,8 +39,10 @@ class VectorChain(
 
     override fun getThisObject(): Any? = thisObj
 
-    // The API documents this list as immutable; toList() hands back a mutable ArrayList.
-    override fun getArgs(): List<Any?> = Collections.unmodifiableList(args.asList())
+    // Immutable, and a snapshot rather than a view: the chain rewrites this array in place when a
+    // hooker calls proceed(args) and when a legacy hook edits its arguments, which would otherwise
+    // change a list a hooker is still holding.
+    override fun getArgs(): List<Any?> = Collections.unmodifiableList(args.toMutableList())
 
     override fun getArg(index: Int): Any? = args[index]
 

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/VectorNativeHooker.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/VectorNativeHooker.kt
@@ -6,6 +6,7 @@ import io.github.libxposed.api.XposedInterface.HookBuilder
 import io.github.libxposed.api.XposedInterface.HookHandle
 import io.github.libxposed.api.XposedInterface.Hooker
 import io.github.libxposed.api.error.HookFailedError
+import java.lang.reflect.Constructor
 import java.lang.reflect.Executable
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
@@ -37,6 +38,14 @@ class VectorHookBuilder(private val origin: Executable) : HookBuilder {
                 origin.name == "invoke"
         ) {
             throw IllegalArgumentException("Cannot hook Method.invoke")
+        } else if (
+            origin is Method &&
+                origin.declaringClass == Constructor::class.java &&
+                origin.name == "newInstance"
+        ) {
+            // Named alongside Method.invoke by the API: the framework reflects through both, so
+            // hooking either recurses into the hook dispatch.
+            throw IllegalArgumentException("Cannot hook Constructor.newInstance")
         }
 
         val record = VectorHookRecord(hooker, priority, exceptionMode)
@@ -72,8 +81,11 @@ class VectorNativeHooker<T : Executable>(private val method: T) {
         val thisObject = if (isStatic) null else args[0]
         val actualArgs = if (isStatic) args else args.sliceArray(1 until args.size)
 
-        // Retrieve the hook snapshots
-        val snapshots = HookBridge.callbackSnapshot(VectorHookRecord::class.java, method)
+        // Retrieve the hook snapshots. Null means every hook was removed after this trampoline was
+        // entered, which is indistinguishable from having none.
+        val snapshots =
+            HookBridge.callbackSnapshot(VectorHookRecord::class.java, method)
+                ?: return invokeOriginalSafely(thisObject, actualArgs)
 
         @Suppress("UNCHECKED_CAST") val modernHooks = snapshots[0] as Array<VectorHookRecord>
         val legacyHooks = snapshots[1]

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/VectorNativeHooker.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/hooks/VectorNativeHooker.kt
@@ -16,7 +16,12 @@ import org.matrix.vector.impl.di.VectorBootstrap
 import org.matrix.vector.nativebridge.HookBridge
 
 /** Builder for configuring and registering hooks. */
-class VectorHookBuilder(private val origin: Executable) : HookBuilder {
+class VectorHookBuilder(
+    private val origin: Executable,
+    // Framework-internal hooks have no module.prop, and must stay protective: letting one of
+    // them propagate would take the boot path down with it.
+    private val defaultExceptionMode: ExceptionMode = ExceptionMode.PROTECTIVE,
+) : HookBuilder {
 
     private var priority = XposedInterface.PRIORITY_DEFAULT
     private var exceptionMode = ExceptionMode.DEFAULT
@@ -48,7 +53,12 @@ class VectorHookBuilder(private val origin: Executable) : HookBuilder {
             throw IllegalArgumentException("Cannot hook Constructor.newInstance")
         }
 
-        val record = VectorHookRecord(hooker, priority, exceptionMode)
+        // Resolve DEFAULT here rather than at throw time: the record is stored natively and
+        // reaches VectorChain with no way back to the module, and module.prop cannot change
+        // for the life of the process.
+        val resolvedMode =
+            if (exceptionMode == ExceptionMode.DEFAULT) defaultExceptionMode else exceptionMode
+        val record = VectorHookRecord(hooker, priority, resolvedMode)
 
         // Register natively. HookBridge now stores VectorHookRecord instead of HookerCallback.
         if (

--- a/xposed/src/main/kotlin/org/matrix/vector/nativebridge/HookBridge.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/nativebridge/HookBridge.kt
@@ -68,4 +68,15 @@ object HookBridge {
      */
     @JvmStatic
     external fun getStaticInitializer(clazz: Class<*>): Executable?
+
+    /**
+     * Locates a class's static initializer without initializing it, unlike [getStaticInitializer].
+     * [artMethods] must be the ArtMethod addresses of the class's declared constructors and
+     * methods, which reflection can supply without triggering initialization.
+     *
+     * Returns null when the class has no static initializer or the method layout is not the one
+     * this relies on.
+     */
+    @JvmStatic
+    external fun findStaticInitializer(clazz: Class<*>, artMethods: LongArray): Executable?
 }

--- a/xposed/src/main/kotlin/org/matrix/vector/nativebridge/HookBridge.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/nativebridge/HookBridge.kt
@@ -64,11 +64,17 @@ object HookBridge {
     /**
      * Locates a class's static initializer without initializing it.
      * [artMethods] must be the ArtMethod addresses of the class's declared constructors and
-     * methods, which reflection can supply without triggering initialization.
+     * methods, which reflection can supply without triggering initialization, and [artMethodSize]
+     * the size of one ArtMethod. One member is enough, which matters because a class whose only
+     * members are the static initializer and an implicit constructor shows just one to reflection.
      *
      * Returns null when the class has no static initializer or the method layout is not the one
      * this relies on.
      */
     @JvmStatic
-    external fun findStaticInitializer(clazz: Class<*>, artMethods: LongArray): Executable?
+    external fun findStaticInitializer(
+        clazz: Class<*>,
+        artMethods: LongArray,
+        artMethodSize: Long,
+    ): Executable?
 }

--- a/xposed/src/main/kotlin/org/matrix/vector/nativebridge/HookBridge.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/nativebridge/HookBridge.kt
@@ -61,5 +61,11 @@ object HookBridge {
         method: Executable,
     ): Array<Array<Any?>>?
 
-    @JvmStatic external fun getStaticInitializer(clazz: Class<*>): Method?
+    /**
+     * ART reflects <clinit> as a Constructor, not a Method, so this returns the
+     * common supertype. Declaring Method made the JNI return-type check abort the
+     * process on every call.
+     */
+    @JvmStatic
+    external fun getStaticInitializer(clazz: Class<*>): Executable?
 }

--- a/xposed/src/main/kotlin/org/matrix/vector/nativebridge/HookBridge.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/nativebridge/HookBridge.kt
@@ -62,15 +62,7 @@ object HookBridge {
     ): Array<Array<Any?>>?
 
     /**
-     * ART reflects <clinit> as a Constructor, not a Method, so this returns the
-     * common supertype. Declaring Method made the JNI return-type check abort the
-     * process on every call.
-     */
-    @JvmStatic
-    external fun getStaticInitializer(clazz: Class<*>): Executable?
-
-    /**
-     * Locates a class's static initializer without initializing it, unlike [getStaticInitializer].
+     * Locates a class's static initializer without initializing it.
      * [artMethods] must be the ArtMethod addresses of the class's declared constructors and
      * methods, which reflection can supply without triggering initialization.
      *

--- a/xposed/src/main/kotlin/org/matrix/vector/nativebridge/HookBridge.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/nativebridge/HookBridge.kt
@@ -54,8 +54,12 @@ object HookBridge {
 
     @JvmStatic @FastNative external fun setTrusted(cookie: Any?): Boolean
 
+    /** Returns null when [method] carries no hooks at all. */
     @JvmStatic
-    external fun callbackSnapshot(hooker_callback: Class<*>, method: Executable): Array<Array<Any?>>
+    external fun callbackSnapshot(
+        hooker_callback: Class<*>,
+        method: Executable,
+    ): Array<Array<Any?>>?
 
     @JvmStatic external fun getStaticInitializer(clazz: Class<*>): Method?
 }


### PR DESCRIPTION
Fixes against libxposed API 101, the version master vendors. Nothing to do with #757 — no submodule bumps, no new API.

All of it was found and checked with small test modules that assert the documented behaviour and log pass/fail, on a Pixel 6 running Android 17, debuggable and release targets.

**`hookClassInitializer` never worked at all.** It crashed the process, and once that was fixed the hook still could not fire. It works now — there is a separate comment below, that is the part worth reading properly.

**The chain and the invokers.** Two protective hooks could resurrect an exception the chain had already swallowed. `ExceptionMode.DEFAULT` ignored `exceptionMode`, so passthrough was unreachable. `getInvoker()` threw NPE on an unhooked method, `Constructor.newInstance` was hookable when the doc names it as the one you cannot hook, and an unhooked constructor dispatched `Method.invoke`'s id against itself. `Invoker.invoke` wrapped the target's exception only for unhooked constructors — it is `Method#invoke` semantics on every path now, while `Chain.proceed` still gives hookers the raw one. `getArgs()` was mutable.

**Elsewhere.** A late-injected system server loaded no modern modules but dispatched `onSystemServerStarting` anyway. `android:ui` was reported to modules as the `system` package. `edit().clear()` did nothing, and fixing it turned up that preference updates reached every Android user's hooked processes rather than the one that made the change. Empty scope requests never called back, `openRemoteFile` threw `RemoteException` where the doc promises `FileNotFoundException`, `getScope()` repeated a package once per user, and `module.prop` was not parsed as `Properties` despite the spec naming it.

**Manager.** One bad `module.prop` could blank the entire module list — twice over, through a missing key and through a malformed escape. The list now shows which API each module targets. `staticScope` is enforced instead of ignored: the picker offers only what a module claims, and the daemon refuses the rest whether it comes from the socket CLI, a backup restore or the module's own `requestScope`, and drops stale rows when it starts.

Two things were tried and then reverted: teaching the daemon to parse `targetApiVersion` like the manager, and the manager to trim `scope.list` like the daemon. Neither is in the spec, and that road ends with two implementations of a spec implementing each other instead.
