### PR TITLE
Restore the INET group patch on the manager's original gid array

### DIFF
--- a/zygisk/src/main/cpp/module.cpp
+++ b/zygisk/src/main/cpp/module.cpp
@@ -260,6 +260,20 @@ void VectorModule::preAppSpecialize(zygisk::AppSpecializeArgs *args) {
             jint inet_gid = GID_INET;
             env_->SetIntArrayRegion(new_gids, original_gids_count, 1, &inet_gid);
 
+            // The new array is only seen by the native specialization, which calls setgroups().
+            // Once it returns, Zygote#forkAndSpecialize keeps using the array it passed in:
+            //
+            //   NetworkUtils.setAllowNetworkingForProcess(containsInetGid(gids));
+            //
+            // That flag lives in libnetd_client and gates the whole process: without it,
+            // socket() and dns_open_proxy() fail with EPERM no matter which groups we really
+            // belong to. So overwrite the first entry of the original array as well, to make
+            // containsInetGid() see the INET group. Dropping this slot is harmless: the array
+            // has no further use once specialization is done.
+            if (original_gids_count > 0) {
+                env_->SetIntArrayRegion(args->gids, 0, 1, &inet_gid);
+            }
+
             args->nice_name = env_->NewStringUTF(INJECTED_PACKAGE_NAME);
             args->gids = new_gids;
         }


### PR DESCRIPTION
The manager runs inside `com.android.shell`, which has no INTERNET permission before Android 12, so we add the INET group ourselves during zygote specialization. We were patching only the gid array that the native specialization uses; the array Java keeps holding is the one `Zygote#forkAndSpecialize` reads a moment later to decide whether the process is allowed to use the network. It still said no, so every socket and DNS query inside the manager failed with `EPERM`, which surfaces as `SecurityException: Permission denied (missing INTERNET permission?)`.

LSPosed patched both arrays ever since the parasitic manager was introduced, and I dropped that line while rewriting the module for the new zygisk architecture. Android 12 and later were never affected, because `com.android.shell` declares INTERNET there and the gid array already carries the group.

This is still a hypothesis until it is confirmed on a device. If it holds, it should also explain the empty Repository tab: the manager simply had no network at all.

Fixes #636
