### PR TITLE
Fix the CI artifacts, the update endpoint and the translations

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,11 +5,11 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for reporting issues of LSPosed!
+        Thanks for reporting issues of Vector!
 
         To make it easier for us to help you, please read all pinned issues and provide the following details.
 
-        感谢给 LSPosed 汇报问题！
+        感谢给 Vector 汇报问题！
         为了使我们更好地帮助你，请务必阅读所有已置顶的 Issues 并提供以下细节。
         为了防止重复汇报，标题请务必使用英文。
   - type: textarea
@@ -54,7 +54,7 @@ body:
       required: true
   - type: input
     attributes:
-      label: LSPosed version/LSPosed 版本
+      label: Vector version/Vector 版本
       description: Don't use 'latest'. Specify actual version with 4 digits, otherwise your issue will be closed./不要填用“最新版”。给出四位版本号，不然 issue 会被关闭。
     validations:
       required: true
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Version requirement/版本要求
       options:
-        - label: I am using the latest debug build from [GitHub Actions](https://github.com/JingMatrix/LSPosed/actions?query=branch%3Amaster)./我正在使用 [GitHub Actions](https://github.com/JingMatrix/LSPosed/actions?query=branch%3Amaster) 中最新的调试版本。
+        - label: I am using the latest debug build from [GitHub Actions](https://github.com/JingMatrix/Vector/actions?query=branch%3Amaster)./我正在使用 [GitHub Actions](https://github.com/JingMatrix/Vector/actions?query=branch%3Amaster) 中最新的调试版本。
           required: true
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question/提问
-    url: https://github.com/JingMatrix/LSPosed/discussions/new?category=Q-A
+    url: https://github.com/JingMatrix/Vector/discussions/new?category=Q-A
     about: Please ask and answer questions here./如果有任何疑问请在这里提问

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -126,19 +126,28 @@ jobs:
           name: ${{ steps.prepareArtifact.outputs.zygiskDebugName }}
           path: "./Vector-Debug/*"
 
+      # One entry per module that minifies. `app` was the old manager and has not existed since
+      # #796, so the manager's mapping — the one an obfuscated stack trace from a user actually
+      # needs — has been missing from every run since.
       - name: Upload mappings
         uses: actions/upload-artifact@v7
         with:
           name: mappings
           path: |
             zygisk/build/outputs/mapping
-            app/build/outputs/mapping
+            manager/build/outputs/mapping
+            daemon/build/outputs/mapping
 
+      # DEBUG_SYMBOLS_PATH is set from `layout.buildDirectory` inside the root `subprojects` block,
+      # so each module writes its own build/symbols and nothing ever lands in the root one.
       - name: Upload symbols
         uses: actions/upload-artifact@v7
         with:
           name: symbols
-          path: build/symbols
+          path: |
+            zygisk/build/symbols
+            daemon/build/symbols
+            dex2oat/build/symbols
 
       # --- canary distribution ---------------------------------------------------------------
       #

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -27,6 +27,15 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      # Before anything is built, because it needs nothing but Python and a translator's mistake
+      # should not wait twenty minutes to surface. Crowdin owns the content of these files, so what
+      # this catches is a bad merge or a line pasted into the wrong language -- both of which have
+      # happened, and neither of which any other check in this repository looks for.
+      - name: Check translations
+        run: |
+          python3 manager/tools/check_translations.py manager/src/main/res
+          python3 manager/tools/check_translations.py daemon/src/main/res
+
       # A missing secret used to be skipped over in silence, and the build carried on to publish a
       # canary or a tag signed with the debug key — which the daemon's InstallerVerifier rejects,
       # and which nobody notices until someone tries to install the manager. On this repository the

--- a/daemon/src/main/res/values-af/strings.xml
+++ b/daemon/src/main/res/values-af/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Xposed module is not activated yet</string>
+    <string name="module_is_not_activated_yet">Module is nog nie geaktiveer nie</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s is geïnstalleer, maar is nog nie geaktiveer nie</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s is vir gebruiker %2$s geïnstalleer, maar is nog nie geaktiveer nie</string>
     <string name="xposed_module_updated_notification_title">Module opgedateer</string>
     <string name="xposed_module_updated_notification_content">%s is opgedateer, forseer asseblief stop en herbegin programme binne die omvang daarvan</string>
-    <string name="xposed_module_updated_notification_title_system">Xposed-module is opgedateer, stelselherlaai vereis</string>
+    <string name="xposed_module_updated_notification_title_system">Module is opgedateer, stelselherlaai vereis</string>
     <string name="xposed_module_updated_notification_content_system">%s is opgedateer, aangesien die omvang System Framework bevat, vereis herlaai om veranderinge toe te pas</string>
     <string name="module_updated_channel_name">Module-opdatering voltooi</string>
     <string name="status_channel_name">Vector status</string>

--- a/daemon/src/main/res/values-af/strings.xml
+++ b/daemon/src/main/res/values-af/strings.xml
@@ -3,8 +3,8 @@
     <!-- Notification -->
     <string name="module_is_not_activated_yet">Xposed module is not activated yet</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s is geïnstalleer, maar is nog nie geaktiveer nie</string>
-    <string name="module_is_not_activated_yet_multi_user_detailed">%1$s 已為用戶 %2$s 安裝，但尚未激活</string>
-    <string name="xposed_module_updated_notification_title">%d module enabled</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%1$s is vir gebruiker %2$s geïnstalleer, maar is nog nie geaktiveer nie</string>
+    <string name="xposed_module_updated_notification_title">Module opgedateer</string>
     <string name="xposed_module_updated_notification_content">%s is opgedateer, forseer asseblief stop en herbegin programme binne die omvang daarvan</string>
     <string name="xposed_module_updated_notification_title_system">Xposed-module is opgedateer, stelselherlaai vereis</string>
     <string name="xposed_module_updated_notification_content_system">%s is opgedateer, aangesien die omvang System Framework bevat, vereis herlaai om veranderinge toe te pas</string>

--- a/daemon/src/main/res/values-ar/strings.xml
+++ b/daemon/src/main/res/values-ar/strings.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">وحدة Xposed لم يتم تفعيلها بعد</string>
+    <string name="module_is_not_activated_yet">الوحدة لم يتم تفعيلها بعد</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s تم التثبيت ولكنه لم يفعل بعد</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s تم تثبيته للمستخدم %2$s ولكن لم يتم تفعيله بعد</string>
-    <string name="xposed_module_updated_notification_title">وحدة Xposed تم تحديثها</string>
+    <string name="xposed_module_updated_notification_title">تم تحديث الوحدة</string>
     <string name="xposed_module_updated_notification_content">%s تم تحديثه، يرجى فرض إيقاف وإعادة تشغيل التطبيقات في نطاقه</string>
-    <string name="xposed_module_updated_notification_title_system">تم تحديث وحدة Xposed، مطلوب إعادة تشغيل النظام</string>
+    <string name="xposed_module_updated_notification_title_system">تم تحديث الوحدة، مطلوب إعادة تشغيل النظام</string>
     <string name="xposed_module_updated_notification_content_system">%s تم تحديثه، نظراً لأن النطاق يحتوي على إطار النظام، يتطلب إعادة التشغيل لتطبيق التغييرات</string>
     <string name="module_updated_channel_name">اكتمل تحديث الوحدة</string>
     <string name="status_channel_name">حالة Vector</string>
     <string name="vector_running_notification_title">تم تحميل Vector</string>
     <string name="vector_running_notification_content">اضغط على الإشعار لفتح المدير</string>
-    <string name="xposed_module_request_scope_title">Scope Request</string>
+    <string name="xposed_module_request_scope_title">طلب النطاق</string>
     <string name="xposed_module_request_scope_content">%1$s على %2$s طلبات المستخدم لإضافة %3$s إلى نطاقه.</string>
     <string name="scope_channel_name">طلب النطاق</string>
     <string name="scope_approve">اوافق</string>

--- a/daemon/src/main/res/values-bg/strings.xml
+++ b/daemon/src/main/res/values-bg/strings.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Модулът Xposed все още не е активиран</string>
+    <string name="module_is_not_activated_yet">Модулът все още не е активиран</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s е инсталиран, но все още не е активиран</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s е инсталиран на потребител %2$s, но все още не е активиран</string>
-    <string name="xposed_module_updated_notification_title">Актуализиран модул Xposed</string>
+    <string name="xposed_module_updated_notification_title">Актуализиран модул</string>
     <string name="xposed_module_updated_notification_content">%s е актуализиран, моля, спрете принудително и рестартирайте приложенията в неговия обхват</string>
-    <string name="xposed_module_updated_notification_title_system">Актуализиран модул Xposed, изисква се рестартиране на системата</string>
+    <string name="xposed_module_updated_notification_title_system">Актуализиран модул, изисква се рестартиране на системата</string>
     <string name="xposed_module_updated_notification_content_system">%s е актуализиран, тъй като обхватът съдържа System Framework, необходимо е рестартиране, за да се приложат промените</string>
     <string name="module_updated_channel_name">Актуализация на модула е завършена</string>
-    <string name="status_channel_name">Предложен статус на LSP</string>
+    <string name="status_channel_name">Статус на Vector</string>
     <string name="vector_running_notification_title">Vector заредени</string>
     <string name="vector_running_notification_content">Докоснете известието, за да отворите мениджъра</string>
     <string name="xposed_module_request_scope_title">Заявка за обхват</string>
     <string name="xposed_module_request_scope_content">%1$s при заявки от страна на потребителя %2$s за добавяне на %3$s към неговия обхват.</string>
     <string name="scope_channel_name">Искане за обхват</string>
-    <string name="scope_approve">Одобряване на</string>
+    <string name="scope_approve">Одобряване</string>
     <string name="scope_deny">Отказ</string>
     <string name="never_ask_again">Никога не питайте</string>
 </resources>

--- a/daemon/src/main/res/values-bn/strings.xml
+++ b/daemon/src/main/res/values-bn/strings.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Xposed মডিউল এখনও সক্রিয় করা হয় নি</string>
+    <string name="module_is_not_activated_yet">মডিউল এখনও সক্রিয় করা হয় নি</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s ইনস্টল করা হয়েছে, কিন্তু এখনও সক্রিয় করা হয়নি</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s ব্যবহারকারী %2$sএ ইনস্টল করা হয়েছে, কিন্তু এখনও সক্রিয় করা হয়নি</string>
-    <string name="xposed_module_updated_notification_title">এক্সপোজড মডিউল আপডেট করা হয়েছে</string>
+    <string name="xposed_module_updated_notification_title">মডিউল আপডেট করা হয়েছে</string>
     <string name="xposed_module_updated_notification_content">%s আপডেট করা হয়েছে, অনুগ্রহ করে এর সুযোগে অ্যাপগুলিকে জোর করে থামান এবং পুনরায় চালু করুন</string>
-    <string name="xposed_module_updated_notification_title_system">Xposed মডিউল আপডেট করা হয়েছে, সিস্টেম রিবুট প্রয়োজন</string>
+    <string name="xposed_module_updated_notification_title_system">মডিউল আপডেট করা হয়েছে, সিস্টেম রিবুট প্রয়োজন</string>
     <string name="xposed_module_updated_notification_content_system">%s আপডেট করা হয়েছে, যেহেতু সুযোগে সিস্টেম ফ্রেমওয়ার্ক রয়েছে, পরিবর্তনগুলি প্রয়োগ করার জন্য রিবুট প্রয়োজন</string>
     <string name="module_updated_channel_name">মডিউল আপডেট সম্পূর্ণ</string>
-    <string name="status_channel_name">LSPপোজড স্ট্যাটাস</string>
+    <string name="status_channel_name">Vector স্ট্যাটাস</string>
     <string name="vector_running_notification_title">Vector লোড</string>
     <string name="vector_running_notification_content">ম্যানেজার খুলতে বিজ্ঞপ্তিতে ট্যাপ করুন</string>
     <string name="xposed_module_request_scope_title">সুযোগ অনুরোধ</string>

--- a/daemon/src/main/res/values-ca/strings.xml
+++ b/daemon/src/main/res/values-ca/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">El mòdul Xposed encara no està activat</string>
+    <string name="module_is_not_activated_yet">El mòdul encara no està activat</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s s\'ha instal·lat, però encara no està activat</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s s\'ha instal·lat a l\'usuari %2$s, però encara no està activat</string>
-    <string name="xposed_module_updated_notification_title">Mòdul Xposed actualitzat</string>
+    <string name="xposed_module_updated_notification_title">Mòdul actualitzat</string>
     <string name="xposed_module_updated_notification_content">%s s\'ha actualitzat, si us plau, força l\'aturada i reinici de les aplicacions del seu abast</string>
-    <string name="xposed_module_updated_notification_title_system">Mòdul Xposed actualitzat, cal reiniciar el sistema</string>
+    <string name="xposed_module_updated_notification_title_system">Mòdul actualitzat, cal reiniciar el sistema</string>
     <string name="xposed_module_updated_notification_content_system">%s s\'ha actualitzat, ja que l\'abast conté System Framework, cal reiniciar per aplicar els canvis</string>
     <string name="module_updated_channel_name">S\'ha completat l\'actualització del mòdul</string>
     <string name="status_channel_name">Estat Vector</string>

--- a/daemon/src/main/res/values-cs/strings.xml
+++ b/daemon/src/main/res/values-cs/strings.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Xposed modul ještě není aktivován</string>
+    <string name="module_is_not_activated_yet">Modul ještě není aktivován</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s byl nainstalován, ale ještě není aktivován</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s byl nainstalován uživateli %2$s, ale ještě není aktivován</string>
-    <string name="xposed_module_updated_notification_title">Xposed modul byl aktualizován</string>
+    <string name="xposed_module_updated_notification_title">Modul byl aktualizován</string>
     <string name="xposed_module_updated_notification_content">%s byl aktualizován, prosím, násilně zastavte aplikace a restartujte je</string>
-    <string name="xposed_module_updated_notification_title_system">Xposed modul aktualizován, je vyžadován restart systému</string>
+    <string name="xposed_module_updated_notification_title_system">Modul aktualizován, je vyžadován restart systému</string>
     <string name="xposed_module_updated_notification_content_system">%s byl aktualizován, a protože se provedly změny v souvislosti se Systémovým Frameworkem, je vyžadován restart pro aplikaci změn</string>
     <string name="module_updated_channel_name">Aktualizace modulu dokončena</string>
     <string name="status_channel_name">Stav Vector</string>
-    <string name="vector_running_notification_title">LPosed načten</string>
+    <string name="vector_running_notification_title">Vector načten</string>
     <string name="vector_running_notification_content">Klepnutím na oznámení otevřete správce</string>
     <string name="xposed_module_request_scope_title">Žádost o rozsah</string>
     <string name="xposed_module_request_scope_content">%1$s pro uživatele %2$s požaduje přidání %3$s do jeho rozsahu.</string>

--- a/daemon/src/main/res/values-da/strings.xml
+++ b/daemon/src/main/res/values-da/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Xposed modul er endnu ikke aktiveret</string>
+    <string name="module_is_not_activated_yet">Modulet er endnu ikke aktiveret</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s er blevet installeret, men er ikke aktiveret endnu</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s er blevet installeret på brugeren %2$s, men er endnu ikke aktiveret</string>
-    <string name="xposed_module_updated_notification_title">Xposed modul opdateret</string>
+    <string name="xposed_module_updated_notification_title">Modul opdateret</string>
     <string name="xposed_module_updated_notification_content">%s er blevet opdateret, gennemtving stop og genstart apps i dets anvendelsesområde</string>
-    <string name="xposed_module_updated_notification_title_system">Xposed modul opdateret, system genstart kræves</string>
+    <string name="xposed_module_updated_notification_title_system">Modul opdateret, system genstart kræves</string>
     <string name="xposed_module_updated_notification_content_system">%s er blevet opdateret, da anvendelsesområdet indeholder System Framework, krævede genstart for at anvende ændringer</string>
     <string name="module_updated_channel_name">Modulopdatering afsluttet</string>
     <string name="status_channel_name">Vector status</string>

--- a/daemon/src/main/res/values-de/strings.xml
+++ b/daemon/src/main/res/values-de/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Das Xposed-Modul ist noch nicht aktiviert</string>
+    <string name="module_is_not_activated_yet">Das Modul ist noch nicht aktiviert</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s wurde installiert, ist aber noch nicht aktiviert</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s wurde unter dem Benutzer %2$s installiert, ist aber noch nicht aktiviert</string>
-    <string name="xposed_module_updated_notification_title">Xposed-Modul aktualisiert</string>
+    <string name="xposed_module_updated_notification_title">Modul aktualisiert</string>
     <string name="xposed_module_updated_notification_content">%s wurde aktualisiert, bitte Stopp erzwingen und die Apps in deren Scope neu starten</string>
-    <string name="xposed_module_updated_notification_title_system">Xposed-Modul aktualisiert, Systemneustart erforderlich</string>
+    <string name="xposed_module_updated_notification_title_system">Modul aktualisiert, Systemneustart erforderlich</string>
     <string name="xposed_module_updated_notification_content_system">%s wurde aktualisiert, da der Geltungsbereich System-Framework enthält, ist ein Neustart erforderlich, damit die Änderungen übernommen werden</string>
     <string name="module_updated_channel_name">Modulaktualisierung abgeschlossen</string>
     <string name="status_channel_name">Vector-Status</string>

--- a/daemon/src/main/res/values-el/strings.xml
+++ b/daemon/src/main/res/values-el/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Το Xposed πρόσθετο δεν έχει ενεργοποιηθεί ακόμα</string>
+    <string name="module_is_not_activated_yet">Το πρόσθετο δεν έχει ενεργοποιηθεί ακόμα</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s έχει εγκατασταθεί, αλλά δεν έχει ενεργοποιηθεί ακόμα</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s έχει εγκατασταθεί στον χρήστη %2$s, αλλά δεν έχει ενεργοποιηθεί ακόμη</string>
-    <string name="xposed_module_updated_notification_title">Το πρόσθετο Xposed ενημερώθηκε</string>
+    <string name="xposed_module_updated_notification_title">Το πρόσθετο ενημερώθηκε</string>
     <string name="xposed_module_updated_notification_content">%s ενημερώθηκε, παρακαλώ κλείστε εξαναγκαστικά και επανεκκινήστε τις εφαρμογές στο πεδίο εφαρμογής της</string>
-    <string name="xposed_module_updated_notification_title_system">Το πρόσθετο Xposed ενημερώθηκε, απαιτείται επανεκκίνηση συστήματος</string>
+    <string name="xposed_module_updated_notification_title_system">Το πρόσθετο ενημερώθηκε, απαιτείται επανεκκίνηση συστήματος</string>
     <string name="xposed_module_updated_notification_content_system">%s έχει ενημερωθεί, δεδομένου ότι το πεδίο εφαρμογής περιέχει Πλαίσιο Συστήματος, απαιτείται επανεκκίνηση για να εφαρμοστούν οι αλλαγές</string>
     <string name="module_updated_channel_name">Η ενημέρωση πρόσθετου ολοκληρώθηκε</string>
     <string name="status_channel_name">Κατάσταση Vector</string>

--- a/daemon/src/main/res/values-es/strings.xml
+++ b/daemon/src/main/res/values-es/strings.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">El módulo Xposed aún no está activado</string>
+    <string name="module_is_not_activated_yet">El módulo aún no está activado</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s ha sido instalado, pero aún no está activado</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s ha sido instalado al usuario %2$s, pero no está activado todavía</string>
-    <string name="xposed_module_updated_notification_title">Módulo Xpose actualizado</string>
+    <string name="xposed_module_updated_notification_title">Módulo actualizado</string>
     <string name="xposed_module_updated_notification_content">%s ha sido actualizado, fuerce la detención y el reinicio de las aplicaciones en su alcance</string>
-    <string name="xposed_module_updated_notification_title_system">Módulo Xposed actualizado, es necesario reiniciar el sistema</string>
+    <string name="xposed_module_updated_notification_title_system">Módulo actualizado, es necesario reiniciar el sistema</string>
     <string name="xposed_module_updated_notification_content_system">%s ha sido actualizado, ya que el ámbito contiene la estructura del sistema, requiere reiniciar para aplicar cambios</string>
     <string name="module_updated_channel_name">Módulo de actualización completo</string>
-    <string name="status_channel_name">LSPosición de estado</string>
+    <string name="status_channel_name">Estado de Vector</string>
     <string name="vector_running_notification_title">Vector cargado</string>
     <string name="vector_running_notification_content">Toca la notificación para abrir el gestor</string>
     <string name="xposed_module_request_scope_title">Solicitud de alcance</string>
-    <string name="xposed_module_request_scope_content">%1$s cuando el usuario %2$s solicita añadir %3$s a su ámbito.</string>
+    <string name="xposed_module_request_scope_content">%1$s en el usuario %2$s solicita añadir %3$s a su ámbito.</string>
     <string name="scope_channel_name">Solicitud de alcance</string>
     <string name="scope_approve">Aprobar</string>
     <string name="scope_deny">Denegar</string>

--- a/daemon/src/main/res/values-et/strings.xml
+++ b/daemon/src/main/res/values-et/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Xposed moodul ei ole aktiveeritud</string>
+    <string name="module_is_not_activated_yet">Moodul ei ole aktiveeritud</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s on paigaldatud, kuid ei ole aktiveeritud</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s on paigaldatud kasutajale %2$s, kuid ei ole aktiveeritud</string>
-    <string name="xposed_module_updated_notification_title">Xposed moodul uuendatud</string>
+    <string name="xposed_module_updated_notification_title">Moodul uuendatud</string>
     <string name="xposed_module_updated_notification_content">%s on uuendatud, siis peatage ja taaskäivitage rakendused, mis kuuluvad selle kohaldamisalasse.</string>
-    <string name="xposed_module_updated_notification_title_system">Xposed moodul uuendatud, süsteemi taaskäivitamine vajalik</string>
+    <string name="xposed_module_updated_notification_title_system">Moodul uuendatud, süsteemi taaskäivitamine vajalik</string>
     <string name="xposed_module_updated_notification_content_system">%s on uuendatud, kuna reguleerimisala sisaldab System Framework, vajalik taaskäivitamine, et rakendada muudatusi</string>
     <string name="module_updated_channel_name">Mooduli uuendamine lõpetatud</string>
     <string name="status_channel_name">Vectori staatus</string>

--- a/daemon/src/main/res/values-fa/strings.xml
+++ b/daemon/src/main/res/values-fa/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">ماژول Xposed هنوز فعال نشده است</string>
+    <string name="module_is_not_activated_yet">ماژول هنوز فعال نشده است</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s نصب شده اما هنوز فعال نشده است</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s برای کاربر %2$s نصب شده اما هنوز فعال نشده است</string>
-    <string name="xposed_module_updated_notification_title">ماژول Xposed به‌روزرسانی شد</string>
+    <string name="xposed_module_updated_notification_title">ماژول به‌روزرسانی شد</string>
     <string name="xposed_module_updated_notification_content">%s به‌روزرسانی شده است، لطفاً برنامه‌های مربوطه را به‌زور متوقف و مجدداً راه‌اندازی کنید</string>
-    <string name="xposed_module_updated_notification_title_system">ماژول Xposed به‌روزرسانی شد، نیاز به راه‌اندازی مجدد سیستم</string>
+    <string name="xposed_module_updated_notification_title_system">ماژول به‌روزرسانی شد، نیاز به راه‌اندازی مجدد سیستم</string>
     <string name="xposed_module_updated_notification_content_system">%s به‌روزرسانی شده است؛ از آنجا که محدوده شامل چارچوب سیستم است، برای اعمال تغییرات نیاز به راه‌اندازی مجدد سیستم است</string>
     <string name="module_updated_channel_name">به‌روزرسانی ماژول کامل شد</string>
     <string name="status_channel_name">وضعیت Vector</string>

--- a/daemon/src/main/res/values-fi/strings.xml
+++ b/daemon/src/main/res/values-fi/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Xposed moduuli ei ole vielä aktivoitu</string>
+    <string name="module_is_not_activated_yet">Moduuli ei ole vielä aktivoitu</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s on asennettu, mutta sitä ei ole vielä aktivoitu.</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s on asennettu käyttäjälle %2$s, mutta sitä ei ole vielä aktivoitu.</string>
-    <string name="xposed_module_updated_notification_title">Xposed moduuli päivitetty</string>
+    <string name="xposed_module_updated_notification_title">Moduuli päivitetty</string>
     <string name="xposed_module_updated_notification_content">%s on päivitetty, paina pysäytä ja käynnistä sovellukset uudelleen sen laajuudessa</string>
-    <string name="xposed_module_updated_notification_title_system">Xposed moduuli päivitetty, järjestelmän uudelleenkäynnistys vaaditaan</string>
+    <string name="xposed_module_updated_notification_title_system">Moduuli päivitetty, järjestelmän uudelleenkäynnistys vaaditaan</string>
     <string name="xposed_module_updated_notification_content_system">%s on päivitetty, koska soveltamisala sisältää järjestelmän kehyksen, vaaditaan uudelleenkäynnistys muutosten käyttöön</string>
     <string name="module_updated_channel_name">Moduulin päivitys valmis</string>
     <string name="status_channel_name">Vector status</string>

--- a/daemon/src/main/res/values-fr/strings.xml
+++ b/daemon/src/main/res/values-fr/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Le module Vector n\’est pas encore actif</string>
+    <string name="module_is_not_activated_yet">Le module n\’est pas encore actif</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s a été installé, mais n\'a pas été encore activé</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s a été installé pour l\'utilisateur %2$s, mais n\'a pas été encore activé</string>
-    <string name="xposed_module_updated_notification_title">Module Xposed mis à jour</string>
-    <string name="xposed_module_updated_notification_content">%s a été mis à jour, merci de forcer l\’arrêt ou de redémarrer les applis dans leurs champs d\’application</string>
-    <string name="xposed_module_updated_notification_title_system">Module Xposed mis à jour, redémarrage du système requis</string>
+    <string name="xposed_module_updated_notification_title">Module mis à jour</string>
+    <string name="xposed_module_updated_notification_content">%s a été mis à jour, merci de forcer l’arrêt et de redémarrer les applis dans leurs champs d’application</string>
+    <string name="xposed_module_updated_notification_title_system">Module mis à jour, redémarrage du système requis</string>
     <string name="xposed_module_updated_notification_content_system">%s a été mis à jour, étant donné que le champ d\'application est étendu au sous système, un redémarrage est nécessaire pour appliquer les changements</string>
     <string name="module_updated_channel_name">Mise à jour du module terminée</string>
     <string name="status_channel_name">Statut Vector</string>

--- a/daemon/src/main/res/values-hi/strings.xml
+++ b/daemon/src/main/res/values-hi/strings.xml
@@ -9,7 +9,7 @@
     <string name="xposed_module_updated_notification_title_system">एक्सपोज़ड मॉड्यूल अपडेट किया गया, सिस्टम रीबूट की आवश्यकता है</string>
     <string name="xposed_module_updated_notification_content_system">%s को अपडेट कर दिया गया है, क्योंकि स्कोप में सिस्टम फ्रेमवर्क है, परिवर्तनों को लागू करने के लिए रीबूट की आवश्यकता है</string>
     <string name="module_updated_channel_name">मॉड्यूल अद्यतन पूर्ण</string>
-    <string name="status_channel_name">एलएसपोस्ड स्थिति</string>
+    <string name="status_channel_name">Vector की स्थिति</string>
     <string name="vector_running_notification_title">Vector लोड किया गया</string>
     <string name="vector_running_notification_content">मैनेजर खोलने के लिए नोटिफिकेशन पर टैप करें</string>
     <string name="xposed_module_request_scope_title">गुंजाइश अनुरोध</string>

--- a/daemon/src/main/res/values-hr/strings.xml
+++ b/daemon/src/main/res/values-hr/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Xposed modul još nije aktiviran</string>
+    <string name="module_is_not_activated_yet">Modul još nije aktiviran</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s je instaliran, ali još nije aktiviran</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s je instaliran korisniku %2$s, ali još nije aktiviran</string>
-    <string name="xposed_module_updated_notification_title">Modul Xposed ažuriran</string>
+    <string name="xposed_module_updated_notification_title">Modul ažuriran</string>
     <string name="xposed_module_updated_notification_content">%s je ažuriran, prisilno zaustavite i ponovno pokrenite aplikacije u njegovom opsegu</string>
-    <string name="xposed_module_updated_notification_title_system">Xposed modul je ažuriran, potrebno je ponovno pokretanje sustava</string>
+    <string name="xposed_module_updated_notification_title_system">Modul je ažuriran, potrebno je ponovno pokretanje sustava</string>
     <string name="xposed_module_updated_notification_content_system">%s je ažuriran, budući da opseg sadrži System Framework, potrebno je ponovno pokretanje za primjenu promjena</string>
     <string name="module_updated_channel_name">Ažuriranje modula dovršeno</string>
     <string name="status_channel_name">Vector status</string>

--- a/daemon/src/main/res/values-hu/strings.xml
+++ b/daemon/src/main/res/values-hu/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Az Xposed modul még nincs aktiválva</string>
+    <string name="module_is_not_activated_yet">A modul még nincs aktiválva</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s telepítve lett, de még nincs aktiválva.</string>
-    <string name="module_is_not_activated_yet_multi_user_detailed">%1$s telepítve lett a %2$sfelhasználóhoz, de még nincs aktiválva.</string>
-    <string name="xposed_module_updated_notification_title">Xposed modul frissítve</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%1$s telepítve lett a %2$s felhasználóhoz, de még nincs aktiválva.</string>
+    <string name="xposed_module_updated_notification_title">Modul frissítve</string>
     <string name="xposed_module_updated_notification_content">%s frissítésre került, kérjük, kényszerítse az alkalmazások leállítását és újraindítását a hatókörében.</string>
-    <string name="xposed_module_updated_notification_title_system">Xposed modul frissítve, rendszer újraindítás szükséges</string>
+    <string name="xposed_module_updated_notification_title_system">Modul frissítve, rendszer újraindítás szükséges</string>
     <string name="xposed_module_updated_notification_content_system">%s frissítve lett, mivel a hatókör tartalmazza a System Framework-et, a változások alkalmazásához szükséges újraindítás szükséges.</string>
     <string name="module_updated_channel_name">A modul frissítése befejeződött</string>
     <string name="status_channel_name">Vector állapot</string>

--- a/daemon/src/main/res/values-in/strings.xml
+++ b/daemon/src/main/res/values-in/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Modul Xposed belum diaktifkan</string>
+    <string name="module_is_not_activated_yet">Modul belum diaktifkan</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s sudah diinstal, tetapi belum diaktifkan</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s telah diinstal ke pengguna %2$s, tetapi belum diaktifkan</string>
-    <string name="xposed_module_updated_notification_title">Modul xposed diperbarui</string>
+    <string name="xposed_module_updated_notification_title">Modul diperbarui</string>
     <string name="xposed_module_updated_notification_content">%s telah diperbarui, harap paksa berhenti dan mulai ulang aplikasi dalam cakupannya</string>
-    <string name="xposed_module_updated_notification_title_system">Modul Xposed diperbarui, diperlukan memulai ulang sistem</string>
+    <string name="xposed_module_updated_notification_title_system">Modul diperbarui, diperlukan memulai ulang sistem</string>
     <string name="xposed_module_updated_notification_content_system">%s telah diperbarui, karena cakupannya berisi Kerangka Sistem, diperlukan mulai ulang untuk menerapkan perubahan</string>
     <string name="module_updated_channel_name">Pembaruan modul selesai</string>
     <string name="status_channel_name">Status Vector</string>

--- a/daemon/src/main/res/values-it/strings.xml
+++ b/daemon/src/main/res/values-it/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Il modulo Xposed non è ancora attivo</string>
+    <string name="module_is_not_activated_yet">Il modulo non è ancora attivo</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s è stato installato, ma non è ancora attivo</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s è stato installato sull\'utente %2$s, ma non è ancora attivo</string>
-    <string name="xposed_module_updated_notification_title">Modulo Xposed aggiornato</string>
+    <string name="xposed_module_updated_notification_title">Modulo aggiornato</string>
     <string name="xposed_module_updated_notification_content">%s è stato aggiornato, arresta e riavvia le applicazioni per le quali è abilitato</string>
-    <string name="xposed_module_updated_notification_title_system">Modulo Xposed aggiornato, è necessario il riavvio del sistema</string>
+    <string name="xposed_module_updated_notification_title_system">Modulo aggiornato, è necessario il riavvio del sistema</string>
     <string name="xposed_module_updated_notification_content_system">%s è stato aggiornato. Poiché è abilitato per il framework di sistema, è necessario riavviare per applicare le modifiche</string>
     <string name="module_updated_channel_name">Aggiornamento del modulo completato</string>
     <string name="status_channel_name">Stato Vector</string>

--- a/daemon/src/main/res/values-iw/strings.xml
+++ b/daemon/src/main/res/values-iw/strings.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">מודול Vector עדיין לא הופעל</string>
+    <string name="module_is_not_activated_yet">המודול עדיין לא הופעל</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s הותקן, אך אינו מופעל עדיין</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s הותקן למשתמש %2$s, אך אינו מופעל עדיין</string>
-    <string name="xposed_module_updated_notification_title">מודול Vector עודכן</string>
+    <string name="xposed_module_updated_notification_title">המודול עודכן</string>
     <string name="xposed_module_updated_notification_content">%s עודכן</string>
-    <string name="xposed_module_updated_notification_title_system">מודול Xposed עודכן, נדרש אתחול המערכת</string>
+    <string name="xposed_module_updated_notification_title_system">המודול עודכן, נדרש אתחול המערכת</string>
     <string name="xposed_module_updated_notification_content_system">%s עודכן, מכיוון שההיקף מכיל System Framework, נדרש אתחול כדי להחיל שינויים</string>
     <string name="module_updated_channel_name">עדכון המודול הושלם</string>
-    <string name="status_channel_name">סטטוס LSPost</string>
+    <string name="status_channel_name">סטטוס Vector</string>
     <string name="vector_running_notification_title">Vector נטען</string>
     <string name="vector_running_notification_content">הקש על ההודעה כדי לפתוח את המנהל</string>
-    <string name="xposed_module_request_scope_title">Xposed_מודול_מבקש_כותרת_תחום</string>
+    <string name="xposed_module_request_scope_title">בקשת היקף</string>
     <string name="xposed_module_request_scope_content">%1$s על משתמש %2$s מבקש להוסיף %3$s להיקף שלו.</string>
-    <string name="scope_channel_name">תחום_שם_ערוץ</string>
-    <string name="scope_approve">אישור_תחום</string>
+    <string name="scope_channel_name">בקשת היקף</string>
+    <string name="scope_approve">אישור</string>
     <string name="scope_deny">לְהַכּחִישׁ</string>
     <string name="never_ask_again">לעולם אל תשאל</string>
 </resources>

--- a/daemon/src/main/res/values-ja/strings.xml
+++ b/daemon/src/main/res/values-ja/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Xposed モジュールが有効化されていません</string>
+    <string name="module_is_not_activated_yet">モジュールが有効化されていません</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s はインストールされましたが､ 有効化されていません</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s はユーザー %2$s にインストールされましたが､ 有効化されていません</string>
-    <string name="xposed_module_updated_notification_title">Xposed モジュールが更新されました</string>
+    <string name="xposed_module_updated_notification_title">モジュールが更新されました</string>
     <string name="xposed_module_updated_notification_content">%s が更新されました。スコープ内のアプリを強制停止してから再起動してください</string>
-    <string name="xposed_module_updated_notification_title_system">Xposed モジュールが更新されました。システムの再起動が必要です</string>
+    <string name="xposed_module_updated_notification_title_system">モジュールが更新されました。システムの再起動が必要です</string>
     <string name="xposed_module_updated_notification_content_system">%s が更新されました。スコープにシステムフレームワークが含まれているため、変更を適用するには再起動が必要です</string>
     <string name="module_updated_channel_name">モジュールの更新完了通知</string>
     <string name="status_channel_name">Vector のステータス通知</string>

--- a/daemon/src/main/res/values-ko/strings.xml
+++ b/daemon/src/main/res/values-ko/strings.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Xposed 모듈이 아직 활성화되지 않았습니다.</string>
+    <string name="module_is_not_activated_yet">모듈이 아직 활성화되지 않았습니다.</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s이(가) 설치되었지만 아직 활성화되지 않았습니다.</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">사용자 %2$s님에게 %1$s 이(가) 설치되었지만 아직 활성화되지 않았습니다.</string>
-    <string name="xposed_module_updated_notification_title">Xposed 모듈 업데이트</string>
+    <string name="xposed_module_updated_notification_title">모듈 업데이트</string>
     <string name="xposed_module_updated_notification_content">%s이(가) 업데이트되었습니다.</string>
-    <string name="xposed_module_updated_notification_title_system">Xposed 모듈이 업데이트되었습니다, 재부팅이 필요합니다.</string>
+    <string name="xposed_module_updated_notification_title_system">모듈이 업데이트되었습니다, 재부팅이 필요합니다.</string>
     <string name="xposed_module_updated_notification_content_system">범위에 시스템 프레임워크가 포함되어 있으므로 %s 이 업데이트되었습니다. 변경 사항을 적용하려면 재부팅해야 합니다.</string>
     <string name="module_updated_channel_name">모듈 업데이트 완료</string>
-    <string name="status_channel_name">LS포즈 상태</string>
+    <string name="status_channel_name">Vector 상태</string>
     <string name="vector_running_notification_title">Vector 로드됨</string>
     <string name="vector_running_notification_content">알림을 탭하여 관리자 열기</string>
     <string name="xposed_module_request_scope_title">범위 요청</string>

--- a/daemon/src/main/res/values-ku/strings.xml
+++ b/daemon/src/main/res/values-ku/strings.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Modula Xposed hîn nehatiye çalak kirin</string>
+    <string name="module_is_not_activated_yet">Modul hîn nehatiye çalak kirin</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s hatiye saz kirin, lê hîn nehatiye aktîfkirin</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s ji bikarhêner %2$sre hate saz kirin, lê hêj nehatiye çalak kirin</string>
-    <string name="xposed_module_updated_notification_title">Modula Xposed hate nûve kirin</string>
+    <string name="xposed_module_updated_notification_title">Modul hate nûve kirin</string>
     <string name="xposed_module_updated_notification_content">%s hate nûve kirin, ji kerema xwe bi zorê sepanan rawestînin û di çarçoveya wê de ji nû ve bidin destpêkirin</string>
-    <string name="xposed_module_updated_notification_title_system">Modula Xposed hate nûve kirin, pêdivî ye ku pergalê ji nû ve dest pê bike</string>
+    <string name="xposed_module_updated_notification_title_system">Modul hate nûve kirin, pêdivî ye ku pergalê ji nû ve dest pê bike</string>
     <string name="xposed_module_updated_notification_content_system">%s hate nûve kirin, ji ber ku çarçove Çarçoveya Pergalê dihewîne, ji bo sepandina guhertinan ji nû ve destpêkirinê hewce dike</string>
     <string name="module_updated_channel_name">Nûvekirina modulê qediya</string>
-    <string name="status_channel_name">statûya LSP</string>
-    <string name="vector_running_notification_title">LSP hate barkirin</string>
+    <string name="status_channel_name">Statûya Vector</string>
+    <string name="vector_running_notification_title">Vector hate barkirin</string>
     <string name="vector_running_notification_content">Daxuyaniyê bikirtînin da ku rêveberê vekin</string>
-    <string name="xposed_module_request_scope_title">Scope Daxwaza</string>
+    <string name="xposed_module_request_scope_title">Daxwaza qadê</string>
     <string name="xposed_module_request_scope_content">%1$s li ser bikarhêner %2$s daxwaz dike ku %3$s li qada xwe zêde bike.</string>
-    <string name="scope_channel_name">Daxwaza Scope</string>
+    <string name="scope_channel_name">Daxwaza qadê</string>
     <string name="scope_approve">Destûrdan</string>
     <string name="scope_deny">Înkarkirin</string>
     <string name="never_ask_again">Never Ask</string>

--- a/daemon/src/main/res/values-lt/strings.xml
+++ b/daemon/src/main/res/values-lt/strings.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Xposed modulis dar nėra aktyvuotas</string>
+    <string name="module_is_not_activated_yet">Modulis dar nėra aktyvuotas</string>
     <string name="module_is_not_activated_yet_main_user_detailed">\"%1$s\" buvo įdiegta, tačiau liko dar nesuaktyvuota</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">\"%1$s\" buvo įdiegta vartotojui \"%2$s\", tačiau liko dar nesuaktyvuota</string>
-    <string name="xposed_module_updated_notification_title">Atnaujintas Xposed modulis</string>
+    <string name="xposed_module_updated_notification_title">Atnaujintas modulis</string>
     <string name="xposed_module_updated_notification_content">%s buvo atnaujintas, priverstinai sustabdykite ir iš naujo paleiskite jo taikymo srityje esančias programas</string>
-    <string name="xposed_module_updated_notification_title_system">Atnaujintas \"Xposed\" modulis, reikalingas sistemos perkrovimas</string>
+    <string name="xposed_module_updated_notification_title_system">Atnaujintas modulis, reikalingas sistemos perkrovimas</string>
     <string name="xposed_module_updated_notification_content_system">%s buvo atnaujintas, nes srityje yra System Framework, reikalingas perkrovimas, kad būtų galima taikyti pakeitimus</string>
     <string name="module_updated_channel_name">Modulio atnaujinimas baigtas</string>
-    <string name="status_channel_name">LSPatvirtintas statusas</string>
-    <string name="vector_running_notification_title">LSPpateiktas pakrautas</string>
+    <string name="status_channel_name">Vector statusas</string>
+    <string name="vector_running_notification_title">Vector įkeltas</string>
     <string name="vector_running_notification_content">Bakstelėkite pranešimą, kad atidarytumėte tvarkytuvę</string>
     <string name="xposed_module_request_scope_title">Apimties prašymas</string>
     <string name="xposed_module_request_scope_content">%1$s pagal naudotojo %2$s užklausas įtraukti %3$s į jo taikymo sritį.</string>

--- a/daemon/src/main/res/values-nl/strings.xml
+++ b/daemon/src/main/res/values-nl/strings.xml
@@ -5,7 +5,7 @@
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s is geïnstalleerd, maar nog niet geactiveerd</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s is geïnstalleerd bij gebruiker %2$s, maar is nog niet geactiveerd</string>
     <string name="xposed_module_updated_notification_title">Vector module bijgewerkt</string>
-    <string name="xposed_module_updated_notification_content">%1$s is geupdate</string>
+    <string name="xposed_module_updated_notification_content">%s is geupdate</string>
     <string name="xposed_module_updated_notification_title_system">Xposed-module bijgewerkt, systeem opnieuw opstarten vereist</string>
     <string name="xposed_module_updated_notification_content_system">%s is bijgewerkt, omdat het bereik een systeemkader bevat, moet je opnieuw opstarten om wijzigingen toe te passen</string>
     <string name="module_updated_channel_name">Module update voltooid</string>

--- a/daemon/src/main/res/values-nl/strings.xml
+++ b/daemon/src/main/res/values-nl/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Vector module is nog niet geactiveerd</string>
+    <string name="module_is_not_activated_yet">Module is nog niet geactiveerd</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s is geïnstalleerd, maar nog niet geactiveerd</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s is geïnstalleerd bij gebruiker %2$s, maar is nog niet geactiveerd</string>
-    <string name="xposed_module_updated_notification_title">Vector module bijgewerkt</string>
+    <string name="xposed_module_updated_notification_title">Module bijgewerkt</string>
     <string name="xposed_module_updated_notification_content">%s is geupdate</string>
-    <string name="xposed_module_updated_notification_title_system">Xposed-module bijgewerkt, systeem opnieuw opstarten vereist</string>
+    <string name="xposed_module_updated_notification_title_system">Module bijgewerkt, systeem opnieuw opstarten vereist</string>
     <string name="xposed_module_updated_notification_content_system">%s is bijgewerkt, omdat het bereik een systeemkader bevat, moet je opnieuw opstarten om wijzigingen toe te passen</string>
     <string name="module_updated_channel_name">Module update voltooid</string>
     <string name="status_channel_name">Vector status</string>

--- a/daemon/src/main/res/values-no/strings.xml
+++ b/daemon/src/main/res/values-no/strings.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Xposed modul er ikke aktivert enda</string>
+    <string name="module_is_not_activated_yet">Modulen er ikke aktivert enda</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s er installert, men er ikke aktivert ennå</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s har blitt installert til bruker %2$s, men er ikke aktivert ennå</string>
-    <string name="xposed_module_updated_notification_title">Xposed modul er oppdatert</string>
+    <string name="xposed_module_updated_notification_title">Modulen er oppdatert</string>
     <string name="xposed_module_updated_notification_content">%s har blitt oppdatert, vennligst tvang-stopp og start apper på nytt i virkeområdet</string>
-    <string name="xposed_module_updated_notification_title_system">Xposed modul oppdatert, system-omstart kreves</string>
+    <string name="xposed_module_updated_notification_title_system">Modul oppdatert, system-omstart kreves</string>
     <string name="xposed_module_updated_notification_content_system">%s er blitt oppdatert, siden omfanget inneholder systemramme, nødvendig for omstart av endringene</string>
     <string name="module_updated_channel_name">Moduloppdatering fullført</string>
-    <string name="status_channel_name">LSPosert status</string>
-    <string name="vector_running_notification_title">LSPosert lastet</string>
+    <string name="status_channel_name">Vector-status</string>
+    <string name="vector_running_notification_title">Vector lastet</string>
     <string name="vector_running_notification_content">Trykk på varselet for å åpne administrator</string>
     <string name="xposed_module_request_scope_title">Forespørsel om omfang</string>
     <string name="xposed_module_request_scope_content">%1$s på bruker %2$s ber om å legge til %3$s i omfanget.</string>

--- a/daemon/src/main/res/values-pl/strings.xml
+++ b/daemon/src/main/res/values-pl/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Moduł Xposed nie jest jeszcze aktywowany</string>
+    <string name="module_is_not_activated_yet">Moduł nie jest jeszcze aktywowany</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s został zainstalowany, ale nie jest jeszcze aktywny</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s został zainstalowany na użytkowniku %2$s, ale nie jest jeszcze aktywowany</string>
-    <string name="xposed_module_updated_notification_title">Moduł Xposed zaktualizowany</string>
+    <string name="xposed_module_updated_notification_title">Moduł zaktualizowany</string>
     <string name="xposed_module_updated_notification_content">%s został zaktualizowany, wymuś zatrzymanie i ponownie uruchom aplikacje w jego zakresie</string>
-    <string name="xposed_module_updated_notification_title_system">Zaktualizowano moduł Xposed, wymagane ponowne uruchomienie systemu</string>
+    <string name="xposed_module_updated_notification_title_system">Zaktualizowano moduł, wymagane ponowne uruchomienie systemu</string>
     <string name="xposed_module_updated_notification_content_system">%s został zaktualizowany, ponieważ zakres zawiera System Framework, wymagany restart aby zastosować zmiany</string>
     <string name="module_updated_channel_name">Aktualizowanie modułu zakończone</string>
     <string name="status_channel_name">Status Vector</string>

--- a/daemon/src/main/res/values-ro/strings.xml
+++ b/daemon/src/main/res/values-ro/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Modulul Xposed nu este încă activat</string>
+    <string name="module_is_not_activated_yet">Modulul nu este încă activat</string>
     <string name="module_is_not_activated_yet_main_user_detailed">Modulul %1$s este instalat, dar nu este încă activat</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">Modulul %1$s a fost instalat pentru utilizatorul %2$s, dar nu este încă activat</string>
-    <string name="xposed_module_updated_notification_title">Modulul Xposed a fost actualizat</string>
+    <string name="xposed_module_updated_notification_title">Modulul a fost actualizat</string>
     <string name="xposed_module_updated_notification_content">Modulul %s a fost actualizat, vă rugăm să reporniți aplicațiile din cadrul configurației sale</string>
-    <string name="xposed_module_updated_notification_title_system">Modulul Xposed a fost actualizat, este necesară repornirea sistemului</string>
+    <string name="xposed_module_updated_notification_title_system">Modulul a fost actualizat, este necesară repornirea sistemului</string>
     <string name="xposed_module_updated_notification_content_system">Modulul %s a fost actualizat. Este necesară repornirea dispozitivului, deoarece Sistemul Android face parte din configurația modulului.</string>
     <string name="module_updated_channel_name">Actualizarea modulelor este completă</string>
     <string name="status_channel_name">Stare Vector</string>

--- a/daemon/src/main/res/values-ru/strings.xml
+++ b/daemon/src/main/res/values-ru/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Модуль Xposed пока не активирован</string>
+    <string name="module_is_not_activated_yet">Модуль пока не активирован</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s установлен, но пока не активирован</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s установлен (пользователь %2$s), но пока не активирован</string>
-    <string name="xposed_module_updated_notification_title">Модуль Xposed обновлён</string>
+    <string name="xposed_module_updated_notification_title">Модуль обновлён</string>
     <string name="xposed_module_updated_notification_content">%s обновлён, выполните остановку приложений в его «охвате» и перезапустите их</string>
-    <string name="xposed_module_updated_notification_title_system">Модуль Xposed обновлён, требуется перезагрузка устройства</string>
+    <string name="xposed_module_updated_notification_title_system">Модуль обновлён, требуется перезагрузка устройства</string>
     <string name="xposed_module_updated_notification_content_system">%s обновлён; ввиду того, что системный фреймворк (System Framework) в его «охвате», требуется перезагрузка для применения изменений</string>
     <string name="module_updated_channel_name">Обновление модуля завершено</string>
     <string name="status_channel_name">Статус Vector</string>

--- a/daemon/src/main/res/values-si/strings.xml
+++ b/daemon/src/main/res/values-si/strings.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Xposed මොඩියුලය තවම සක්‍රිය කර නැත</string>
+    <string name="module_is_not_activated_yet">මොඩියුලය තවම සක්‍රිය කර නැත</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s ස්ථාපනය කර ඇත, නමුත් තවමත් සක්රිය කර නැත</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">පරිශීලක %2$sවෙත %1$s ස්ථාපනය කර ඇත, නමුත් තවමත් සක්‍රිය කර නොමැත</string>
-    <string name="xposed_module_updated_notification_title">Xposed මොඩියුලය යාවත්කාලීන කරන ලදී</string>
+    <string name="xposed_module_updated_notification_title">මොඩියුලය යාවත්කාලීන කරන ලදී</string>
     <string name="xposed_module_updated_notification_content">%s යාවත්කාලීන කර ඇත, කරුණාකර එහි විෂය පථය තුළ යෙදුම් බලහත්කාරයෙන් නතර කර නැවත ආරම්භ කරන්න</string>
-    <string name="xposed_module_updated_notification_title_system">Xposed මොඩියුලය යාවත්කාලීන කරන ලදි, පද්ධතිය නැවත ආරම්භ කිරීම අවශ්‍යයි</string>
+    <string name="xposed_module_updated_notification_title_system">මොඩියුලය යාවත්කාලීන කරන ලදි, පද්ධතිය නැවත ආරම්භ කිරීම අවශ්‍යයි</string>
     <string name="xposed_module_updated_notification_content_system">%s යාවත්කාලීන කර ඇත, විෂය පථයේ පද්ධති රාමුව අඩංගු බැවින්, වෙනස්කම් යෙදීමට නැවත පණගැන්වීම අවශ්‍ය වේ</string>
     <string name="module_updated_channel_name">මොඩියුල යාවත්කාලීන කිරීම සම්පූර්ණයි</string>
-    <string name="status_channel_name">එල්එස්පී තත්ත්වය</string>
-    <string name="vector_running_notification_title">LSPposed පටවා ඇත</string>
+    <string name="status_channel_name">Vector තත්ත්වය</string>
+    <string name="vector_running_notification_title">Vector පටවා ඇත</string>
     <string name="vector_running_notification_content">කළමනාකරු විවෘත කිරීමට දැනුම්දීම තට්ටු කරන්න</string>
     <string name="xposed_module_request_scope_title">විෂය පථය ඉල්ලීම</string>
     <string name="xposed_module_request_scope_content">පරිශීලක %2$s හි %1$s එහි විෂය පථයට %3$s එකතු කරන ලෙස ඉල්ලා සිටී.</string>

--- a/daemon/src/main/res/values-sk/strings.xml
+++ b/daemon/src/main/res/values-sk/strings.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Modul Xposed ešte nie je aktivovaný</string>
+    <string name="module_is_not_activated_yet">Modul ešte nie je aktivovaný</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s bol nainštalovaný, ale ešte nie je aktivovaný</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s bol nainštalovaný na stránke používateľa %2$s, ale ešte nie je aktivovaný.</string>
-    <string name="xposed_module_updated_notification_title">Aktualizovaný modul Xposed</string>
+    <string name="xposed_module_updated_notification_title">Aktualizovaný modul</string>
     <string name="xposed_module_updated_notification_content">%s bola aktualizovaná, vynúťte si zastavenie a reštartovanie aplikácií v jej rozsahu</string>
-    <string name="xposed_module_updated_notification_title_system">Aktualizácia modulu Xposed, potrebný reštart systému</string>
+    <string name="xposed_module_updated_notification_title_system">Aktualizácia modulu, potrebný reštart systému</string>
     <string name="xposed_module_updated_notification_content_system">%s bola aktualizovaná, pretože rozsah obsahuje System Framework, potrebný reštart na uplatnenie zmien</string>
     <string name="module_updated_channel_name">Aktualizácia modulu dokončená</string>
-    <string name="status_channel_name">LSPonúkaný stav</string>
+    <string name="status_channel_name">Stav Vector</string>
     <string name="vector_running_notification_title">Vector naložené</string>
     <string name="vector_running_notification_content">Ťuknutím na oznámenie otvorte správcu</string>
     <string name="xposed_module_request_scope_title">Žiadosť o rozsah</string>
-    <string name="xposed_module_request_scope_content">%1$s na žiadosti používateľa %2$s o pridanie stránky %3$s do jej rozsahu.</string>
+    <string name="xposed_module_request_scope_content">%1$s na žiadosti používateľa %2$s o pridanie %3$s do jej rozsahu.</string>
     <string name="scope_channel_name">Žiadosť o rozsah</string>
     <string name="scope_approve">Schváliť</string>
     <string name="scope_deny">Odmietnuť</string>

--- a/daemon/src/main/res/values-sv/strings.xml
+++ b/daemon/src/main/res/values-sv/strings.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Xposed modul är inte aktiverad än</string>
+    <string name="module_is_not_activated_yet">Modulen är inte aktiverad än</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s har installerats, men är ännu inte aktiverad.</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s har installerats för användaren %2$s, men är ännu inte aktiverad.</string>
-    <string name="xposed_module_updated_notification_title">Xposed modul uppdaterad</string>
+    <string name="xposed_module_updated_notification_title">Modul uppdaterad</string>
     <string name="xposed_module_updated_notification_content">%s har uppdaterats. Tvinga stopp och starta om appar i dess omfattning</string>
-    <string name="xposed_module_updated_notification_title_system">Xposed modul uppdaterad, systemomstart krävs</string>
+    <string name="xposed_module_updated_notification_title_system">Modul uppdaterad, systemomstart krävs</string>
     <string name="xposed_module_updated_notification_content_system">%s har uppdaterats, eftersom omfattningen innehåller Systemramverk, krävs omstart för att tillämpa ändringar</string>
     <string name="module_updated_channel_name">Uppdatering av modulen slutförd</string>
     <string name="status_channel_name">Vector status</string>
     <string name="vector_running_notification_title">Vector laddad</string>
     <string name="vector_running_notification_content">Tryck på meddelandet för att öppna administratören</string>
     <string name="xposed_module_request_scope_title">Begäran om tillämpningsområde</string>
-    <string name="xposed_module_request_scope_content">%1$s om användaren %2$s begär att %3$s ska läggas till i dess räckvidd.</string>
+    <string name="xposed_module_request_scope_content">%1$s för användaren %2$s begär att %3$s ska läggas till i dess räckvidd.</string>
     <string name="scope_channel_name">Begäran om tillämpningsområde</string>
     <string name="scope_approve">Godkänna</string>
     <string name="scope_deny">Förneka</string>

--- a/daemon/src/main/res/values-th/strings.xml
+++ b/daemon/src/main/res/values-th/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">โมดูล Xposed ยังไม่ได้เปิดใช้งาน</string>
+    <string name="module_is_not_activated_yet">โมดูลยังไม่ได้เปิดใช้งาน</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s ถูกติดตั้งแล้ว แต่ยังไม่ได้เปิดใช้งาน</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">ติดตั้ง %1$s ให้กับผู้ใช้แล้ว %2$s แต่ยังไม่ได้เปิดใช้งาน</string>
-    <string name="xposed_module_updated_notification_title">โมดูล Xposed อัปเดตแล้ว</string>
+    <string name="xposed_module_updated_notification_title">โมดูลอัปเดตแล้ว</string>
     <string name="xposed_module_updated_notification_content">%s ได้รับการอัปเดตแล้ว โปรดบังคับหยุดและรีสตาร์ทแอปที่อยู่ใน Scope.</string>
-    <string name="xposed_module_updated_notification_title_system">อัปเดตโมดูล Xposed จำเป็นต้องรีสตาร์ทเครื่อง</string>
+    <string name="xposed_module_updated_notification_title_system">อัปเดตโมดูล จำเป็นต้องรีสตาร์ทเครื่อง</string>
     <string name="xposed_module_updated_notification_content_system">%s ได้รับการอัปเดตแล้ว เนื่องจาก Scope มี System Framework จึงจำเป็นต้องรีสตาร์ทเครื่องเพื่อใช้การเปลี่ยนแปลง</string>
     <string name="module_updated_channel_name">การอัปเดตโมดูลเสร็จสมบูรณ์</string>
     <string name="status_channel_name">สถานะ Vector</string>

--- a/daemon/src/main/res/values-tr/strings.xml
+++ b/daemon/src/main/res/values-tr/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Xposed modülü henüz aktif değil!</string>
+    <string name="module_is_not_activated_yet">Modül henüz aktif değil!</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s kuruldu, ancak henüz etkinleştirilmedi</string>
-    <string name="module_is_not_activated_yet_multi_user_detailed">%1$s, kullanıcıya %2$syüklendi, ancak henüz etkinleştirilmedi</string>
-    <string name="xposed_module_updated_notification_title">Xposed modülü güncellendi</string>
+    <string name="module_is_not_activated_yet_multi_user_detailed">%1$s, kullanıcıya %2$s yüklendi, ancak henüz etkinleştirilmedi</string>
+    <string name="xposed_module_updated_notification_title">Modül güncellendi</string>
     <string name="xposed_module_updated_notification_content">%s güncellendi, lütfen kapsamındaki uygulamaları durdurmaya ve yeniden başlatmaya zorlayın</string>
-    <string name="xposed_module_updated_notification_title_system">Xposed modülü güncellendi, sistemin yeniden başlatılması gerekiyor</string>
+    <string name="xposed_module_updated_notification_title_system">Modül güncellendi, sistemin yeniden başlatılması gerekiyor</string>
     <string name="xposed_module_updated_notification_content_system">%s Güncelleme kapsamı Sistem Çerçevesi içerdiğinden, değişiklikleri uygulamak için yeniden başlatma gereklidir</string>
     <string name="module_updated_channel_name">Modül güncellemesi tamamlandı</string>
     <string name="status_channel_name">Vector durumu</string>

--- a/daemon/src/main/res/values-uk/strings.xml
+++ b/daemon/src/main/res/values-uk/strings.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Модуль Xposed ще не активований</string>
+    <string name="module_is_not_activated_yet">Модуль ще не активований</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s було встановлено, але ще не активовано</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s було встановлено до користувача %2$s, але ще не активовано</string>
-    <string name="xposed_module_updated_notification_title">Модуль Xposed оновлено</string>
+    <string name="xposed_module_updated_notification_title">Модуль оновлено</string>
     <string name="xposed_module_updated_notification_content">%s було оновлено, будь ласка, примусово перезапустіть програми з області модуля</string>
-    <string name="xposed_module_updated_notification_title_system">Модуль Xposed оновлено, потрібно перезавантаження системи</string>
+    <string name="xposed_module_updated_notification_title_system">Модуль оновлено, потрібно перезавантаження системи</string>
     <string name="xposed_module_updated_notification_content_system">%s було оновлено, оскільки область містить System Framework, необхідне перезавантаження для застосування змін</string>
     <string name="module_updated_channel_name">Оновлення модуля завершено</string>
     <string name="status_channel_name">Статус Vector</string>
     <string name="vector_running_notification_title">Vector завантажено</string>
     <string name="vector_running_notification_content">Натисніть на повідомлення, щоб відкрити менеджер</string>
     <string name="xposed_module_request_scope_title">Запит на визначення обсягу робіт</string>
-    <string name="xposed_module_request_scope_content">%1$s на запит користувача %2$s з проханням додати %3$s до своєї області видимості.</string>
-    <string name="scope_channel_name">Запит обсягу робіт</string>
+    <string name="xposed_module_request_scope_content">%1$s у користувача %2$s просить додати %3$s до своєї області видимості.</string>
+    <string name="scope_channel_name">Запит області видимості</string>
     <string name="scope_approve">Затвердити</string>
     <string name="scope_deny">Відхилити</string>
     <string name="never_ask_again">Ніколи не питай</string>

--- a/daemon/src/main/res/values-ur/strings.xml
+++ b/daemon/src/main/res/values-ur/strings.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Xposed ماڈیول ابھی تک چالو نہیں ہوا ہے۔</string>
+    <string name="module_is_not_activated_yet">ماڈیول ابھی تک چالو نہیں ہوا ہے۔</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s انسٹال ہو چکا ہے، لیکن ابھی تک چالو نہیں ہوا ہے۔</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s کو صارف %2$sپر انسٹال کر دیا گیا ہے، لیکن ابھی تک فعال نہیں ہوا ہے۔</string>
-    <string name="xposed_module_updated_notification_title">Xposed ماڈیول کو اپ ڈیٹ کر دیا گیا۔</string>
+    <string name="xposed_module_updated_notification_title">ماڈیول کو اپ ڈیٹ کر دیا گیا۔</string>
     <string name="xposed_module_updated_notification_content">%s کو اپ ڈیٹ کر دیا گیا ہے، براہ کرم اس کے دائرہ کار میں ایپس کو زبردستی روکنے اور دوبارہ شروع کریں۔</string>
-    <string name="xposed_module_updated_notification_title_system">Xposed ماڈیول کو اپ ڈیٹ کر دیا گیا، سسٹم ریبوٹ درکار ہے۔</string>
+    <string name="xposed_module_updated_notification_title_system">ماڈیول کو اپ ڈیٹ کر دیا گیا، سسٹم ریبوٹ درکار ہے۔</string>
     <string name="xposed_module_updated_notification_content_system">%s کو اپ ڈیٹ کر دیا گیا ہے، چونکہ دائرہ کار میں سسٹم فریم ورک ہے، تبدیلیاں لاگو کرنے کے لیے ریبوٹ کی ضرورت ہے۔</string>
     <string name="module_updated_channel_name">ماڈیول اپ ڈیٹ مکمل ہو گیا۔</string>
-    <string name="status_channel_name">ایل ایس پیز کی حیثیت</string>
-    <string name="vector_running_notification_title">ایل ایس پیز لوڈ شدہ</string>
+    <string name="status_channel_name">Vector کی حیثیت</string>
+    <string name="vector_running_notification_title">Vector لوڈ شدہ</string>
     <string name="vector_running_notification_content">مینیجر کو کھولنے کے لیے نوٹیفکیشن کو تھپتھپائیں۔</string>
     <string name="xposed_module_request_scope_title">دائرہ کار کی درخواست</string>
     <string name="xposed_module_request_scope_content">صارف %2$s پر %1$s اپنے دائرہ کار میں %3$s شامل کرنے کی درخواست کرتا ہے۔</string>

--- a/daemon/src/main/res/values-vi/strings.xml
+++ b/daemon/src/main/res/values-vi/strings.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Mô-đun Xposed chưa được kích hoạt</string>
+    <string name="module_is_not_activated_yet">Mô-đun chưa được kích hoạt</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s đã được cài đặt, nhưng chưa được kích hoạt</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s vừa được cài đặt cho người dùng %2$s, nhưng chưa được kích hoạt</string>
-    <string name="xposed_module_updated_notification_title">Mô-đun Xposed đã được cập nhật</string>
+    <string name="xposed_module_updated_notification_title">Mô-đun đã được cập nhật</string>
     <string name="xposed_module_updated_notification_content">%s đã được cập nhật, xin hãy buộc dừng và khởi động lại ứng dụng liên quan</string>
-    <string name="xposed_module_updated_notification_title_system">Mô-đun Xposed đã được cập nhật, yêu cầu khởi động lại hệ thống</string>
+    <string name="xposed_module_updated_notification_title_system">Mô-đun đã được cập nhật, yêu cầu khởi động lại hệ thống</string>
     <string name="xposed_module_updated_notification_content_system">%s đã được cập nhật, vì phạm vi bao gồm Framework Hệ thống, thì khởi động lại là cần thiết để áp dụng các thay đổi</string>
     <string name="module_updated_channel_name">Tiện ích bổ sung cập nhật hoàn tất</string>
-    <string name="status_channel_name">Trạng thái hoạt động</string>
-    <string name="vector_running_notification_title">Ứng dụng đã được tải</string>
+    <string name="status_channel_name">Trạng thái Vector</string>
+    <string name="vector_running_notification_title">Vector đã được tải</string>
     <string name="vector_running_notification_content">Nhấn để mở trình quản lý</string>
     <string name="xposed_module_request_scope_title">Yêu cầu phạm vi</string>
     <string name="xposed_module_request_scope_content">%1$s khi người dùng %2$s yêu cầu thêm %3$s vào phạm vi của nó.</string>

--- a/daemon/src/main/res/values-zh-rCN/strings.xml
+++ b/daemon/src/main/res/values-zh-rCN/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Xposed 模块尚未激活</string>
+    <string name="module_is_not_activated_yet">模块尚未激活</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s 已安装，但尚未激活</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s 已安装到用户 %2$s，但尚未激活</string>
-    <string name="xposed_module_updated_notification_title">Xposed 模块已更新</string>
+    <string name="xposed_module_updated_notification_title">模块已更新</string>
     <string name="xposed_module_updated_notification_content">%s 已更新，请强行停止并重新打开其作用域内的应用</string>
-    <string name="xposed_module_updated_notification_title_system">Xposed 模块已更新，需要重新启动</string>
+    <string name="xposed_module_updated_notification_title_system">模块已更新，需要重新启动</string>
     <string name="xposed_module_updated_notification_content_system">%s 已更新，由于作用域包含系统框架，需重启以应用更改</string>
     <string name="module_updated_channel_name">模块更新完成</string>
     <string name="status_channel_name">Vector 状态</string>

--- a/daemon/src/main/res/values-zh-rHK/strings.xml
+++ b/daemon/src/main/res/values-zh-rHK/strings.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Xposed 模組尚未啟用</string>
+    <string name="module_is_not_activated_yet">模組尚未啟用</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s 已安裝，但尚未啟用</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s 已安裝到用戶 %2$s，但尚未啟用</string>
-    <string name="xposed_module_updated_notification_title">Xposed 模組已更新</string>
+    <string name="xposed_module_updated_notification_title">模組已更新</string>
     <string name="xposed_module_updated_notification_content">%s 已更新，請強制停止並重新開啟其作用範圍內的應用程式</string>
-    <string name="xposed_module_updated_notification_title_system">Xposed 模組已更新，需要重新啟動。</string>
+    <string name="xposed_module_updated_notification_title_system">模組已更新，需要重新啟動。</string>
     <string name="xposed_module_updated_notification_content_system">%s 已更新，由於作用範圍包含系統架構，需要重新啟動以套用修改。</string>
-    <string name="module_updated_channel_name">模块更新完成</string>
+    <string name="module_updated_channel_name">模組更新完成</string>
     <string name="status_channel_name">Vector 狀態</string>
     <string name="vector_running_notification_title">Vector 已載入</string>
     <string name="vector_running_notification_content">輕觸通知以開啟管理員</string>

--- a/daemon/src/main/res/values-zh-rTW/strings.xml
+++ b/daemon/src/main/res/values-zh-rTW/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification -->
-    <string name="module_is_not_activated_yet">Xposed 模組尚未啟用</string>
+    <string name="module_is_not_activated_yet">模組尚未啟用</string>
     <string name="module_is_not_activated_yet_main_user_detailed">%1$s 已安裝，但尚未啟用</string>
     <string name="module_is_not_activated_yet_multi_user_detailed">%1$s 已安裝到使用者 %2$s，但尚未啟用</string>
-    <string name="xposed_module_updated_notification_title">Xposed 模組已更新</string>
+    <string name="xposed_module_updated_notification_title">模組已更新</string>
     <string name="xposed_module_updated_notification_content">%s 已更新，請強制停止並重新打開其作用域內的程式</string>
-    <string name="xposed_module_updated_notification_title_system">Xposed 模組已更新，需要重新啟動。</string>
+    <string name="xposed_module_updated_notification_title_system">模組已更新，需要重新啟動。</string>
     <string name="xposed_module_updated_notification_content_system">%s 已更新，由於作用域包含系統框架，需要重新啟動以套用修改。</string>
     <string name="module_updated_channel_name">模組更新完成</string>
     <string name="status_channel_name">Vector 狀態</string>

--- a/manager/tools/check_translations.py
+++ b/manager/tools/check_translations.py
@@ -41,11 +41,23 @@ for d in sorted(base.glob('values-*')):
         for k, v in tr.items():
             src = en.get(k)
             if src is None: continue
-            def args(t): return set(re.findall(r'%(\d+)\$[sd]', t))
+            # Which %1$-style indices appear, plus how many bare %s/%d one item can carry. Bare
+            # arguments have to be counted as well as indexed ones: a translation holding a %d the
+            # source does not have prints the literal "%d" to the user, and looking only for the
+            # indexed form walks straight past it. Indices go in a set and bare ones are maxed over
+            # the items rather than summed, because a plural's item count is a property of the
+            # language -- Polish has four forms where English has two -- and is not a mismatch.
+            def args(t):
+                items = [t] if isinstance(t, str) else list(t.values())
+                idx = set()
+                bare = 0
+                for i in items:
+                    idx |= set(re.findall(r'%(\d+)\$[sd]', i))
+                    bare = max(bare, len(re.findall(r'%[sd]', i)))
+                return sorted(idx), bare
             sv = v if isinstance(v, str) else ' '.join(v.values())
-            ss = src if isinstance(src, str) else ' '.join(src.values())
-            if args(sv) != args(ss):
-                print(f"  {lang}/{name}:{k}: placeholder mismatch {sorted(args(ss))} -> {sorted(args(sv))}"); problems += 1
+            if args(v) != args(src):
+                print(f"  {lang}/{name}:{k}: placeholder mismatch {args(src)} -> {args(v)}"); problems += 1
             # A Latin-script translation containing Han or kana is almost always a line
             # pasted from the wrong file — the mistake that put a Chinese sentence inside the
             # Russian strings. Languages that legitimately use those scripts are exempt.

--- a/zygisk/module/module.prop
+++ b/zygisk/module/module.prop
@@ -4,4 +4,4 @@ version=${versionName} (${versionCode}-${versionHash})
 versionCode=${versionCode}
 author=JingMatrix
 description=A modern, Xposed-compatible framework for Android application hooking. (Android 8.1 ~ 16)
-updateJson=https://raw.githubusercontent.com/JingMatrix/LSPosed/master/zygisk/update.json
+updateJson=https://raw.githubusercontent.com/JingMatrix/Vector/master/zygisk/update.json

--- a/zygisk/update.json
+++ b/zygisk/update.json
@@ -1,6 +1,6 @@
 {
 	"version": "v2.0",
 	"versionCode": 3021,
-	"zipUrl": "https://github.com/JingMatrix/LSPosed/releases/download/v2.0/Vector-v2.0-Release.zip",
-	"changelog": "https://raw.githubusercontent.com/JingMatrix/LSPosed/master/zygisk/changelog.md"
+	"zipUrl": "https://github.com/JingMatrix/Vector/releases/download/v2.0/Vector-v2.0-3021-Release.zip",
+	"changelog": "https://raw.githubusercontent.com/JingMatrix/Vector/master/zygisk/changelog.md"
 }


### PR DESCRIPTION
Four unrelated fixes.

app/build/outputs/mapping has not existed since #796, and DEBUG_SYMBOLS_PATH resolves per module rather than to the root build/symbols the workflow read, so both artifacts have been silently empty. upload-artifact calls an unmatched path a success, which is why neither ever complained.

manager/tools/check_translations.py had no caller. It runs in CI over both resource trees now, and it fails on three real defects, fixed here: a zh-rTW line pasted into values-af, a literal "%d" Afrikaans users have been reading, and a stray %1$s in values-nl.

zygisk/update.json asks for Vector-v2.0-Release.zip where the release attaches Vector-v2.0-3021-Release.zip, so Magisk has offered the v2.0 update and then failed the install ever since it shipped. Fixed, along with the old repository paths there, in module.prop's updateJson and in the issue templates.

Then the daemon translations, read locale by locale rather than through the checker. The product name had been machine-translated in 18 of them -- Spanish "LSPosición de estado", Bulgarian "Предложен статус на LSP" with "posed" read as "proposed", Slovak "LSPonúkaný stav". Hebrew had three strings where the resource key was translated instead of the value, so the Approve button read "אישור_תחום". Hungarian and Turkish ran the user name into the following word with a spaceless %2$s, and values-zh-rHK held a Simplified string in a Traditional file. 152 strings in all, of which 116 are the wording: 39 locales said "Xposed module" where the source says just "module", and the manager says "module" everywhere, so the locales come to it.

Nine strings I left alone, listed in that commit. They need somebody who reads Bulgarian, Greek, Hungarian, Thai, Vietnamese, Hebrew, Kurdish or Slovak, and a guess there would be worse than the wart.

Two things to know before merging. update.json is served live from master, so that one reaches every v2.0 install on its next update check the moment it lands; nothing else here touches a device. And Crowdin owns the string files, so the translation changes want the same correction upstream or the next pull reverts them.

No tests, as usual. The translation check is its own proof -- put the defects back and it fails with exactly those.
