### PR TITLE
Let the parasitic manager load its DEX on GrapheneOS

### DIFF
--- a/zygisk/src/main/kotlin/org/matrix/vector/GrapheneDclHooker.kt
+++ b/zygisk/src/main/kotlin/org/matrix/vector/GrapheneDclHooker.kt
@@ -1,57 +1,75 @@
 package org.matrix.vector
 
 import android.content.pm.ApplicationInfo
-import de.robv.android.xposed.XC_MethodReplacement
+import de.robv.android.xposed.XC_MethodHook
 import de.robv.android.xposed.XposedBridge
 import de.robv.android.xposed.XposedHelpers
 import org.lsposed.lspd.util.Utils
 
 /**
  * Exempts the parasitic manager's host package from GrapheneOS's "Restrict dynamic code loading"
- * (memory DCL) exploit protection.
+ * exploit protections.
  *
- * The setting is immutable and enabled for system apps. As the manager runs inside
- * [BuildConfig.InjectedPackageName] (`com.android.shell`, a system app), it cannot load its DEX
- * and fails to start. The hook forces the restriction to "allowed" for that package alone; every
- * other app retains GrapheneOS's verdict. It applies only on GrapheneOS, where the target class
- * exists, and only in system_server, where the value is resolved.
+ * GrapheneOS splits DCL into three settings — memory, storage and WebView — and enforces each one
+ * through *two* independent channels, both fed by the same `AswRestrict*DynCodeLoading` verdict:
+ *
+ *  1. **ART DexFile checks.** `DynCodeLoading.getAppBindFlags` reads the three settings, ships the
+ *     bitmask to the app and arms `DexFile.enableDynCodeLoadingChecks`, which rejects the manager's
+ *     transplanted `/proc/self/fd/N` DEX with a "DCL via storage" `SecurityException`.
+ *  2. **Kernel `grapheneos_flags`.** `SELinuxFlags.get` turns the same settings into the
+ *     `DENY_EXECMEM`/`DENY_EXECMOD`/… task flags, written to `/proc/self/attr/grapheneos_flags`
+ *     during zygote specialization (writable only from the zygote context, so it cannot be undone
+ *     later). With `DENY_EXECMEM` set, LSPlant/Dobby cannot allocate executable memory for its
+ *     inline hook and the process aborts with `SIGSEGV` / `TSEC_FLAG_DENY_EXECMEM: op denied`.
+ *
+ * As the manager runs inside [BuildConfig.InjectedPackageName] (`com.android.shell`, a system app)
+ * these verdicts are immutable and enabled. Clearing only channel 1 (e.g. zeroing `getAppBindFlags`)
+ * lets the DEX load but leaves `DENY_EXECMEM` armed, so hooking still crashes.
+ *
+ * Both channels call `AswRestrict*DynCodeLoading.I.get()`, which returns the immutable verdict when
+ * `getImmutableValue` is non-null. Forcing that method to `false` for the manager host alone marks
+ * DCL as allowed at the source, clearing both channels at once. Every other app keeps GrapheneOS's
+ * verdict. It applies only on GrapheneOS, where these classes exist, and only in system_server,
+ * where the settings are resolved before the process is specialized.
  */
 object GrapheneDclHooker {
 
-    private const val ASW_CLASS = "android.ext.settings.app.AswRestrictMemoryDynCodeLoading"
+    private val ASW_DCL_CLASSES =
+        arrayOf(
+            "android.ext.settings.app.AswRestrictMemoryDynCodeLoading",
+            "android.ext.settings.app.AswRestrictStorageDynCodeLoading",
+            "android.ext.settings.app.AswRestrictWebViewDynCodeLoading",
+        )
 
     @JvmStatic
     fun start() {
-        val aswClass =
-            try {
-                XposedHelpers.findClass(ASW_CLASS, this.javaClass.classLoader)
-            } catch (_: XposedHelpers.ClassNotFoundError) {
-                return // Not GrapheneOS.
+        // Boolean getImmutableValue(Context, int userId, ApplicationInfo, GosPackageState, StateInfo)
+        // returns true (immutable, restricted) for every system app. Returning false instead marks
+        // DCL as allowed for the manager host, so neither the DexFile checks nor the kernel
+        // execmem/execmod flags derived from the same verdict are armed.
+        val exempt =
+            object : XC_MethodHook() {
+                override fun afterHookedMethod(param: MethodHookParam<*>) {
+                    val appInfo = param.args.getOrNull(2) as? ApplicationInfo
+                    if (appInfo?.packageName == BuildConfig.InjectedPackageName) {
+                        param.result = false
+                    }
+                }
             }
 
-        try {
-            // Boolean getImmutableValue(Context, int, ApplicationInfo, GosPackageState, StateInfo)
-            // returns true (restricted), false (allowed), or null (user-configurable). A non-null
-            // result overrides the user toggle and the default, so false forces DCL to be allowed.
-            XposedBridge.hookAllMethods(
-                aswClass,
-                "getImmutableValue",
-                object : XC_MethodReplacement() {
-                    override fun replaceHookedMethod(param: MethodHookParam<*>): Any? {
-                        val appInfo = param.args.getOrNull(2) as? ApplicationInfo
-                        if (appInfo?.packageName == BuildConfig.InjectedPackageName) {
-                            return false // Allow the manager host to load its DEX.
-                        }
-                        return XposedBridge.invokeOriginalMethod(
-                            param.method,
-                            param.thisObject,
-                            param.args,
-                        )
-                    }
-                },
-            )
-        } catch (e: Throwable) {
-            Utils.logE("Failed to patch GrapheneOS DCL restriction", e)
+        for (className in ASW_DCL_CLASSES) {
+            val aswClass =
+                try {
+                    XposedHelpers.findClass(className, this.javaClass.classLoader)
+                } catch (_: XposedHelpers.ClassNotFoundError) {
+                    return // Not GrapheneOS.
+                }
+
+            try {
+                XposedBridge.hookAllMethods(aswClass, "getImmutableValue", exempt)
+            } catch (e: Throwable) {
+                Utils.logE("Failed to patch GrapheneOS DCL restriction ($className)", e)
+            }
         }
     }
 }

--- a/zygisk/src/main/kotlin/org/matrix/vector/GrapheneDclHooker.kt
+++ b/zygisk/src/main/kotlin/org/matrix/vector/GrapheneDclHooker.kt
@@ -1,0 +1,57 @@
+package org.matrix.vector
+
+import android.content.pm.ApplicationInfo
+import de.robv.android.xposed.XC_MethodReplacement
+import de.robv.android.xposed.XposedBridge
+import de.robv.android.xposed.XposedHelpers
+import org.lsposed.lspd.util.Utils
+
+/**
+ * Exempts the parasitic manager's host package from GrapheneOS's "Restrict dynamic code loading"
+ * (memory DCL) exploit protection.
+ *
+ * The setting is immutable and enabled for system apps. As the manager runs inside
+ * [BuildConfig.InjectedPackageName] (`com.android.shell`, a system app), it cannot load its DEX
+ * and fails to start. The hook forces the restriction to "allowed" for that package alone; every
+ * other app retains GrapheneOS's verdict. It applies only on GrapheneOS, where the target class
+ * exists, and only in system_server, where the value is resolved.
+ */
+object GrapheneDclHooker {
+
+    private const val ASW_CLASS = "android.ext.settings.app.AswRestrictMemoryDynCodeLoading"
+
+    @JvmStatic
+    fun start() {
+        val aswClass =
+            try {
+                XposedHelpers.findClass(ASW_CLASS, this.javaClass.classLoader)
+            } catch (_: XposedHelpers.ClassNotFoundError) {
+                return // Not GrapheneOS.
+            }
+
+        try {
+            // Boolean getImmutableValue(Context, int, ApplicationInfo, GosPackageState, StateInfo)
+            // returns true (restricted), false (allowed), or null (user-configurable). A non-null
+            // result overrides the user toggle and the default, so false forces DCL to be allowed.
+            XposedBridge.hookAllMethods(
+                aswClass,
+                "getImmutableValue",
+                object : XC_MethodReplacement() {
+                    override fun replaceHookedMethod(param: MethodHookParam<*>): Any? {
+                        val appInfo = param.args.getOrNull(2) as? ApplicationInfo
+                        if (appInfo?.packageName == BuildConfig.InjectedPackageName) {
+                            return false // Allow the manager host to load its DEX.
+                        }
+                        return XposedBridge.invokeOriginalMethod(
+                            param.method,
+                            param.thisObject,
+                            param.args,
+                        )
+                    }
+                },
+            )
+        } catch (e: Throwable) {
+            Utils.logE("Failed to patch GrapheneOS DCL restriction", e)
+        }
+    }
+}

--- a/zygisk/src/main/kotlin/org/matrix/vector/core/Main.kt
+++ b/zygisk/src/main/kotlin/org/matrix/vector/core/Main.kt
@@ -5,6 +5,7 @@ import android.os.Process
 import org.lsposed.lspd.service.ILSPApplicationService
 import org.lsposed.lspd.util.Utils
 import org.matrix.vector.BuildConfig
+import org.matrix.vector.GrapheneDclHooker
 import org.matrix.vector.ParasiticManagerHooker
 import org.matrix.vector.ParasiticManagerSystemHooker
 import org.matrix.vector.Startup
@@ -33,6 +34,8 @@ object Main {
         // Initialize system-specific resolution hooks if in system_server
         if (isSystem) {
             ParasiticManagerSystemHooker.start()
+            // Exempt the manager host from GrapheneOS DCL restriction; no-op on other systems.
+            GrapheneDclHooker.start()
         }
 
         // Initialize Xposed bridge components


### PR DESCRIPTION
On GrapheneOS, the "Restrict dynamic code loading" (memory DCL) exploit-protection setting is immutable and enabled for system apps. The parasitic manager runs inside `com.android.shell`, a system app, so the manager's DEX cannot be loaded and the manager fails to start.

This change hooks a single method in `system_server`, `AswRestrictMemoryDynCodeLoading.getImmutableValue`, and returns `false` for `com.android.shell`. All other apps retain GrapheneOS's original behaviour.

The choice of method and return value follows from the GrapheneOS source:

* [`AswRestrictMemoryDynCodeLoading.getImmutableValue`](https://github.com/GrapheneOS/platform_frameworks_base/blob/be845e834f3affd4cbf8ce89e2e023509c41220b/core/java/android/ext/settings/app/AswRestrictMemoryDynCodeLoading.java#L37-L58) determines the per-app verdict and returns `true` for non-allowlisted system apps, which is what blocks the shell.
* [`AppSwitch.get`](https://github.com/GrapheneOS/platform_frameworks_base/blob/918c027231ec6bb787c7ac9a0a459669b7a558a9/core/java/android/ext/settings/app/AppSwitch.java#L117-L124) is the value consumed by enforcement. A non-null result from `getImmutableValue` takes precedence over both the user toggle and the default, so returning `false` forces the setting to allowed regardless of the user's configuration. The three possible results are `false` (allowed), `true` (restricted), and `null` (user-configurable).

GrapheneOS is identified solely by the presence of the class. On any other ROM, `findClass` throws `ClassNotFoundError` and the hook does nothing.

The scope is intentionally narrow:

* Only `com.android.shell` is affected, and only in `system_server`, where the value is computed. No other app's verdict changes.
* No new build variable and no daemon change are required, as the host package is already exposed as `BuildConfig.InjectedPackageName`.
* Modules are excluded. On GrapheneOS a normal app already exposes a user-configurable DCL toggle, so a module can be permitted without a patch. Automatically allowing enabled scopes would require the scope list inside `system_server` and can be addressed separately.

This supersedes #711 with a smaller footprint and incorporates the review feedback there: the `GRAPHENE_SETTINGS_PACKAGE_NAME` build variable is dropped, and the hook resides in its own class. The technique was originally developed by @Enovale in #711 and in [discussion #340](https://github.com/JingMatrix/Vector/discussions/340).