### PR TITLE
Fix the manager crashing on launch

### DIFF
--- a/manager/build.gradle.kts
+++ b/manager/build.gradle.kts
@@ -97,6 +97,9 @@ android {
     packaging {
         resources {
             excludes += "META-INF/**"
+            // Java resources only, so it is inert against the Android artifact, which ships its
+            // public suffix list under assets/. Pinning the JVM variant would move that list back
+            // to okhttp3/internal/publicsuffix/ and this line would then delete it.
             excludes += "okhttp3/**"
             excludes += "kotlin/**"
             excludes += "**.properties"

--- a/manager/src/main/kotlin/org/matrix/vector/manager/data/github/GitHubRepository.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/data/github/GitHubRepository.kt
@@ -700,6 +700,23 @@ class GitHubRepository(
     }
 
     /**
+     * The releases page, or null when GitHub could not be reached.
+     *
+     * Both readers of this endpoint are launched from a `viewModelScope` or a `LaunchedEffect`,
+     * neither of which has a `CoroutineExceptionHandler` anywhere in this app — so a throw here is
+     * a fatal on the main thread rather than a card that stays empty. Every other request in this
+     * file already guards itself; these two did not, which is how a resolver failure took the whole
+     * manager down instead of leaving the update card blank.
+     *
+     * One helper for both because it is the same request: fetching it twice under two URLs built
+     * from the same three constants is how the two lists drift apart.
+     */
+    private fun releaseListJson(freshness: Freshness): String? =
+        runCatching { get("$API/$REPO/releases?per_page=$CANARY_FETCH", freshness) }
+            .onFailure { e -> Log.w(Constants.TAG, "update: github release list unavailable", e) }
+            .getOrNull()
+
+    /**
      * The canary builds, newest first.
      *
      * These are **prereleases**, not Actions artifacts, and that is the whole point. GitHub gates an
@@ -714,9 +731,7 @@ class GitHubRepository(
      */
     suspend fun canaryBuilds(freshness: Freshness = Freshness.Revalidate): List<CanaryBuild> =
         withContext(Dispatchers.IO) {
-            val body =
-                get("$API/$REPO/releases?per_page=$CANARY_FETCH", freshness)
-                    ?: return@withContext emptyList()
+            val body = releaseListJson(freshness) ?: return@withContext emptyList()
 
             runCatching { json.decodeFromString<List<GhRelease>>(body) }
                 .onFailure { e -> Log.e(Constants.TAG, "update: canary release list unreadable", e) }
@@ -757,9 +772,7 @@ class GitHubRepository(
     suspend fun frameworkReleases(freshness: Freshness = Freshness.Revalidate):
         List<FrameworkRelease> =
         withContext(Dispatchers.IO) {
-            val body =
-                get("$API/$REPO/releases?per_page=$CANARY_FETCH", freshness)
-                    ?: return@withContext emptyList()
+            val body = releaseListJson(freshness) ?: return@withContext emptyList()
 
             runCatching { json.decodeFromString<List<GhRelease>>(body) }
                 .onFailure { e -> Log.e(Constants.TAG, "update: release list unreadable", e) }

--- a/manager/src/main/kotlin/org/matrix/vector/manager/data/log/CrashRecorder.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/data/log/CrashRecorder.kt
@@ -53,7 +53,7 @@ object CrashRecorder {
     @Volatile private var installed = false
 
     /**
-     * Takes over the default handler, once per process.
+     * Takes over the default handler, once per process, and discards what another build left.
      *
      * Called from [org.matrix.vector.manager.di.ServiceLocator.attach], early in the activity's
      * `onCreate` and before anything that could fail, so the handler is in place before any screen
@@ -64,6 +64,7 @@ object CrashRecorder {
         if (installed) return
         installed = true
         val application = context.applicationContext ?: context
+        runCatching { discardOtherBuilds(application) }
         val previous = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
             runCatching { record(application, thread, throwable) }
@@ -88,6 +89,29 @@ object CrashRecorder {
 
     fun clear(context: Context) {
         runCatching { files(context).forEach { it.delete() } }
+    }
+
+    /**
+     * Drops the records that some other build of the manager wrote.
+     *
+     * A record outlives the build that made it — the directory is this process's cache, which an
+     * update does not clear — so the status card goes on showing a crash that the running build
+     * has already fixed, until somebody thinks to press clear. That is not a stale line on a
+     * screen. It is what a reporter copies into the issue to show the fix did not work: #799 was
+     * answered with five traces from the build before the one that fixed them.
+     *
+     * Only at [install], never at [record]: this is about what a *new* build inherits, and a crash
+     * loop within one build must keep every record it makes.
+     *
+     * A file whose second line cannot be read is kept. Losing a trace is the worse of the two
+     * failures, and a record this class cannot parse is exactly the one worth still having.
+     */
+    private fun discardOtherBuilds(context: Context) {
+        val current = BUILD
+        files(context).forEach { file ->
+            val theirs = runCatching { file.useLines { it.drop(1).firstOrNull() } }.getOrNull()
+            if (theirs != null && !theirs.startsWith(current)) runCatching { file.delete() }
+        }
     }
 
     /** Newest first, which is the order both the card and the clipboard want. */
@@ -124,10 +148,21 @@ object CrashRecorder {
         val parasitic = context.packageName == BuildConfig.INJECTED_PACKAGE_NAME
         val host = if (parasitic) "parasitic in ${context.packageName}" else "standalone"
         return "${TIMESTAMP.format(Date(at))}\n" +
-            "manager ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE}) " +
-            "${BuildConfig.VERSION_HASH} · $host · thread ${thread.name} · " +
+            "$BUILD · $host · thread ${thread.name} · " +
             "android ${android.os.Build.VERSION.RELEASE} (sdk ${android.os.Build.VERSION.SDK_INT})"
     }
+
+    /**
+     * How a record says which build wrote it, and so what [discardOtherBuilds] matches on.
+     *
+     * The whole line rather than the hash alone: a build from a dirty tree carries the hash of the
+     * commit it was built from, so two of them can share it while differing by everything that was
+     * uncommitted at the time.
+     */
+    private val BUILD: String
+        get() =
+            "manager ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE}) " +
+                BuildConfig.VERSION_HASH
 
     private const val SUFFIX = ".log"
 

--- a/manager/src/main/kotlin/org/matrix/vector/manager/di/ServiceLocator.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/di/ServiceLocator.kt
@@ -12,6 +12,10 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.SharingStarted
 import android.annotation.SuppressLint
 import android.content.Context
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.SingletonImageLoader
+import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -205,6 +209,21 @@ object ServiceLocator {
         // Before anything else that could fail. Nothing below is load-bearing for it, and a crash
         // during startup is exactly the one that is hardest to catch on a cable.
         CrashRecorder.install(appContext!!)
+
+        // Coil is configured by hand rather than through its manifest hooks, for the same reason
+        // OkHttp is: parasitically this app's manifest is never installed, so nothing that
+        // self-registers there ever runs. Here rather than in the activity because every entry
+        // point comes through `attach` — including the debug demo host, which never opens
+        // MainActivity and so had no image loader at all while this lived there.
+        //
+        // The factory is not called until the first image, so this costs nothing at startup and
+        // does not build the OkHttp client before something asks for it.
+        SingletonImageLoader.setSafe { platformContext: PlatformContext ->
+            ImageLoader.Builder(platformContext)
+                .components { add(OkHttpNetworkFetcherFactory(callFactory = { http })) }
+                .build()
+        }
+
         observePackageChanges()
     }
 

--- a/manager/src/main/kotlin/org/matrix/vector/manager/di/ServiceLocator.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/di/ServiceLocator.kt
@@ -36,6 +36,7 @@ import org.matrix.vector.manager.data.repository.SettingsRepository
 import org.matrix.vector.manager.ipc.DaemonClient
 import org.matrix.vector.manager.ipc.packageEventsFlow
 import org.matrix.vector.manager.net.HttpClientFactory
+import org.matrix.vector.manager.net.VectorDns
 
 /**
  * Hand-rolled service location, deliberately not a DI framework.
@@ -77,7 +78,16 @@ object ServiceLocator {
 
     val daemon: DaemonClient by lazy { DaemonClient(service) }
 
-    val http: OkHttpClient by lazy { HttpClientFactory.create(context, settings) }
+    private val net: HttpClientFactory.NetStack by lazy {
+        HttpClientFactory.create(context, settings)
+    }
+
+    val http: OkHttpClient
+        get() = net.client
+
+    /** The resolver inside [http], so the settings sheet can report what DoH is actually doing. */
+    val dns: VectorDns
+        get() = net.dns
 
     val settings: SettingsRepository by lazy { SettingsRepository(context) }
 

--- a/manager/src/main/kotlin/org/matrix/vector/manager/net/HttpClientFactory.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/net/HttpClientFactory.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import java.io.File
 import java.util.concurrent.TimeUnit
 import okhttp3.Cache
+import okhttp3.OkHttp
 import okhttp3.OkHttpClient
 import org.matrix.vector.manager.data.repository.SettingsRepository
 
@@ -26,6 +27,20 @@ object HttpClientFactory {
     private const val CACHE_SIZE_BYTES = 16L * 1024 * 1024
 
     fun create(context: Context, settings: SettingsRepository): OkHttpClient {
+        // OkHttp's Android artifact ships the public suffix list as an *asset* and reaches it
+        // through a process-static Context that `PlatformInitializer` sets from `androidx.startup`.
+        // Parasitically this app's manifest is never installed, so that provider never runs and the
+        // first DoH lookup — which asks the list whether a host is private before opening any
+        // socket — dies with "Unable to load PublicSuffixDatabase.list". OkHttp latches that
+        // failure for the life of the process, so it has to be prevented rather than recovered
+        // from.
+        //
+        // Here rather than in the activity because this is the only place a client is built, which
+        // puts it on the path to every request in both parasitic and standalone runs and in the
+        // debug demo host, which never opens MainActivity. Idempotent, so it is a no-op in the
+        // standalone install, where the Startup initializer did run.
+        OkHttp.initialize(context)
+
         val cache = Cache(File(context.cacheDir, CACHE_DIR), CACHE_SIZE_BYTES)
 
         val base =

--- a/manager/src/main/kotlin/org/matrix/vector/manager/net/HttpClientFactory.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/net/HttpClientFactory.kt
@@ -26,7 +26,16 @@ object HttpClientFactory {
     private const val CACHE_DIR = "http_cache"
     private const val CACHE_SIZE_BYTES = 16L * 1024 * 1024
 
-    fun create(context: Context, settings: SettingsRepository): OkHttpClient {
+    /**
+     * The client and the resolver inside it.
+     *
+     * The resolver comes back alongside rather than being fished out of `client.dns` later: it is
+     * the only thing that knows whether DoH is actually working, the settings sheet reports that,
+     * and a cast back from the `Dns` interface would be a promise that nothing checks.
+     */
+    class NetStack(val client: OkHttpClient, val dns: VectorDns)
+
+    fun create(context: Context, settings: SettingsRepository): NetStack {
         // OkHttp's Android artifact ships the public suffix list as an *asset* and reaches it
         // through a process-static Context that `PlatformInitializer` sets from `androidx.startup`.
         // Parasitically this app's manifest is never installed, so that provider never runs and the
@@ -55,6 +64,7 @@ object HttpClientFactory {
         // and the shared client — with its connection pool and its disk cache — is never rebuilt.
         // `base` is passed in as the bootstrap client because a DoH client must not itself resolve
         // through DoH.
-        return base.newBuilder().dns(VectorDns(settings, base)).build()
+        val dns = VectorDns(settings, base)
+        return NetStack(base.newBuilder().dns(dns).build(), dns)
     }
 }

--- a/manager/src/main/kotlin/org/matrix/vector/manager/net/VectorDns.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/net/VectorDns.kt
@@ -6,11 +6,46 @@ import java.net.InetAddress
 import java.net.Proxy
 import java.net.ProxySelector
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import okhttp3.Dns
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.dnsoverhttps.DnsOverHttps
 import org.matrix.vector.manager.data.repository.SettingsRepository
+
+/**
+ * What the last name lookup of this session actually did.
+ *
+ * Deliberately a record of the real resolver rather than something a probe could produce. A "test
+ * DoH" button would be a second code path — another host, another moment — and it can pass while
+ * the client that fetches the module list is failing. Only the shared resolver knows the truth, so
+ * only the shared resolver reports it.
+ */
+sealed interface DohStatus {
+    /** Nothing has been resolved yet, so there is nothing to report. */
+    data object Untested : DohStatus
+
+    /** The setting is off; names went to the system resolver. */
+    data object Disabled : DohStatus
+
+    /** A proxy is configured, so resolving is its job and DoH was skipped. */
+    data object Bypassed : DohStatus
+
+    /** The last lookup went through the DoH endpoint. */
+    data class Working(val host: String) : DohStatus
+
+    /**
+     * DoH failed and the session has fallen back to the system resolver.
+     *
+     * No hostname here on purpose. What failed is reaching the DoH endpoint; whichever name was
+     * being looked up at that moment is incidental — it is simply whatever the app asked for first
+     * — and naming it reads as though that host were the subject of a test. The log line keeps it
+     * for anyone diagnosing; the sheet does not need it.
+     */
+    data class FellBack(val reason: String) : DohStatus
+}
 
 /**
  * Name resolution: DNS over HTTPS when it helps, the system resolver when it does not.
@@ -26,14 +61,23 @@ import org.matrix.vector.manager.data.repository.SettingsRepository
  * - a configured HTTP proxy disables DoH entirely, because the proxy is doing the resolving and
  *   bootstrap IPs are meaningless to it.
  *
- * The setting is read **per lookup** rather than baked into the client at construction. OkHttp
- * cannot have its DNS swapped on a live client, and rebuilding the shared client would drop the
- * connection pool and orphan the disk cache, so reading it here is what lets the switch take effect
- * before the next process start.
+ * Every one of those branches used to be invisible: off, bypassed and latched all looked like the
+ * same working switch, and the fallback existed only as a log line. [status] is what each lookup
+ * did, so the sheet that owns the switch can say which of them is happening.
+ *
+ * The setting and the proxy are both read **per lookup** rather than baked into the client at
+ * construction. OkHttp cannot have its DNS swapped on a live client, and rebuilding the shared
+ * client would drop the connection pool and orphan the disk cache, so reading them here is what
+ * lets a switch — or joining a VPN — take effect before the next process start.
  */
 class VectorDns(private val settings: SettingsRepository, bootstrapClient: OkHttpClient) : Dns {
 
     private val endpoint = "https://cloudflare-dns.com/dns-query".toHttpUrl()
+
+    private val _status = MutableStateFlow<DohStatus>(DohStatus.Untested)
+
+    /** What the last lookup did. See [DohStatus] for why this is observed and never probed. */
+    val status: StateFlow<DohStatus> = _status.asStateFlow()
 
     /**
      * Latched once the DoH endpoint proves unreachable.
@@ -65,18 +109,43 @@ class VectorDns(private val settings: SettingsRepository, bootstrapClient: OkHtt
             .build()
     }
 
-    /** True when nothing is proxying our traffic, which is the only case where DoH is ours to do. */
-    private val direct: Boolean by lazy {
+    /**
+     * True when nothing is proxying our traffic, which is the only case where DoH is ours to do.
+     *
+     * Asked on every lookup rather than cached. A proxy can appear mid-session — joining a VPN or a
+     * work profile does exactly that — and a value read once at startup would keep sending queries
+     * to Cloudflare long after the answer changed, while [status] claimed a state that was no
+     * longer true. The call is local and a lookup is about to do network I/O anyway.
+     */
+    private fun direct(): Boolean =
         runCatching {
                 ProxySelector.getDefault().select(endpoint.toUri()).firstOrNull() == Proxy.NO_PROXY
             }
             .getOrDefault(true)
+
+    /**
+     * Clears the session latch so the next lookup tries DoH again.
+     *
+     * The latch is what keeps a blocked endpoint from costing five seconds per name, but "the
+     * session" here is `com.android.shell`, a process nobody can restart on purpose — so without
+     * this a single bad lookup on a captive portal disables DoH until something else happens to
+     * kill the host. This is the way back, and it is offered only once the fallback has happened.
+     */
+    fun retry() {
+        dohUnavailable = false
+        _status.value = DohStatus.Untested
     }
 
     override fun lookup(hostname: String): List<InetAddress> {
-        if (settings.dohEnabled.value && direct && !dohUnavailable) {
+        if (!settings.dohEnabled.value) {
+            _status.value = DohStatus.Disabled
+        } else if (!direct()) {
+            _status.value = DohStatus.Bypassed
+        } else if (!dohUnavailable) {
             try {
-                return doh.lookup(hostname)
+                val resolved = doh.lookup(hostname)
+                _status.value = DohStatus.Working(hostname)
+                return resolved
             } catch (e: Exception) {
                 // Every way DoH can fail, not only "no such host". A blocked endpoint raises
                 // UnknownHostException, a slow one raises InterruptedIOException from the timeouts
@@ -90,6 +159,7 @@ class VectorDns(private val settings: SettingsRepository, bootstrapClient: OkHtt
                 // no CancellationException to preserve either — this is a plain blocking call on an
                 // OkHttp dispatcher thread, with no coroutine in the stack.
                 dohUnavailable = true
+                _status.value = DohStatus.FellBack(e.describe(hostname))
                 Log.w(
                     Constants.TAG,
                     "dns: DoH lookup of $hostname failed, using the system resolver for this session",
@@ -97,7 +167,21 @@ class VectorDns(private val settings: SettingsRepository, bootstrapClient: OkHtt
                 )
             }
         }
+        // Latched: the status already says why, and repeating it on every name would only replace
+        // the host that actually failed with whichever one asked next.
         return Dns.SYSTEM.lookup(hostname)
     }
 
+    /**
+     * A line short enough to sit under a switch, and worth the room it takes.
+     *
+     * The class name whenever the message would not add anything. `UnknownHostException` carries
+     * the hostname as its entire message, so using it verbatim printed the name twice — "could not
+     * resolve example.org (example.org)" — while the one thing a reader wants, *which way* it
+     * failed, went missing. The class name is jargon, but it is jargon that distinguishes a blocked
+     * endpoint from a timeout, and it is what a bug report needs to carry anyway.
+     */
+    private fun Throwable.describe(host: String): String =
+        message?.takeIf { it.isNotBlank() && !it.equals(host, ignoreCase = true) }
+            ?: javaClass.simpleName
 }

--- a/manager/src/main/kotlin/org/matrix/vector/manager/net/VectorDns.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/net/VectorDns.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import java.net.InetAddress
 import java.net.Proxy
 import java.net.ProxySelector
-import java.net.UnknownHostException
 import java.util.concurrent.TimeUnit
 import okhttp3.Dns
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -78,7 +77,18 @@ class VectorDns(private val settings: SettingsRepository, bootstrapClient: OkHtt
         if (settings.dohEnabled.value && direct && !dohUnavailable) {
             try {
                 return doh.lookup(hostname)
-            } catch (e: UnknownHostException) {
+            } catch (e: Exception) {
+                // Every way DoH can fail, not only "no such host". A blocked endpoint raises
+                // UnknownHostException, a slow one raises InterruptedIOException from the timeouts
+                // above, and a resolver that cannot read its own public suffix list raises
+                // IllegalStateException before a socket is ever opened — which used to escape this
+                // method entirely, so the latch never closed and the fallback this class is built
+                // around never engaged. Anything arriving here means DoH is not usable, which is
+                // the condition documented above.
+                //
+                // Exception and not Throwable: an OutOfMemoryError is not a DNS outcome. There is
+                // no CancellationException to preserve either — this is a plain blocking call on an
+                // OkHttp dispatcher thread, with no coroutine in the stack.
                 dohUnavailable = true
                 Log.w(
                     Constants.TAG,

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/MainActivity.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/MainActivity.kt
@@ -5,10 +5,6 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import coil3.ImageLoader
-import coil3.PlatformContext
-import coil3.SingletonImageLoader
-import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import org.matrix.vector.manager.di.ServiceLocator
 import org.matrix.vector.manager.ui.screens.splash.SplashGate
 import org.matrix.vector.manager.ui.theme.LocalizedContent
@@ -33,18 +29,9 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         // Idempotent, and safe whether or not the daemon already called Constants.setBinder.
+        // Configures Coil, among the rest: it used to be done here, which left the debug demo host
+        // without it.
         ServiceLocator.attach(this)
-
-        // Coil is configured explicitly rather than through its manifest hooks: parasitically this
-        // app's manifest is never installed, so nothing that self-registers there ever runs.
-        // It shares the one OkHttp client, which carries the DoH configuration and the disk cache.
-        SingletonImageLoader.setSafe { platformContext: PlatformContext ->
-            ImageLoader.Builder(platformContext)
-                .components {
-                    add(OkHttpNetworkFetcherFactory(callFactory = { ServiceLocator.http }))
-                }
-                .build()
-        }
 
         // Started here rather than from the panels that need it: the splash is dead time the app
         // is spending anyway, and these reads are what makes a panel's first visit slower than its

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/components/SheetParts.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/components/SheetParts.kt
@@ -3,6 +3,7 @@ package org.matrix.vector.manager.ui.components
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -16,6 +17,7 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -104,6 +106,44 @@ fun ToggleRow(
         leadingContent = { Icon(icon, contentDescription = null) },
         trailingContent = { Switch(checked = checked, onCheckedChange = null) },
     )
+}
+
+/**
+ * What the setting above is currently doing, and — when it is not working — the way back.
+ *
+ * Indented to the same column as a [ToggleRow]'s subtitle rather than given a row of its own,
+ * because it is not another setting: it belongs to the switch above it and has to read as a
+ * consequence of that switch, not as a sibling of it.
+ *
+ * The action is optional and deliberately quiet. A row that always carries a button trains people
+ * to press it, and most of the states here are the ones where there is nothing to fix.
+ */
+@Composable
+fun StatusNote(
+    text: String,
+    modifier: Modifier = Modifier,
+    tone: Color? = null,
+    actionLabel: String? = null,
+    onAction: (() -> Unit)? = null,
+) {
+    Row(
+        modifier =
+            modifier.fillMaxWidth().padding(start = 72.dp, end = 24.dp, top = 2.dp, bottom = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodySmall,
+            color = tone ?: MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f),
+        )
+        if (actionLabel != null && onAction != null) {
+            Spacer(Modifier.width(8.dp))
+            TextButton(onClick = onAction, contentPadding = PaddingValues(horizontal = 12.dp)) {
+                Text(actionLabel, style = MaterialTheme.typography.labelLarge)
+            }
+        }
+    }
 }
 
 /**

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/home/HomeAppearanceSheet.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/home/HomeAppearanceSheet.kt
@@ -68,7 +68,9 @@ import org.matrix.vector.manager.ui.theme.LocalizedOverlay
 import org.matrix.vector.manager.R
 import org.matrix.vector.manager.ui.components.ChoiceRow
 import org.matrix.vector.manager.ui.components.SheetHeading
+import org.matrix.vector.manager.ui.components.StatusNote
 import org.matrix.vector.manager.ui.components.ToggleRow
+import org.matrix.vector.manager.net.DohStatus
 import org.matrix.vector.manager.di.ServiceLocator
 import org.matrix.vector.manager.ui.components.ColorWheel
 import org.matrix.vector.manager.ui.components.ambience.AmbienceKind
@@ -107,6 +109,7 @@ fun HomeAppearanceSheet(onDismiss: () -> Unit) {
     val windowMonths by settings.activityWindowMonths.collectAsStateWithLifecycle()
     val openExternally by settings.openLinksExternally.collectAsStateWithLifecycle()
     val doh by settings.dohEnabled.collectAsStateWithLifecycle()
+    val dohStatus by ServiceLocator.dns.status.collectAsStateWithLifecycle()
 
     // The default state, deliberately. `skipPartiallyExpanded` removes the half-height stop, which
     // is the only thing a drag on a sheet can *do* other than dismiss it, so a sheet taller than
@@ -209,6 +212,44 @@ LocalizedOverlay {
                 checked = doh,
                 onCheckedChange = settings::setDohEnabled,
             )
+            // The switch says what was asked for; this says what happened. They come apart more
+            // often than the switch admits — a proxy takes the decision away entirely, and one
+            // unreachable lookup latches the fallback for the rest of the session — and until now
+            // all three cases looked identical from here.
+            //
+            // Only while the switch is on. Off, the switch has already said so, and a second line
+            // repeating it would be the one piece of this that carries no information.
+            if (doh) {
+                when (val state = dohStatus) {
+                    is DohStatus.Untested ->
+                        StatusNote(stringResource(R.string.settings_doh_untested))
+
+                    is DohStatus.Bypassed ->
+                        StatusNote(stringResource(R.string.settings_doh_bypassed))
+
+                    is DohStatus.Working ->
+                        StatusNote(
+                            stringResource(R.string.settings_doh_working, state.host),
+                            tone = MaterialTheme.colorScheme.primary,
+                        )
+
+                    // The one state with something to offer. Not an error colour: falling back is
+                    // the designed behaviour and the app is working, so this is the shade the rest
+                    // of the app uses for "worth knowing", not for "something is broken".
+                    is DohStatus.FellBack ->
+                        StatusNote(
+                            stringResource(R.string.settings_doh_fell_back, state.reason),
+                            tone = MaterialTheme.colorScheme.tertiary,
+                            actionLabel = stringResource(R.string.settings_doh_retry),
+                            onAction = ServiceLocator.dns::retry,
+                        )
+
+                    // Reachable only in the gap between flipping the switch on and the next lookup
+                    // recording something newer.
+                    is DohStatus.Disabled ->
+                        StatusNote(stringResource(R.string.settings_doh_untested))
+                }
+            }
 
             ToggleRow(
                 title = stringResource(R.string.settings_open_externally),

--- a/manager/src/main/res/values-ar/strings.xml
+++ b/manager/src/main/res/values-ar/strings.xml
@@ -440,4 +440,9 @@
     <string name="settings_network">الشبكة</string>
     <string name="settings_doh">تحليل الأسماء عبر HTTPS</string>
     <string name="settings_doh_summary">يحلّل الأسماء عبر Cloudflare بدلاً من محلّل الشبكة. للشبكات التي تحجب الـ DNS أو تعبث به.</string>
+    <string name="settings_doh_untested">لم يُحلَّل أي اسم بعد.</string>
+    <string name="settings_doh_bypassed">غير مستخدَم: هناك وكيل مُهيَّأ، وهو الذي يحلّل الأسماء.</string>
+    <string name="settings_doh_working">يعمل — حُلّل %1$s عبر Cloudflare.</string>
+    <string name="settings_doh_fell_back">تعذّر الوصول إلى Cloudflare (%1$s)، لذا سيُستخدَم محلّل الشبكة لبقية هذه الجلسة.</string>
+    <string name="settings_doh_retry">إعادة المحاولة</string>
 </resources>

--- a/manager/src/main/res/values-de/strings.xml
+++ b/manager/src/main/res/values-de/strings.xml
@@ -396,4 +396,9 @@
     <string name="settings_network">Netzwerk</string>
     <string name="settings_doh">Namen über HTTPS auflösen</string>
     <string name="settings_doh_summary">Löst Namen über Cloudflare auf statt über den Resolver des Netzwerks. Für Netzwerke, die DNS blockieren oder verfälschen.</string>
+    <string name="settings_doh_untested">Bisher wurden keine Namen aufgelöst.</string>
+    <string name="settings_doh_bypassed">Nicht in Verwendung: Ein Proxy ist eingerichtet und übernimmt die Auflösung.</string>
+    <string name="settings_doh_working">Funktioniert — %1$s wurde über Cloudflare aufgelöst.</string>
+    <string name="settings_doh_fell_back">Cloudflare ist nicht erreichbar (%1$s); für den Rest dieser Sitzung wird der Resolver des Netzwerks verwendet.</string>
+    <string name="settings_doh_retry">Erneut versuchen</string>
 </resources>

--- a/manager/src/main/res/values-es/strings.xml
+++ b/manager/src/main/res/values-es/strings.xml
@@ -396,4 +396,9 @@
     <string name="settings_network">Red</string>
     <string name="settings_doh">Resolver nombres por HTTPS</string>
     <string name="settings_doh_summary">Resuelve los nombres a través de Cloudflare en lugar del resolutor de la red. Para redes que bloquean o manipulan el DNS.</string>
+    <string name="settings_doh_untested">Todavía no se ha resuelto ningún nombre.</string>
+    <string name="settings_doh_bypassed">Sin usar: hay un proxy configurado, así que es él quien resuelve los nombres.</string>
+    <string name="settings_doh_working">Funciona: %1$s se resolvió a través de Cloudflare.</string>
+    <string name="settings_doh_fell_back">No se pudo contactar con Cloudflare (%1$s), así que se usará el resolutor de la red durante el resto de esta sesión.</string>
+    <string name="settings_doh_retry">Reintentar</string>
 </resources>

--- a/manager/src/main/res/values-fa/strings.xml
+++ b/manager/src/main/res/values-fa/strings.xml
@@ -396,4 +396,9 @@
     <string name="settings_network">شبکه</string>
     <string name="settings_doh">تحلیل نام‌ها از راه HTTPS</string>
     <string name="settings_doh_summary">نام‌ها را به‌جای تحلیل‌گر شبکه از راه Cloudflare پیدا می‌کند. برای شبکه‌هایی که DNS را مسدود یا دستکاری می‌کنند.</string>
+    <string name="settings_doh_untested">هنوز هیچ نامی تحلیل نشده است.</string>
+    <string name="settings_doh_bypassed">استفاده نمی‌شود: یک پیشکار پیکربندی شده و نام‌ها را او تحلیل می‌کند.</string>
+    <string name="settings_doh_working">کار می‌کند — %1$s از راه Cloudflare تحلیل شد.</string>
+    <string name="settings_doh_fell_back">دسترسی به Cloudflare ممکن نشد (%1$s)، بنابراین تا پایان این نشست از تحلیل‌گر شبکه استفاده می‌شود.</string>
+    <string name="settings_doh_retry">تلاش دوباره</string>
 </resources>

--- a/manager/src/main/res/values-fr/strings.xml
+++ b/manager/src/main/res/values-fr/strings.xml
@@ -396,4 +396,9 @@
     <string name="settings_network">Réseau</string>
     <string name="settings_doh">Résoudre les noms via HTTPS</string>
     <string name="settings_doh_summary">Résout les noms via Cloudflare plutôt que par le résolveur du réseau. Pour les réseaux qui bloquent ou altèrent le DNS.</string>
+    <string name="settings_doh_untested">Aucun nom résolu pour l\'instant.</string>
+    <string name="settings_doh_bypassed">Inutilisé : un proxy est configuré, c\'est donc lui qui résout les noms.</string>
+    <string name="settings_doh_working">Fonctionne — %1$s a été résolu via Cloudflare.</string>
+    <string name="settings_doh_fell_back">Cloudflare est injoignable (%1$s) ; le résolveur du réseau est utilisé pour le reste de cette session.</string>
+    <string name="settings_doh_retry">Réessayer</string>
 </resources>

--- a/manager/src/main/res/values-in/strings.xml
+++ b/manager/src/main/res/values-in/strings.xml
@@ -389,4 +389,9 @@
     <string name="settings_network">Jaringan</string>
     <string name="settings_doh">Selesaikan nama lewat HTTPS</string>
     <string name="settings_doh_summary">Menyelesaikan nama lewat Cloudflare alih-alih resolver jaringan. Untuk jaringan yang memblokir atau mengubah DNS.</string>
+    <string name="settings_doh_untested">Belum ada nama yang diselesaikan.</string>
+    <string name="settings_doh_bypassed">Tidak dipakai: proxy telah dikonfigurasi, jadi proxy yang menyelesaikan nama.</string>
+    <string name="settings_doh_working">Berfungsi — %1$s diselesaikan lewat Cloudflare.</string>
+    <string name="settings_doh_fell_back">Cloudflare tidak dapat dihubungi (%1$s), jadi resolver jaringan dipakai untuk sisa sesi ini.</string>
+    <string name="settings_doh_retry">Coba lagi</string>
 </resources>

--- a/manager/src/main/res/values-it/strings.xml
+++ b/manager/src/main/res/values-it/strings.xml
@@ -396,4 +396,9 @@
     <string name="settings_network">Rete</string>
     <string name="settings_doh">Risolvere i nomi via HTTPS</string>
     <string name="settings_doh_summary">Risolve i nomi tramite Cloudflare invece che con il resolver della rete. Per reti che bloccano o alterano il DNS.</string>
+    <string name="settings_doh_untested">Nessun nome ancora risolto.</string>
+    <string name="settings_doh_bypassed">Non in uso: è configurato un proxy, quindi è lui a risolvere i nomi.</string>
+    <string name="settings_doh_working">Funziona — %1$s è stato risolto tramite Cloudflare.</string>
+    <string name="settings_doh_fell_back">Cloudflare non è raggiungibile (%1$s), quindi per il resto di questa sessione viene usato il resolver della rete.</string>
+    <string name="settings_doh_retry">Riprova</string>
 </resources>

--- a/manager/src/main/res/values-iw/strings.xml
+++ b/manager/src/main/res/values-iw/strings.xml
@@ -422,4 +422,9 @@
     <string name="settings_network">רשת</string>
     <string name="settings_doh">פענוח שמות דרך HTTPS</string>
     <string name="settings_doh_summary">מפענח שמות דרך Cloudflare במקום דרך המפענח של הרשת. לרשתות שחוסמות או משבשות DNS.</string>
+    <string name="settings_doh_untested">עדיין לא פוענח אף שם.</string>
+    <string name="settings_doh_bypassed">לא בשימוש: מוגדר פרוקסי, ולכן הוא מפענח את השמות.</string>
+    <string name="settings_doh_working">עובד — %1$s פוענח דרך Cloudflare.</string>
+    <string name="settings_doh_fell_back">לא ניתן היה להגיע ל-Cloudflare (%1$s), ולכן ייעשה שימוש במפענח של הרשת בהמשך ההפעלה הזו.</string>
+    <string name="settings_doh_retry">ניסיון נוסף</string>
 </resources>

--- a/manager/src/main/res/values-ja/strings.xml
+++ b/manager/src/main/res/values-ja/strings.xml
@@ -385,4 +385,9 @@
     <string name="settings_network">ネットワーク</string>
     <string name="settings_doh">名前を HTTPS で解決する</string>
     <string name="settings_doh_summary">名前をネットワークのリゾルバではなく Cloudflare 経由で解決します。DNS を遮断または改変するネットワーク向けです。</string>
+    <string name="settings_doh_untested">まだ名前を解決していません。</string>
+    <string name="settings_doh_bypassed">未使用: プロキシが設定されているため、名前解決はプロキシが行います。</string>
+    <string name="settings_doh_working">動作中 — %1$s を Cloudflare 経由で解決しました。</string>
+    <string name="settings_doh_fell_back">Cloudflare に接続できませんでした (%1$s)。このセッションの残りはネットワークのリゾルバを使用します。</string>
+    <string name="settings_doh_retry">再試行</string>
 </resources>

--- a/manager/src/main/res/values-ko/strings.xml
+++ b/manager/src/main/res/values-ko/strings.xml
@@ -385,4 +385,9 @@
     <string name="settings_network">네트워크</string>
     <string name="settings_doh">HTTPS로 이름 확인</string>
     <string name="settings_doh_summary">네트워크의 확인자 대신 Cloudflare를 통해 이름을 확인합니다. DNS를 차단하거나 변조하는 네트워크용입니다.</string>
+    <string name="settings_doh_untested">아직 확인한 이름이 없습니다.</string>
+    <string name="settings_doh_bypassed">사용 안 함: 프록시가 설정되어 있어 프록시가 이름을 확인합니다.</string>
+    <string name="settings_doh_working">작동 중 — %1$s을(를) Cloudflare로 확인했습니다.</string>
+    <string name="settings_doh_fell_back">Cloudflare에 연결할 수 없어(%1$s) 이 세션의 나머지 동안 네트워크의 확인자를 사용합니다.</string>
+    <string name="settings_doh_retry">다시 시도</string>
 </resources>

--- a/manager/src/main/res/values-pl/strings.xml
+++ b/manager/src/main/res/values-pl/strings.xml
@@ -418,4 +418,9 @@
     <string name="settings_network">Sieć</string>
     <string name="settings_doh">Rozwiązuj nazwy przez HTTPS</string>
     <string name="settings_doh_summary">Rozwiązuje nazwy przez Cloudflare zamiast przez resolver sieci. Dla sieci, które blokują lub zmieniają DNS.</string>
+    <string name="settings_doh_untested">Nie rozwiązano jeszcze żadnej nazwy.</string>
+    <string name="settings_doh_bypassed">Nieużywane: skonfigurowano proxy, więc to ono rozwiązuje nazwy.</string>
+    <string name="settings_doh_working">Działa — %1$s rozwiązano przez Cloudflare.</string>
+    <string name="settings_doh_fell_back">Nie udało się połączyć z Cloudflare (%1$s), więc przez resztę tej sesji używany jest resolver sieci.</string>
+    <string name="settings_doh_retry">Spróbuj ponownie</string>
 </resources>

--- a/manager/src/main/res/values-pt-rBR/strings.xml
+++ b/manager/src/main/res/values-pt-rBR/strings.xml
@@ -396,4 +396,9 @@
     <string name="settings_network">Rede</string>
     <string name="settings_doh">Resolver nomes por HTTPS</string>
     <string name="settings_doh_summary">Resolve nomes pela Cloudflare em vez do resolvedor da rede. Para redes que bloqueiam ou adulteram o DNS.</string>
+    <string name="settings_doh_untested">Nenhum nome resolvido ainda.</string>
+    <string name="settings_doh_bypassed">Sem uso: há um proxy configurado, então é ele que resolve os nomes.</string>
+    <string name="settings_doh_working">Funcionando — %1$s foi resolvido pela Cloudflare.</string>
+    <string name="settings_doh_fell_back">Não foi possível alcançar a Cloudflare (%1$s), então o resolvedor da rede será usado no resto desta sessão.</string>
+    <string name="settings_doh_retry">Tentar de novo</string>
 </resources>

--- a/manager/src/main/res/values-ru/strings.xml
+++ b/manager/src/main/res/values-ru/strings.xml
@@ -399,4 +399,9 @@
     <string name="settings_network">Сеть</string>
     <string name="settings_doh">Разрешать имена через HTTPS</string>
     <string name="settings_doh_summary">Разрешает имена через Cloudflare, а не через резолвер сети. Для сетей, которые блокируют или подменяют DNS.</string>
+    <string name="settings_doh_untested">Пока ни одно имя не разрешалось.</string>
+    <string name="settings_doh_bypassed">Не используется: настроен прокси, и разрешением имён занимается он.</string>
+    <string name="settings_doh_working">Работает — %1$s разрешено через Cloudflare.</string>
+    <string name="settings_doh_fell_back">Cloudflare недоступен (%1$s), поэтому до конца этого сеанса используется резолвер сети.</string>
+    <string name="settings_doh_retry">Повторить</string>
 </resources>

--- a/manager/src/main/res/values-tr/strings.xml
+++ b/manager/src/main/res/values-tr/strings.xml
@@ -396,4 +396,9 @@
     <string name="settings_network">Ağ</string>
     <string name="settings_doh">Adları HTTPS üzerinden çöz</string>
     <string name="settings_doh_summary">Adları ağın çözümleyicisi yerine Cloudflare üzerinden çözer. DNS\'i engelleyen veya kurcalayan ağlar için.</string>
+    <string name="settings_doh_untested">Henüz hiçbir ad çözümlenmedi.</string>
+    <string name="settings_doh_bypassed">Kullanılmıyor: bir proxy yapılandırılmış, adları o çözümlüyor.</string>
+    <string name="settings_doh_working">Çalışıyor — %1$s Cloudflare üzerinden çözümlendi.</string>
+    <string name="settings_doh_fell_back">Cloudflare\'a ulaşılamadı (%1$s), bu oturumun kalanında ağın çözümleyicisi kullanılacak.</string>
+    <string name="settings_doh_retry">Yeniden dene</string>
 </resources>

--- a/manager/src/main/res/values-uk/strings.xml
+++ b/manager/src/main/res/values-uk/strings.xml
@@ -418,4 +418,9 @@
     <string name="settings_network">Мережа</string>
     <string name="settings_doh">Розвʼязувати імена через HTTPS</string>
     <string name="settings_doh_summary">Розвʼязує імена через Cloudflare, а не через резолвер мережі. Для мереж, які блокують або підміняють DNS.</string>
+    <string name="settings_doh_untested">Поки жодне імʼя не розвʼязувалося.</string>
+    <string name="settings_doh_bypassed">Не використовується: налаштовано проксі, і розвʼязуванням імен займається він.</string>
+    <string name="settings_doh_working">Працює — %1$s розвʼязано через Cloudflare.</string>
+    <string name="settings_doh_fell_back">Cloudflare недоступний (%1$s), тому до кінця цього сеансу використовується резолвер мережі.</string>
+    <string name="settings_doh_retry">Повторити</string>
 </resources>

--- a/manager/src/main/res/values-vi/strings.xml
+++ b/manager/src/main/res/values-vi/strings.xml
@@ -385,4 +385,9 @@
     <string name="settings_network">Mạng</string>
     <string name="settings_doh">Phân giải tên qua HTTPS</string>
     <string name="settings_doh_summary">Phân giải tên qua Cloudflare thay vì trình phân giải của mạng. Dành cho mạng chặn hoặc can thiệp DNS.</string>
+    <string name="settings_doh_untested">Chưa phân giải tên nào.</string>
+    <string name="settings_doh_bypassed">Không dùng: đã cấu hình proxy nên proxy đang phân giải tên.</string>
+    <string name="settings_doh_working">Đang hoạt động — %1$s được phân giải qua Cloudflare.</string>
+    <string name="settings_doh_fell_back">Không kết nối được tới Cloudflare (%1$s), nên trình phân giải của mạng sẽ được dùng trong phần còn lại của phiên này.</string>
+    <string name="settings_doh_retry">Thử lại</string>
 </resources>

--- a/manager/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/src/main/res/values-zh-rCN/strings.xml
@@ -386,4 +386,9 @@
     <string name="settings_network">网络</string>
     <string name="settings_doh">通过 HTTPS 解析域名</string>
     <string name="settings_doh_summary">通过 Cloudflare 而非网络自带的解析器查询域名。适用于屏蔽或篡改 DNS 的网络。</string>
+    <string name="settings_doh_untested">尚未解析任何域名。</string>
+    <string name="settings_doh_bypassed">未使用：已配置代理，域名由代理解析。</string>
+    <string name="settings_doh_working">正常 — 已通过 Cloudflare 解析 %1$s。</string>
+    <string name="settings_doh_fell_back">无法连接 Cloudflare（%1$s），本次会话的剩余时间将使用网络自带的解析器。</string>
+    <string name="settings_doh_retry">重试</string>
 </resources>

--- a/manager/src/main/res/values-zh-rTW/strings.xml
+++ b/manager/src/main/res/values-zh-rTW/strings.xml
@@ -386,4 +386,9 @@
     <string name="settings_network">網路</string>
     <string name="settings_doh">透過 HTTPS 解析網域</string>
     <string name="settings_doh_summary">透過 Cloudflare 而非網路自帶的解析器查詢網域。適用於封鎖或竄改 DNS 的網路。</string>
+    <string name="settings_doh_untested">尚未解析任何網域。</string>
+    <string name="settings_doh_bypassed">未使用：已設定 Proxy，網域由 Proxy 解析。</string>
+    <string name="settings_doh_working">正常 — 已透過 Cloudflare 解析 %1$s。</string>
+    <string name="settings_doh_fell_back">無法連線至 Cloudflare（%1$s），本次工作階段的其餘時間將使用網路自帶的解析器。</string>
+    <string name="settings_doh_retry">重試</string>
 </resources>

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -430,4 +430,9 @@
     <string name="settings_network">Network</string>
     <string name="settings_doh">Resolve names over HTTPS</string>
     <string name="settings_doh_summary">Looks names up through Cloudflare instead of the network\'s resolver. For networks that block or tamper with DNS.</string>
+    <string name="settings_doh_untested">No names looked up yet.</string>
+    <string name="settings_doh_bypassed">Not in use: a proxy is configured, so it is resolving names.</string>
+    <string name="settings_doh_working">Working — %1$s was resolved through Cloudflare.</string>
+    <string name="settings_doh_fell_back">Cloudflare could not be reached (%1$s), so the network\'s resolver is being used for the rest of this session.</string>
+    <string name="settings_doh_retry">Try again</string>
 </resources>


### PR DESCRIPTION
OkHttp 5 ships its public suffix list as an asset and takes the `Context` needed to read it from an `androidx.startup` provider. The manager's manifest is never installed parasitically, so that provider never runs, and the first DNS lookup threw before opening a socket. `HttpClientFactory` now initialises OkHttp explicitly, as Coil already was. This is why installing the APK appeared to work around it: for a normal install the provider does run.

Two further defects turned that into a crash rather than a degraded Store, both fixed here:

- `VectorDns` caught only `UnknownHostException`, so its documented fallback to the system resolver never engaged.
- `frameworkReleases` and `canaryBuilds` called the network unguarded on `viewModelScope`.

Also in this branch:

- Moves Coil's own initialisation from `MainActivity` to `ServiceLocator.attach`, for the same reason OkHttp's lives where the client is built: the debug demo host never opens `MainActivity`, so it had no image loader at all.
- Discards crash records left by a different build. A record outlives the build that wrote it, so after an update the status card still shows the crash that was just fixed — which is what #799 was answered with: five traces from the build before the one that fixed them.
- Adds a status line under the DNS-over-HTTPS switch reporting what the resolver last did, with a retry when it has fallen back. The new strings need a Crowdin pass.

The GitHub sign-in removal that was on this branch earlier has been dropped from it, to keep this to the crash and what it turned up. It can come back on its own.

Verified on a Pixel 6: launch from the module action, forced fallback with the radios off, recovery without restarting the process, and a planted crash record from an older build discarded at the next launch while the current build's own record was kept.

Fixes #799.
