### PR TITLE
Arrange the navigation panels, and optionally do without them

### DIFF
--- a/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/SettingsRepository.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/SettingsRepository.kt
@@ -377,6 +377,49 @@ class SettingsRepository(context: Context) {
         _navPanels.value = encoded
     }
 
+    /**
+     * Whether the panels live on a draggable ball over the content instead of in a bar or a rail.
+     *
+     * Off by default: the bar is what every other app on the device puts there, and a reader who
+     * has not asked for anything else should not have to work out where their panels went. It is
+     * offered at all because the bar costs a strip of every screen for four items that are rarely
+     * touched, and on a small phone reading a log that strip is the expensive part.
+     */
+    private val _floatingNav = MutableStateFlow(prefs.getBoolean("floating_nav", false))
+    val floatingNav: StateFlow<Boolean> = _floatingNav.asStateFlow()
+
+    fun setFloatingNav(enabled: Boolean) {
+        prefs.edit().putBoolean("floating_nav", enabled).apply()
+        _floatingNav.value = enabled
+    }
+
+    /**
+     * Where the floating ball was left: which side it snapped to, and how far down it sits as a
+     * fraction of the window height.
+     *
+     * No flow, for the same reason the ambience adjustments have none: written straight through
+     * from a gesture and read once when the ball is composed, so a StateFlow would recompose the
+     * very thing being dragged on every frame of the drag. Persisted rather than remembered because
+     * somebody who moved the ball out of the way of what they were reading has made a decision
+     * about their thumb, and the host process is killed often enough that anything held in memory
+     * would put the ball back over the content within the hour.
+     *
+     * The side is stored, not the x position: the ball always snaps to an edge, so a coordinate
+     * would be a lie the moment the window is a different width — which, unfoldable and in
+     * landscape, it routinely is.
+     */
+    fun floatingNavAtEnd(): Boolean = prefs.getBoolean("floating_nav_at_end", true)
+
+    fun setFloatingNavAtEnd(atEnd: Boolean) {
+        prefs.edit().putBoolean("floating_nav_at_end", atEnd).apply()
+    }
+
+    fun floatingNavY(): Float = prefs.getFloat("floating_nav_y", 0.72f)
+
+    fun setFloatingNavY(fraction: Float) {
+        prefs.edit().putFloat("floating_nav_y", fraction).apply()
+    }
+
     fun setThemeMode(mode: String) {
         prefs.edit().putString("theme_mode", mode).apply()
         _themeMode.value = mode

--- a/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/SettingsRepository.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/SettingsRepository.kt
@@ -357,6 +357,26 @@ class SettingsRepository(context: Context) {
         _logTracesInline.value = inline
     }
 
+    // --- Navigation panels ---
+
+    /**
+     * Which panels the navigation container shows, in which order, and which are hidden.
+     *
+     * One delimited string rather than a set: `putStringSet` does not preserve order — the same
+     * fact `muted_updates` above relies on being harmless — and here the order is the whole point.
+     * Route keys rather than ordinals or class names, because R8 rewrites class names in a release
+     * build and an ordinal would silently mean a different panel the day a fifth one is added.
+     * Empty means "the catalogue as declared", which is what a fresh install has and what anyone
+     * who has never opened edit mode keeps. See NavPanels for the format.
+     */
+    private val _navPanels = MutableStateFlow(prefs.getString("nav_panels", "") ?: "")
+    val navPanels: StateFlow<String> = _navPanels.asStateFlow()
+
+    fun setNavPanels(encoded: String) {
+        prefs.edit().putString("nav_panels", encoded).apply()
+        _navPanels.value = encoded
+    }
+
     fun setThemeMode(mode: String) {
         prefs.edit().putString("theme_mode", mode).apply()
         _themeMode.value = mode

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/VectorApp.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/VectorApp.kt
@@ -1,14 +1,18 @@
 package org.matrix.vector.manager.ui
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldDefaults
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.material3.adaptive.navigationsuite.rememberNavigationSuiteScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.EntryProviderScope
@@ -16,6 +20,7 @@ import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
+import org.matrix.vector.manager.di.ServiceLocator
 import org.matrix.vector.manager.ui.navigation.FrameworkUpdate
 import org.matrix.vector.manager.ui.screens.update.FrameworkUpdateScreen
 import org.matrix.vector.manager.ui.navigation.Canary
@@ -23,6 +28,7 @@ import org.matrix.vector.manager.ui.screens.canary.CanaryScreen
 import org.matrix.vector.manager.ui.navigation.Troubleshoot
 import org.matrix.vector.manager.ui.screens.report.TroubleshootScreen
 import org.matrix.vector.manager.ui.navigation.DeepLink
+import org.matrix.vector.manager.ui.navigation.FloatingPanelNav
 import org.matrix.vector.manager.ui.navigation.LocalNavigator
 import org.matrix.vector.manager.ui.navigation.Navigator
 import org.matrix.vector.manager.ui.navigation.PanelBar
@@ -55,7 +61,10 @@ import org.matrix.vector.manager.ui.screens.web.WebScreen
  * has to work unfolded and in landscape regardless. The scaffold also owns where that container
  * sits, so the destinations below it are laid out beside or above it rather than under it.
  *
- * Which panels that container holds, in which order, is the reader's — see NavPanels.
+ * Which panels that container holds, in which order, is the reader's — see NavPanels — and there is
+ * a third arrangement it can take, a ball floating over the content with no container at all. The
+ * two are not independent: rearranging the panels needs something to rearrange, so edit mode always
+ * puts the container back for as long as it lasts.
  */
 @Composable
 fun VectorApp() {
@@ -85,6 +94,8 @@ fun VectorApp() {
     }
 
     CompositionLocalProvider(LocalNavigator provides navigator) {
+        val settings = ServiceLocator.settings
+        val floating by settings.floatingNav.collectAsStateWithLifecycle()
         val editing = navigator.editingPanels
         // The container shows only at the root of a panel. On a detail screen none of the items is
         // the current destination, and a navigation bar highlighting nothing is worse than none.
@@ -96,23 +107,31 @@ fun VectorApp() {
         val suiteState = rememberNavigationSuiteScaffoldState()
         LaunchedEffect(atRoot) { if (atRoot) suiteState.show() else suiteState.hide() }
 
-        // Computed rather than left to the scaffold's default because PanelBar has to be told which
-        // axis it is laying items along, and the scaffold keeps that decision to itself otherwise.
+        // Computed rather than left to the scaffold's default, for two reasons: the floating style
+        // forces None, which is what actually removes the container instead of hiding it, and
+        // PanelBar has to be told which axis it is laying items along. Entering edit mode overrules
+        // the floating setting for as long as it lasts — there is nothing to rearrange otherwise.
         val suiteType =
-            NavigationSuiteScaffoldDefaults.navigationSuiteType(currentWindowAdaptiveInfo())
+            if (floating && !editing) NavigationSuiteType.None
+            else NavigationSuiteScaffoldDefaults.navigationSuiteType(currentWindowAdaptiveInfo())
 
         NavigationSuiteScaffold(
             navigationItems = {
-                PanelBar(
-                    panels = navigator.panels,
-                    current = navigator.currentTopLevel,
-                    editing = editing,
-                    suiteType = suiteType,
-                    onSelect = { route -> navigator.switchTo(route) },
-                    onEdit = { navigator.editingPanels = true },
-                    onToggleHidden = { key, hidden -> navigator.setPanelHidden(key, hidden) },
-                    onMove = { from, to -> navigator.movePanel(from, to) },
-                )
+                // NavigationSuite's `when` over the type has no None branch and no else, so under
+                // None this slot is silently dropped along with the container. Skipping it here
+                // says so out loud rather than leaving a composable that never runs.
+                if (suiteType != NavigationSuiteType.None) {
+                    PanelBar(
+                        panels = navigator.panels,
+                        current = navigator.currentTopLevel,
+                        editing = editing,
+                        suiteType = suiteType,
+                        onSelect = { route -> navigator.switchTo(route) },
+                        onEdit = { navigator.editingPanels = true },
+                        onToggleHidden = { key, hidden -> navigator.setPanelHidden(key, hidden) },
+                        onMove = { from, to -> navigator.movePanel(from, to) },
+                    )
+                }
             },
             navigationSuiteType = suiteType,
             state = suiteState,
@@ -120,22 +139,37 @@ fun VectorApp() {
                 if (editing) PanelEditDone(onDone = { navigator.editingPanels = false })
             },
         ) {
-            NavDisplay(
-                backStack = navigator.backStack,
-                onBack = { navigator.back() },
-                // Naming any decorator replaces NavDisplay's default, which is the saveable-state
-                // one alone, so it is repeated here; the scene-setup decorator NavDisplay applies
-                // internally is untouched. The ViewModel one is what this list is for: it scopes a
-                // ViewModelStore per entry, so opening the scope editor for a second module builds
-                // a second ViewModel instead of reusing the first (they would otherwise share one
-                // default key under the activity's store).
-                entryDecorators =
-                    listOf(
-                        rememberSaveableStateHolderNavEntryDecorator(),
-                        rememberViewModelStoreNavEntryDecorator(),
-                    ),
-                entryProvider = entryProvider { registerRoutes(navigator) },
-            )
+            Box(Modifier.fillMaxSize()) {
+                NavDisplay(
+                    backStack = navigator.backStack,
+                    onBack = { navigator.back() },
+                    // Naming any decorator replaces NavDisplay's default, which is the
+                    // saveable-state one alone, so it is repeated here; the scene-setup decorator
+                    // NavDisplay applies internally is untouched. The ViewModel one is what this
+                    // list is for: it scopes a ViewModelStore per entry, so opening the scope
+                    // editor for a second module builds a second ViewModel instead of reusing the
+                    // first (they would otherwise share one default key under the activity's
+                    // store).
+                    entryDecorators =
+                        listOf(
+                            rememberSaveableStateHolderNavEntryDecorator(),
+                            rememberViewModelStoreNavEntryDecorator(),
+                        ),
+                    entryProvider = entryProvider { registerRoutes(navigator) },
+                )
+                // Last child of the Box so it draws over the destination, and inside the app window
+                // rather than in one of its own: parasitically this app is com.android.shell, which
+                // must never ask for SYSTEM_ALERT_WINDOW. It follows the same rule the container
+                // does — present at the root of a panel, gone on a detail screen that has its own
+                // back affordance.
+                if (floating && !editing && atRoot) {
+                    FloatingPanelNav(
+                        panels = navigator.panels,
+                        current = navigator.currentTopLevel,
+                        onSelect = { route -> navigator.switchTo(route) },
+                    )
+                }
+            }
         }
 
         // After the scaffold on purpose. Back callbacks are dispatched last-registered-first and

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/VectorApp.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/VectorApp.kt
@@ -1,14 +1,14 @@
 package org.matrix.vector.manager.ui
 
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
+import androidx.activity.compose.BackHandler
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldDefaults
 import androidx.compose.material3.adaptive.navigationsuite.rememberNavigationSuiteScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.EntryProviderScope
@@ -25,13 +25,14 @@ import org.matrix.vector.manager.ui.screens.report.TroubleshootScreen
 import org.matrix.vector.manager.ui.navigation.DeepLink
 import org.matrix.vector.manager.ui.navigation.LocalNavigator
 import org.matrix.vector.manager.ui.navigation.Navigator
+import org.matrix.vector.manager.ui.navigation.PanelBar
+import org.matrix.vector.manager.ui.navigation.PanelEditDone
 import org.matrix.vector.manager.ui.navigation.Scope
 import org.matrix.vector.manager.ui.navigation.StoreDetail
 import org.matrix.vector.manager.ui.navigation.CrashTrace
 import org.matrix.vector.manager.ui.navigation.LogTrace
 import org.matrix.vector.manager.ui.navigation.SystemStatus
 import org.matrix.vector.manager.ui.navigation.Web
-import org.matrix.vector.manager.ui.navigation.TOP_LEVEL_DESTINATIONS
 import org.matrix.vector.manager.ui.navigation.TopLevelRoute
 import org.matrix.vector.manager.ui.navigation.rememberNavigator
 import org.matrix.vector.manager.ui.screens.home.HomeScreen
@@ -53,6 +54,8 @@ import org.matrix.vector.manager.ui.screens.web.WebScreen
  * no longer lock itself to portrait or declare itself non-resizable on large screens, so the shell
  * has to work unfolded and in landscape regardless. The scaffold also owns where that container
  * sits, so the destinations below it are laid out beside or above it rather than under it.
+ *
+ * Which panels that container holds, in which order, is the reader's — see NavPanels.
  */
 @Composable
 fun VectorApp() {
@@ -82,7 +85,8 @@ fun VectorApp() {
     }
 
     CompositionLocalProvider(LocalNavigator provides navigator) {
-        // The bar shows only at the root of a tab. On a detail screen none of the four items is
+        val editing = navigator.editingPanels
+        // The container shows only at the root of a panel. On a detail screen none of the items is
         // the current destination, and a navigation bar highlighting nothing is worse than none.
         val atRoot = !navigator.canGoBack
 
@@ -92,22 +96,30 @@ fun VectorApp() {
         val suiteState = rememberNavigationSuiteScaffoldState()
         LaunchedEffect(atRoot) { if (atRoot) suiteState.show() else suiteState.hide() }
 
+        // Computed rather than left to the scaffold's default because PanelBar has to be told which
+        // axis it is laying items along, and the scaffold keeps that decision to itself otherwise.
+        val suiteType =
+            NavigationSuiteScaffoldDefaults.navigationSuiteType(currentWindowAdaptiveInfo())
+
         NavigationSuiteScaffold(
-            state = suiteState,
-            navigationSuiteItems = {
-                TOP_LEVEL_DESTINATIONS.forEach { destination ->
-                item(
-                    selected = navigator.currentTopLevel == destination.route,
-                    onClick = { navigator.switchTo(destination.route) },
-                    icon = { Icon(destination.icon, contentDescription = null) },
-                    // The label doubles as the item's accessibility name, so the icon above
-                    // carries no contentDescription of its own — otherwise TalkBack announces
-                    // every selected tab twice.
-                    label = { Text(stringResource(destination.labelRes)) },
+            navigationItems = {
+                PanelBar(
+                    panels = navigator.panels,
+                    current = navigator.currentTopLevel,
+                    editing = editing,
+                    suiteType = suiteType,
+                    onSelect = { route -> navigator.switchTo(route) },
+                    onEdit = { navigator.editingPanels = true },
+                    onToggleHidden = { key, hidden -> navigator.setPanelHidden(key, hidden) },
+                    onMove = { from, to -> navigator.movePanel(from, to) },
                 )
-            }
-        },
-    ) {
+            },
+            navigationSuiteType = suiteType,
+            state = suiteState,
+            primaryActionContent = {
+                if (editing) PanelEditDone(onDone = { navigator.editingPanels = false })
+            },
+        ) {
             NavDisplay(
                 backStack = navigator.backStack,
                 onBack = { navigator.back() },
@@ -125,9 +137,21 @@ fun VectorApp() {
                 entryProvider = entryProvider { registerRoutes(navigator) },
             )
         }
+
+        // After the scaffold on purpose. Back callbacks are dispatched last-registered-first and
+        // BackHandler registers from an effect, which run in composition order, so this one
+        // outranks the handler NavDisplay installs and edit mode ends before the stack is touched.
+        BackHandler(enabled = editing) { navigator.editingPanels = false }
     }
 }
 
+/**
+ * Every destination, registered.
+ *
+ * All four panels keep their entry whether or not the reader has hidden them. A saved stack names
+ * its keys by class, and entryProvider throws for one it was never given, so dropping the
+ * registration of a hidden panel would turn a stale saved stack into a crash.
+ */
 private fun EntryProviderScope<NavKey>.registerRoutes(navigator: Navigator) {
     entry<TopLevelRoute.Home> {
         HomeScreen(

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/navigation/FloatingPanelNav.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/navigation/FloatingPanelNav.kt
@@ -1,0 +1,577 @@
+package org.matrix.vector.manager.ui.navigation
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitLongPressOrCancellation
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.drag
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.absoluteOffset
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Apps
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.AbsoluteAlignment
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import kotlin.math.asin
+import kotlin.math.cos
+import kotlin.math.min
+import kotlin.math.roundToInt
+import kotlin.math.sin
+import kotlinx.coroutines.launch
+import org.matrix.vector.manager.R
+import org.matrix.vector.manager.di.ServiceLocator
+
+/** Drawn size of the ball, which is also its touch target — hence not smaller than 48dp. */
+private val BALL_SIZE = 52.dp
+
+/** How much clear space is left between the parked ball and the edge it is parked against. */
+private val BALL_INSET = 10.dp
+
+/** How far from the ball a panel comes to rest once the arc is open. */
+private val FAN_RADIUS = 116.dp
+
+private val FAN_ITEM_SIZE = 48.dp
+
+/** Wide enough for a panel name at `labelSmall`, and the width the arc is clamped by. */
+private val FAN_ITEM_WIDTH = 88.dp
+
+private val FAN_LABEL_GAP = 6.dp
+
+/** Room kept below a fanned panel for its name, so a label cannot land off the window. */
+private val FAN_LABEL_ROOM = 22.dp
+
+/** How far apart two panels sit on the arc when the window has room for the whole fan. */
+private val FAN_STEP = Math.toRadians(46.0).toFloat()
+
+/**
+ * How far off a panel's own direction the finger may point and still be pointing at it, as the
+ * cosine of that angle so the test is a dot product rather than an `atan2` per panel per event.
+ *
+ * Wider than half the step on purpose: neighbouring cones overlap and the nearest one wins, so the
+ * only thing this number really decides is how far the finger has to stray before it has chosen
+ * nothing at all.
+ */
+private val FAN_CONE = cos(Math.toRadians(32.0)).toFloat()
+
+/**
+ * Within this fraction of [FAN_RADIUS] of the ball, the finger has chosen nothing.
+ *
+ * There has to be somewhere to let go that does not navigate, or a held press that turned out to be
+ * a mistake would have no ending but an unwanted panel. Near the ball — where the finger already is
+ * when the arc opens — is the one place nobody reaches by accident on the way to a panel.
+ */
+private const val FAN_DEAD_ZONE = 0.45f
+
+/**
+ * The panels as a ball you can put where you like, for when there is no bar at all.
+ *
+ * Not a [androidx.compose.foundation.layout.BoxScope] extension and it takes no `Alignment`: it
+ * fills the space it is given and places the ball itself, because the arc has to know the window it
+ * must stay inside, and an alignment handed in from outside would describe the ball while telling
+ * this nothing about the room left around it.
+ *
+ * It is drawn inside the app window, as the last child of the shell's content Box. Never a `Popup`,
+ * never a `Dialog`, and above all never a system overlay: parasitically this app *is*
+ * `com.android.shell`, and a manager that asked for `SYSTEM_ALERT_WINDOW` would be asking the
+ * shell's uid for permission to draw over every other app on the device. A floating control is
+ * worth exactly none of that.
+ *
+ * It reads `WindowInsets.safeDrawing` itself, as bounds rather than as padding: with the navigation
+ * container set to `NavigationSuiteType.None` the scaffold consumes no insets at all, so nothing
+ * above this has reserved the system bars and the ball would otherwise park itself under the
+ * gesture handle. Bounds rather than padding because the tap that dismisses the open arc has to
+ * cover the whole window, insets included, while the ball itself must stay out of them.
+ *
+ * Two ways in, on purpose. Holding the ball blooms the arc and the same finger picks from it, which
+ * is the fast one; a plain tap latches the arc open so each panel is an ordinary target, which is
+ * the only one a screen reader can use. A drag-only selector is unreachable by touch exploration,
+ * so the latched path is not polish — it is the accessible path, and every fanned panel is its own
+ * focusable, clickable node with its own description rather than a hit test over one canvas.
+ */
+@Composable
+fun FloatingPanelNav(
+    panels: NavPanels,
+    current: TopLevelRoute,
+    onSelect: (TopLevelRoute) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val settings = ServiceLocator.settings
+    val haptics = LocalHapticFeedback.current
+    val density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
+    val rtl = layoutDirection == LayoutDirection.Rtl
+    val scope = rememberCoroutineScope()
+    // The gesture below outlives its recompositions — see the pointerInput keys — so the callback
+    // is read through a State rather than captured, or a release could call last frame's lambda.
+    val select by rememberUpdatedState(onSelect)
+
+    // Read once and written on release. The two accessors carry no flow precisely so that dragging
+    // the ball does not recompose the ball, and the value is only ever authored from here.
+    var atEnd by remember { mutableStateOf(settings.floatingNavAtEnd()) }
+    var yFraction by remember { mutableFloatStateOf(settings.floatingNavY()) }
+
+    var latched by remember { mutableStateOf(false) }
+    var held by remember { mutableStateOf(false) }
+    var highlighted by remember { mutableIntStateOf(-1) }
+    // True from the moment the arc starts to bloom until it has finished collapsing, which is what
+    // keeps the panels composed long enough to animate out instead of vanishing.
+    var fanned by remember { mutableStateOf(false) }
+    val open = held || latched
+
+    // Read inside placement and layer lambdas rather than during composition, so that dragging the
+    // ball re-places it without recomposing anything at all. The ball's own animation is created
+    // further down, where the window's shape is known.
+    val bloom = remember { Animatable(0f) }
+    val bloomSpec = MaterialTheme.motionScheme.fastSpatialSpec<Float>()
+    val settleSpec = MaterialTheme.motionScheme.defaultSpatialSpec<Offset>()
+
+    LaunchedEffect(open) {
+        if (open) {
+            fanned = true
+            bloom.animateTo(1f, bloomSpec)
+        } else {
+            bloom.animateTo(0f, bloomSpec)
+            fanned = false
+        }
+    }
+
+    // Ahead of NavDisplay's own handler because this composable is the shell content's last child
+    // and back callbacks fire last-registered-first: a latched arc closes before the stack moves.
+    BackHandler(enabled = latched) { latched = false }
+
+    // Every coordinate below is counted from the left of the window, because that is what the
+    // insets, the constraints and a pointer's own position are counted from. The alignment has to
+    // be the absolute one to match: Alignment.TopStart places a child against the *right* edge in
+    // an RTL locale, and values-ar makes that reachable. Which side the ball parks on is decided by
+    // `atEnd` against the layout direction, in one place, rather than by the layout mirroring it.
+    BoxWithConstraints(modifier.fillMaxSize(), contentAlignment = AbsoluteAlignment.TopLeft) {
+        val insets = WindowInsets.safeDrawing
+        val width = constraints.maxWidth.toFloat()
+        val height = constraints.maxHeight.toFloat()
+
+        val ballRadius = with(density) { BALL_SIZE.toPx() } / 2f
+        val ballInset = with(density) { BALL_INSET.toPx() }
+        val radius = with(density) { FAN_RADIUS.toPx() }
+        val itemRadius = with(density) { FAN_ITEM_SIZE.toPx() } / 2f
+        val itemHalfWidth = with(density) { FAN_ITEM_WIDTH.toPx() } / 2f
+        val labelRoom = with(density) { (FAN_LABEL_GAP + FAN_LABEL_ROOM).toPx() }
+
+        // Where the ball's centre may sit, and where a fanned panel's centre may sit. The second
+        // is the taller of the two allowances because a panel carries its name underneath it.
+        val ballBounds =
+            Rect(
+                left = insets.getLeft(density, layoutDirection) + ballInset + ballRadius,
+                top = insets.getTop(density) + ballInset + ballRadius,
+                right = width - insets.getRight(density, layoutDirection) - ballInset - ballRadius,
+                bottom = height - insets.getBottom(density) - ballInset - ballRadius,
+            )
+        val fanBounds =
+            Rect(
+                left = insets.getLeft(density, layoutDirection) + itemHalfWidth,
+                top = insets.getTop(density) + itemRadius,
+                right = width - insets.getRight(density, layoutDirection) - itemHalfWidth,
+                bottom = height - insets.getBottom(density) - itemRadius - labelRoom,
+            )
+
+        // Seeded during composition rather than from an effect, because an effect can land after
+        // the frame it was scheduled in has already drawn and the ball would flash in the corner
+        // of the window on the way to where it was left.
+        val ball =
+            remember {
+                Animatable(
+                    resting(ballBounds, atEnd != rtl, yFraction, height),
+                    Offset.VectorConverter,
+                )
+            }
+
+        // Keyed on the room available rather than on where the ball is: this is what puts it back
+        // after a rotation or a fold, which is exactly why the position is persisted as a side and
+        // a fraction rather than as a coordinate. A move by hand animates itself and must not be
+        // snapped out from under the finger, so `atEnd` is read here and not keyed on.
+        LaunchedEffect(ballBounds) {
+            ball.snapTo(resting(ballBounds, atEnd != rtl, yFraction, height))
+        }
+
+        val visible = panels.visible
+        val deadZone = radius * FAN_DEAD_ZONE
+
+        // One gesture loop rather than a stack of detectors. A long press, a tap and a drag on the
+        // same node cannot be split across `detectTapGestures` and `detectDragGestures`: the tap
+        // detector consumes everything from the moment its long press fires, which starves exactly
+        // the drag this needs to keep following afterwards.
+        val gesture =
+            Modifier.pointerInput(
+                visible,
+                ballBounds,
+                fanBounds,
+                radius,
+                width,
+                height,
+                layoutDirection,
+            ) {
+                // This block restarts whenever a key changes, which can happen in the middle of a
+                // press. The press it was in will never be released, so the hold it announced is
+                // released here instead — otherwise the arc stays bloomed with nothing left
+                // holding it and no gesture able to close it.
+                held = false
+                awaitEachGesture {
+                    val down = awaitFirstDown(requireUnconsumed = false)
+                    val longPress = awaitLongPressOrCancellation(down.id)
+
+                    if (longPress != null) {
+                        haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                        // Held before unlatched, never the other way round: the two are separate
+                        // writes, and dropping both for the instant between them would tell the
+                        // arc to collapse and then to bloom again on a press that never closed it.
+                        held = true
+                        latched = false
+                        highlighted = -1
+                        // The arc is a pure function of where the ball is, so the drawing below
+                        // and this hit test cannot describe different arcs. The ball does not move
+                        // while the arc is open, so one reading of it serves the whole gesture.
+                        val centre = ball.value
+                        val corner = Offset(centre.x - ballRadius, centre.y - ballRadius)
+                        val inward = if (atEnd != rtl) -1f else 1f
+                        val points = fanPoints(visible.size, centre, inward, radius, fanBounds)
+                        val released =
+                            drag(down.id) { change ->
+                                val hit = pick(points, centre, change.position + corner, deadZone)
+                                if (hit != highlighted) {
+                                    if (hit >= 0) {
+                                        haptics.performHapticFeedback(
+                                            HapticFeedbackType.SegmentTick
+                                        )
+                                    }
+                                    highlighted = hit
+                                }
+                                change.consume()
+                            }
+                        val chosen = highlighted
+                        held = false
+                        highlighted = -1
+                        // A cancelled gesture is not a choice. `drag` returns false when the
+                        // pointer was taken away rather than lifted, and navigating on that would
+                        // mean a panel opening because a phone call arrived.
+                        if (released && chosen in visible.indices) {
+                            haptics.performHapticFeedback(HapticFeedbackType.Confirm)
+                            select(visible[chosen].route)
+                        }
+                        return@awaitEachGesture
+                    }
+
+                    // Not a long press, which is two different gestures: the finger came up inside
+                    // the timeout, or it moved far enough to be dragging the ball. Whether the
+                    // pointer is still down is the only thing that tells them apart, and it is
+                    // still the current event that ended the wait.
+                    val moving = currentEvent.changes.firstOrNull { it.id == down.id }?.pressed
+                    if (moving != true) {
+                        latched = !latched
+                        haptics.performHapticFeedback(
+                            if (latched) HapticFeedbackType.ContextClick
+                            else HapticFeedbackType.ToggleOff
+                        )
+                        return@awaitEachGesture
+                    }
+
+                    latched = false
+                    // An absolute target rather than reading the animation back on every event:
+                    // the snaps are launched, and a base read inside one of them could be a frame
+                    // behind the finger.
+                    var target = ball.value
+                    drag(down.id) { change ->
+                        target = within(target + change.positionChange(), ballBounds)
+                        scope.launch { ball.snapTo(target) }
+                        change.consume()
+                    }
+                    val atRight = target.x > width / 2f
+                    atEnd = atRight != rtl
+                    yFraction = (target.y / height).coerceIn(0f, 1f)
+                    settings.setFloatingNavAtEnd(atEnd)
+                    settings.setFloatingNavY(yFraction)
+                    haptics.performHapticFeedback(HapticFeedbackType.ContextClick)
+                    scope.launch {
+                        ball.animateTo(resting(ballBounds, atRight, yFraction, height), settleSpec)
+                    }
+                }
+            }
+
+        // Composed before the ball and the panels so that it takes only the taps they do not, and
+        // present only while the arc is latched — the rest of the time every touch that is not on
+        // the ball itself belongs to the screen underneath.
+        if (latched) {
+            Box(
+                Modifier.fillMaxSize().pointerInput(Unit) {
+                    detectTapGestures { latched = false }
+                }
+            )
+        }
+
+        if (fanned) {
+            val centre = ball.value
+            val inward = if (atEnd != rtl) -1f else 1f
+            val points = fanPoints(visible.size, centre, inward, radius, fanBounds)
+            visible.forEachIndexed { index, destination ->
+                FanItem(
+                    destination = destination,
+                    selected = destination.route == current,
+                    highlighted = index == highlighted,
+                    // While the finger is picking, only the panel under it is named — four labels
+                    // at once would be four things to read on a gesture that is already decided.
+                    // Latched, nothing is under a finger, so every panel has to say what it is.
+                    labelled = latched || index == highlighted,
+                    onClick = {
+                        latched = false
+                        haptics.performHapticFeedback(HapticFeedbackType.Confirm)
+                        select(destination.route)
+                    },
+                    modifier =
+                        // absoluteOffset, like the ball's: these are window coordinates, and the
+                        // mirroring `offset` applies under RTL would put the arc on the far side
+                        // of the window from the ball it belongs to.
+                        Modifier.absoluteOffset {
+                                val grown = bloom.value
+                                val point = points[index]
+                                IntOffset(
+                                    (centre.x + (point.x - centre.x) * grown - itemHalfWidth)
+                                        .roundToInt(),
+                                    (centre.y + (point.y - centre.y) * grown - itemRadius)
+                                        .roundToInt(),
+                                )
+                            }
+                            .graphicsLayer { alpha = bloom.value },
+                )
+            }
+        }
+
+        val colors = MaterialTheme.colorScheme
+        val ballLabel =
+            stringResource(
+                if (latched) R.string.panels_ball_close else R.string.panels_ball_open
+            )
+        Surface(
+            shape = CircleShape,
+            color = if (open) colors.primary else colors.primaryContainer,
+            contentColor = if (open) colors.onPrimary else colors.onPrimaryContainer,
+            shadowElevation = 6.dp,
+            modifier =
+                Modifier.absoluteOffset {
+                        IntOffset(
+                            (ball.value.x - ballRadius).roundToInt(),
+                            (ball.value.y - ballRadius).roundToInt(),
+                        )
+                    }
+                    .size(BALL_SIZE)
+                    // The gesture above is invisible to touch exploration, so the node states its
+                    // own click action: performing it is what a screen reader's double tap does,
+                    // and it lands on the latched arc, which is the path that can then be walked.
+                    .semantics(mergeDescendants = true) {
+                        contentDescription = ballLabel
+                        role = Role.Button
+                        onClick {
+                            latched = !latched
+                            true
+                        }
+                    }
+                    .then(gesture),
+        ) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                // The surface above carries the description; announcing the glyph as well would
+                // name the same control twice.
+                Icon(Icons.Rounded.Apps, contentDescription = null, modifier = Modifier.size(26.dp))
+            }
+        }
+    }
+}
+
+/**
+ * One panel in the open arc.
+ *
+ * [highlighted] is the panel the finger is over, [selected] the one the app is already on, and the
+ * two have to be told apart without relying on colour: under Material You the hues come from the
+ * wallpaper, so the highlight also grows and the current panel also wears a ring.
+ */
+@Composable
+private fun FanItem(
+    destination: TopLevelDestination,
+    selected: Boolean,
+    highlighted: Boolean,
+    labelled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = MaterialTheme.colorScheme
+    val label = stringResource(destination.labelRes)
+    val lift by animateFloatAsState(if (highlighted) 1.18f else 1f, label = "panelLift")
+
+    Column(
+        modifier = modifier.width(FAN_ITEM_WIDTH),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Surface(
+            onClick = onClick,
+            shape = CircleShape,
+            color = if (highlighted) colors.primary else colors.surfaceContainerHigh,
+            contentColor = if (highlighted) colors.onPrimary else colors.onSurfaceVariant,
+            shadowElevation = if (highlighted) 8.dp else 3.dp,
+            border = if (selected) BorderStroke(2.dp, colors.primary) else null,
+            modifier =
+                Modifier.size(FAN_ITEM_SIZE).scale(lift).semantics {
+                    contentDescription = label
+                },
+        ) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Icon(destination.icon, contentDescription = null, modifier = Modifier.size(24.dp))
+            }
+        }
+        if (labelled) {
+            Spacer(Modifier.height(FAN_LABEL_GAP))
+            Text(
+                label,
+                style = MaterialTheme.typography.labelSmall,
+                color = if (highlighted) colors.primary else colors.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                // The circle above already carries this name as its description, so the text under
+                // it is decoration for the eyes and must not be read out a second time.
+                modifier = Modifier.clearAndSetSemantics {},
+            )
+        }
+    }
+}
+
+/**
+ * Where each panel's centre goes, in the coordinates of the whole overlay.
+ *
+ * Angles are measured from "straight inward" and positive downwards, so one piece of arithmetic
+ * serves both edges and the side the ball is parked on only decides which way [inward] points —
+ * `-1` from the right edge, `+1` from the left.
+ *
+ * The arc opens inward and stays inside [bounds] by construction rather than by clipping. How far
+ * it may reach up and down is turned into an angle first, the step between panels is narrowed until
+ * that many of them fit, and the whole fan is then tipped away from whichever edge is too close.
+ * A ball parked at the bottom of the window therefore fans upwards rather than fanning off-screen
+ * and having half its panels clamped into a heap in the corner.
+ */
+private fun fanPoints(
+    count: Int,
+    centre: Offset,
+    inward: Float,
+    radius: Float,
+    bounds: Rect,
+): List<Offset> {
+    if (count <= 0 || radius <= 0f) return emptyList()
+    val up = -asin(((centre.y - bounds.top) / radius).coerceIn(0f, 1f))
+    val down = asin(((bounds.bottom - centre.y) / radius).coerceIn(0f, 1f))
+    val step = if (count == 1) 0f else min(FAN_STEP, (down - up) / (count - 1))
+    val half = step * (count - 1) / 2f
+    val tilt = within(0f, up + half, down - half)
+    return List(count) { index ->
+        val angle = tilt + (index - (count - 1) / 2f) * step
+        // The arithmetic above already keeps the arc inside the window on any shape this app can
+        // be handed. These two calls are what make "never outside the window" true rather than
+        // merely overwhelmingly likely — a window narrower than the arc is wide has no honest
+        // answer, and a panel stacked on its neighbour is a better one than a panel nobody can see.
+        Offset(
+            within(centre.x + inward * radius * cos(angle), bounds.left, bounds.right),
+            within(centre.y + radius * sin(angle), bounds.top, bounds.bottom),
+        )
+    }
+}
+
+/**
+ * Which panel the finger at [at] is pointing at, or -1 for none.
+ *
+ * Direction rather than distance, so the panels behave as sectors around the ball: overshooting one
+ * still chooses it, which matters because the arc is drawn at a radius the thumb has to stretch to
+ * and a selector that only answered inside the circles would be a selector that missed.
+ */
+private fun pick(points: List<Offset>, centre: Offset, at: Offset, deadZone: Float): Int {
+    val reach = at - centre
+    val length = reach.getDistance()
+    if (length < deadZone) return -1
+    var best = -1
+    var closest = FAN_CONE
+    points.forEachIndexed { index, point ->
+        val toPanel = point - centre
+        val span = toPanel.getDistance()
+        if (span <= 0f) return@forEachIndexed
+        val alignment = (reach.x * toPanel.x + reach.y * toPanel.y) / (length * span)
+        if (alignment > closest) {
+            closest = alignment
+            best = index
+        }
+    }
+    return best
+}
+
+/** Where the ball sits when nobody is holding it: against one side, [fraction] of the way down. */
+private fun resting(bounds: Rect, atRight: Boolean, fraction: Float, height: Float): Offset =
+    Offset(
+        if (atRight) bounds.right else bounds.left,
+        within(fraction * height, bounds.top, bounds.bottom),
+    )
+
+/** [point] pulled inside [bounds], which is how a dragged ball is kept in its own window. */
+private fun within(point: Offset, bounds: Rect): Offset =
+    Offset(within(point.x, bounds.left, bounds.right), within(point.y, bounds.top, bounds.bottom))
+
+/**
+ * [value] pulled inside [low]..[high], tolerating the case where the two have met or crossed.
+ *
+ * `coerceIn` answers that case by throwing, and it is reachable here in two ordinary ways: a window
+ * shorter than the arc it is being asked to hold, and an arc whose room is exactly what it needs,
+ * where float arithmetic can leave the lower bound a hair above the upper one. Meeting in the
+ * middle is the only thing either case can mean.
+ */
+private fun within(value: Float, low: Float, high: Float): Float =
+    if (low < high) value.coerceIn(low, high) else (low + high) / 2f

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/navigation/NavPanels.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/navigation/NavPanels.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.Immutable
  * Which panels the navigation container shows, in which order, and which of them are hidden.
  *
  * Every rule the arrangement has to obey lives here rather than at the surfaces that display it, so
- * that the navigation container and the appearance sheet cannot each remember a different half of
+ * that the bar, the floating ball and the appearance sheet cannot each remember a different half of
  * it: [visible] is never empty, [start] is the first visible panel rather than Home, and
  * [withHidden] refuses to hide the last one standing. A surface that asks the right question here
  * cannot produce a state the rest of the app has no answer for.

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/navigation/NavPanels.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/navigation/NavPanels.kt
@@ -1,0 +1,119 @@
+package org.matrix.vector.manager.ui.navigation
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Which panels the navigation container shows, in which order, and which of them are hidden.
+ *
+ * Every rule the arrangement has to obey lives here rather than at the surfaces that display it, so
+ * that the navigation container and the appearance sheet cannot each remember a different half of
+ * it: [visible] is never empty, [start] is the first visible panel rather than Home, and
+ * [withHidden] refuses to hide the last one standing. A surface that asks the right question here
+ * cannot produce a state the rest of the app has no answer for.
+ *
+ * [order] holds every panel, hidden ones included. Hiding is the reader's opinion of the container
+ * and not a deletion — a panel that is not drawn still needs its route type and its NavDisplay
+ * registration, because a back stack saved before it was hidden still names it.
+ */
+@Immutable
+data class NavPanels(val order: List<TopLevelDestination>, val hidden: Set<String>) {
+
+    /** Every panel in the reader's order, hidden ones included — what edit mode shows. */
+    val all: List<TopLevelDestination> = order.ifEmpty { TOP_LEVEL_DESTINATIONS }
+
+    /**
+     * What the navigation container shows. Never empty.
+     *
+     * The `ifEmpty` is not reachable through [withHidden] or [decodeNavPanels], both of which
+     * refuse to leave nothing behind. It is here because a container with no items has no defined
+     * behaviour at all — Navigator.switchTo clears the stack before it adds, and NavDisplay has no
+     * empty-stack branch — and this is the one place that can promise it never happens.
+     */
+    val visible: List<TopLevelDestination> =
+        all.filterNot { it.key in hidden }.ifEmpty { all.take(1) }
+
+    /** The panel a cold start opens on, and the fallback for a root that is no longer shown. */
+    val start: TopLevelRoute = visible.first().route
+
+    fun isHidden(destination: TopLevelDestination): Boolean = destination.key in hidden
+
+    fun isVisible(route: TopLevelRoute): Boolean = visible.any { it.route == route }
+
+    /** False on the last visible panel: a badge that does nothing is never offered. */
+    fun canHide(destination: TopLevelDestination): Boolean =
+        !isHidden(destination) && visible.size > 1
+
+    /**
+     * Hide or restore the panel with this [key], or `this` when that would change nothing.
+     *
+     * The refusal to hide the last visible panel is enforced here rather than at the badge that
+     * asked, so that the screen-reader action, the appearance sheet and anything added later
+     * inherit the same answer [canHide] gives the badge instead of each re-deciding it.
+     */
+    fun withHidden(key: String, hide: Boolean): NavPanels {
+        if (all.none { it.key == key }) return this
+        if (hide == (key in hidden)) return this
+        if (hide && visible.size <= 1) return this
+        return copy(hidden = if (hide) hidden + key else hidden - key)
+    }
+
+    /**
+     * Move the panel at [from] to [to]. Both are indices into [all].
+     *
+     * Out-of-range or equal indices return `this` rather than throwing: a drag that ends where it
+     * started is the common case, and a gesture whose captured index went stale because the list
+     * changed underneath it must not take the app down.
+     */
+    fun withMoved(from: Int, to: Int): NavPanels {
+        if (from == to || from !in all.indices || to !in all.indices) return this
+        val moved = all.toMutableList()
+        moved.add(to, moved.removeAt(from))
+        return copy(order = moved)
+    }
+}
+
+/**
+ * The arrangement as one preference string: keys in order, comma separated, a hidden one prefixed
+ * with '!' — `"logs,home,!store,modules"`.
+ *
+ * One delimited string rather than a set of keys, because `putStringSet` does not preserve order
+ * and the order is the whole point. Route keys rather than ordinals or class names, because R8
+ * rewrites class names in a release build and an ordinal would silently mean a different panel the
+ * day a fifth one is declared.
+ */
+fun encodeNavPanels(panels: NavPanels): String =
+    panels.all.joinToString(",") { if (panels.isHidden(it)) "!${it.key}" else it.key }
+
+/**
+ * Total: any string at all decodes to a usable [NavPanels] — the empty one a fresh install has, one
+ * written by a build that knew a different set of panels, one edited by hand.
+ *
+ * Unknown and duplicate keys are dropped, and every entry of TOP_LEVEL_DESTINATIONS the string does
+ * not name is appended at the end and visible. That last rule is what makes a newly added panel
+ * appear for someone who arranged theirs a year ago, rather than being invisible to precisely the
+ * readers who care most about the arrangement. If what survives would hide everything, the first
+ * entry is un-hidden.
+ */
+fun decodeNavPanels(stored: String): NavPanels {
+    val order = mutableListOf<TopLevelDestination>()
+    val hidden = mutableSetOf<String>()
+    for (raw in stored.split(',')) {
+        val token = raw.trim()
+        val hide = token.startsWith('!')
+        val key = if (hide) token.substring(1) else token
+        val destination = TOP_LEVEL_DESTINATIONS.firstOrNull { it.key == key } ?: continue
+        if (order.any { it.key == key }) continue
+        order += destination
+        if (hide) hidden += key
+    }
+    // Appended rather than slotted back into its declared position: someone who has arranged their
+    // panels has said where the ones they know about go and has said nothing at all about this one,
+    // so the end is the only honest place for it.
+    for (destination in TOP_LEVEL_DESTINATIONS) {
+        if (order.none { it.key == destination.key }) order += destination
+    }
+    // The one invariant a stored string can break by itself, since nothing stops the file being
+    // edited or written by an older build than this one.
+    if (order.all { it.key in hidden }) hidden -= order.first().key
+    return NavPanels(order, hidden)
+}

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/navigation/Navigator.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/navigation/Navigator.kt
@@ -1,12 +1,21 @@
 package org.matrix.vector.manager.ui.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.rememberNavBackStack
+import org.matrix.vector.manager.data.repository.SettingsRepository
+import org.matrix.vector.manager.di.ServiceLocator
 
 /**
  * The back stack, as an object with intent-revealing operations.
@@ -16,16 +25,50 @@ import androidx.navigation3.runtime.rememberNavBackStack
  *
  * Switching tabs truncates to a single root entry, so the stack can never grow without bound and
  * system back leaves the app instead of retracing every tab that was visited.
+ *
+ * It owns the panel arrangement too, which is why every surface reaches for it as
+ * `LocalNavigator.current.panels`, and why there is no second CompositionLocal and no
+ * `rememberNavPanels` anywhere: a second source of truth is exactly what would let the bar, the
+ * ball and the appearance sheet disagree about which panels exist while the reader is rearranging
+ * them. The two writes are here for the same reason — the encoding has one home.
  */
 @Stable
-class Navigator(val backStack: NavBackStack<NavKey>) {
+class Navigator(
+    val backStack: NavBackStack<NavKey>,
+    private val panelsState: State<NavPanels>,
+    private val settings: SettingsRepository,
+) {
+
+    /** The reader's panels. A snapshot read, so a composable that touches it recomposes. */
+    val panels: NavPanels
+        get() = panelsState.value
+
+    /**
+     * Whether the navigation container is being rearranged.
+     *
+     * Transient by construction: a plain `mutableStateOf`, deliberately neither a
+     * `rememberSaveable` nor a preference. Coming back to the app days later to find it still in
+     * edit mode would be a puzzle, and the arrangement itself is already written the instant it
+     * changes, so there is nothing here worth restoring.
+     */
+    var editingPanels: Boolean by mutableStateOf(false)
 
     val current: NavKey?
         get() = backStack.lastOrNull()
 
-    /** Which bar item is highlighted — always the root of the stack. */
+    /**
+     * Which item is highlighted — the root of the stack, or the first visible panel.
+     *
+     * The visibility test is not made redundant by [reconcilePanels]: hiding the panel you are
+     * standing on recomposes the container before the effect that corrects the stack has run, and
+     * for that frame the root names something the container is no longer drawing. A bar that
+     * highlights nothing is worse than one highlighting the panel you are about to be moved to.
+     */
     val currentTopLevel: TopLevelRoute
-        get() = backStack.firstOrNull() as? TopLevelRoute ?: TopLevelRoute.Home
+        get() {
+            val root = backStack.firstOrNull() as? TopLevelRoute ?: return panels.start
+            return if (panels.isVisible(root)) root else panels.start
+        }
 
     val canGoBack: Boolean
         get() = backStack.size > 1
@@ -48,15 +91,52 @@ class Navigator(val backStack: NavBackStack<NavKey>) {
         backStack.removeAt(backStack.lastIndex)
         return true
     }
+
+    /** Hide or restore a panel, and persist it. [key] is a TopLevelDestination.key. */
+    fun setPanelHidden(key: String, hidden: Boolean) {
+        settings.setNavPanels(encodeNavPanels(panels.withHidden(key, hidden)))
+    }
+
+    /** Reorder, and persist it. Both indices are into [NavPanels.all]. */
+    fun movePanel(from: Int, to: Int) {
+        settings.setNavPanels(encodeNavPanels(panels.withMoved(from, to)))
+    }
+
+    /**
+     * Replace a root that names a panel which is no longer shown.
+     *
+     * This is one mechanism serving two stories that look unrelated: hiding the panel you are on
+     * moves you to the first visible one, and a stack restored from before a panel was hidden — a
+     * real state, since the stack survives process death both through SavedStateRegistry and
+     * through the hooker's per-activity Bundle cache — is corrected instead of leaving a container
+     * that highlights nothing.
+     *
+     * `backStack[0] = …` rather than clear() then add(): NavBackStack supports set(index, value),
+     * and emptying the list even for an instant hands NavDisplay a stack with no entries.
+     */
+    fun reconcilePanels() {
+        val root = backStack.firstOrNull() as? TopLevelRoute ?: return
+        if (!panels.isVisible(root)) backStack[0] = panels.start
+    }
 }
 
 val LocalNavigator = staticCompositionLocalOf<Navigator> { error("No Navigator in composition") }
 
 @Composable
 fun rememberNavigator(): Navigator {
+    val settings = ServiceLocator.settings
+    val stored = settings.navPanels.collectAsStateWithLifecycle()
+    // Derived rather than decoded on every recomposition: the string changes when a panel is
+    // dragged or hidden and at no other time, while everything that reads the panels reads them
+    // once per frame.
+    val panels = remember(stored) { derivedStateOf { decodeNavPanels(stored.value) } }
     // rememberNavBackStack persists across process death via SavedState, which matters here:
     // parasitically the manager's activity state is hand-managed by the zygisk hooker, so
-    // anything that relies on the system restoring it needs to survive that path too.
-    val backStack = rememberNavBackStack(TopLevelRoute.Home)
-    return remember(backStack) { Navigator(backStack) }
+    // anything that relies on the system restoring it needs to survive that path too. The first
+    // visible panel is the seed and only the seed — a restored stack skips it entirely, which is
+    // why the correction below is an effect that runs on every arrangement rather than a one-off.
+    val backStack = rememberNavBackStack(panels.value.start)
+    val navigator = remember(backStack, panels, settings) { Navigator(backStack, panels, settings) }
+    LaunchedEffect(navigator, panels.value) { navigator.reconcilePanels() }
+    return navigator
 }

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/navigation/PanelBar.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/navigation/PanelBar.kt
@@ -1,0 +1,516 @@
+package org.matrix.vector.manager.ui.navigation
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.absoluteOffset
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.Remove
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ShortNavigationBarItem
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.WideNavigationRailItem
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventTimeoutCancellationException
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.onLongClick
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import kotlin.math.abs
+import kotlin.math.roundToInt
+import org.matrix.vector.manager.R
+
+/** What is left of a hidden panel in edit mode: Material's disabled alpha, saying the same. */
+private const val HIDDEN_ALPHA = 0.38f
+
+/** How much the dragged item grows, so a finger is visibly carrying it rather than pushing it. */
+private const val DRAG_LIFT = 1.08f
+
+/**
+ * The four panels, as the navigation container's items.
+ *
+ * A plain composable, not a scope extension: the scaffold's `navigationItems` slot has no receiver,
+ * and whatever this emits becomes a direct child of ShortNavigationBar or WideNavigationRail. It
+ * must therefore emit its items as flat siblings — ShortNavigationBar measures every direct child
+ * as one equal-width slot, so wrapping the four in a Row would hand a single slot the whole bar.
+ *
+ * [editing] shows all four, hidden ones dimmed, with a badge and a drag; otherwise it shows
+ * [NavPanels.visible] and a long press asks for [onEdit]. Both index arguments of [onMove] are
+ * indices into [NavPanels.all], which is what [editing] is showing when a drag is possible at all.
+ */
+@Composable
+fun PanelBar(
+    panels: NavPanels,
+    current: TopLevelRoute,
+    editing: Boolean,
+    suiteType: NavigationSuiteType,
+    onSelect: (TopLevelRoute) -> Unit,
+    onEdit: () -> Unit,
+    onToggleHidden: (key: String, hidden: Boolean) -> Unit,
+    onMove: (from: Int, to: Int) -> Unit,
+) {
+    val horizontal = isHorizontal(suiteType)
+    val items = if (editing) panels.all else panels.visible
+    // Rebuilt whenever the arrangement it describes stops being the one on screen. A drag cannot
+    // outlive either change — leaving edit mode ends it, and the axis only flips on a rotation —
+    // so there is nothing in flight to lose, and a stale slot table is exactly how a reorder ends
+    // up dropping an item in the wrong place.
+    val drag = remember(items.size, horizontal) { PanelDrag(items.size) }
+
+    items.forEachIndexed { index, destination ->
+        PanelItem(
+            destination = destination,
+            index = index,
+            count = items.size,
+            selected = destination.route == current,
+            editing = editing,
+            hidden = panels.isHidden(destination),
+            canHide = panels.canHide(destination),
+            horizontal = horizontal,
+            drag = drag,
+            onSelect = { onSelect(destination.route) },
+            onEdit = onEdit,
+            onToggleHidden = { hidden -> onToggleHidden(destination.key, hidden) },
+            onMove = onMove,
+        )
+    }
+}
+
+/**
+ * The way out of edit mode that is not the back gesture.
+ *
+ * Goes in the scaffold's `primaryActionContent`, which the suite draws above a bar and as the
+ * header of a rail — the one place that is present on both axes without this having to know which
+ * it is on. A FloatingActionButton because that is what the slot is documented to hold; anything
+ * flatter reads as one more navigation item rather than as the way out.
+ */
+@Composable
+fun PanelEditDone(onDone: () -> Unit) {
+    val haptics = LocalHapticFeedback.current
+    FloatingActionButton(
+        onClick = {
+            haptics.performHapticFeedback(HapticFeedbackType.Confirm)
+            onDone()
+        }
+    ) {
+        Icon(Icons.Rounded.Check, contentDescription = stringResource(R.string.panels_done))
+    }
+}
+
+/**
+ * Whether [type] lays its items along the bottom of the window rather than down its side.
+ *
+ * The library's own `isNavigationBar` is private and NavigationSuiteType is a value class with no
+ * `values()`, so this is re-derived by comparison against the three bar values. Public so that
+ * VectorApp and this file cannot come to different answers about the same window.
+ */
+fun isHorizontal(type: NavigationSuiteType): Boolean =
+    type == NavigationSuiteType.ShortNavigationBarCompact ||
+        type == NavigationSuiteType.ShortNavigationBarMedium ||
+        type == NavigationSuiteType.NavigationBar
+
+/**
+ * One panel: the container's item, and in edit mode the badge and the drag over the top of it.
+ *
+ * The Box is the slot the container measured, so everything that has to move the whole item —
+ * [zIndex], the drag offset, the lift — goes on it, and everything that describes the panel itself
+ * goes on the item inside it. The badge is a later sibling than the item so that it wins the hit
+ * test over the item's own click.
+ */
+@Composable
+private fun PanelItem(
+    destination: TopLevelDestination,
+    index: Int,
+    count: Int,
+    selected: Boolean,
+    editing: Boolean,
+    hidden: Boolean,
+    canHide: Boolean,
+    horizontal: Boolean,
+    drag: PanelDrag,
+    onSelect: () -> Unit,
+    onEdit: () -> Unit,
+    onToggleHidden: (Boolean) -> Unit,
+    onMove: (from: Int, to: Int) -> Unit,
+) {
+    val haptics = LocalHapticFeedback.current
+    val name = stringResource(destination.labelRes)
+    val rearrange = stringResource(R.string.settings_rearrange_panels)
+    val moveEarlier = stringResource(R.string.panels_move_earlier)
+    val moveLater = stringResource(R.string.panels_move_later)
+
+    val dragged = drag.from == index
+    // Both are kept as State and read inside the placement and layer lambdas below rather than
+    // unwrapped here, so an animation frame re-places the item instead of recomposing it. LogPan
+    // keeps its pan offset the same way and for the same reason.
+    val lift = animateFloatAsState(if (dragged) DRAG_LIFT else 1f, label = "panelLift")
+    // Only the items the dragged one has crossed animate; the dragged one follows the finger
+    // exactly, which is the whole difference between carrying something and nudging it.
+    val shift = animateFloatAsState(drag.displacement(index), label = "panelShift")
+
+    // Two detectors on one node would fight — a drag detector swallows the long press it starts
+    // from — so the item runs exactly one of them, chosen by what it is currently for. Both are
+    // keyed on everything they close over, since a pointerInput block captures its lambda at its
+    // keys and a stale capture is how a drag ends up reordering the index it began at yesterday.
+    val slotGesture =
+        if (editing) {
+            Modifier.pointerInput(drag, index, horizontal, editing) {
+                detectDragGestures(
+                    onDragStart = { drag.start(index) },
+                    onDragEnd = {
+                        val from = drag.from
+                        val to = drag.to
+                        drag.cancel()
+                        if (from >= 0 && from != to) {
+                            haptics.performHapticFeedback(HapticFeedbackType.Confirm)
+                            onMove(from, to)
+                        }
+                    },
+                    onDragCancel = { drag.cancel() },
+                    onDrag = { change, amount ->
+                        change.consume()
+                        val along = if (horizontal) amount.x else amount.y
+                        if (drag.drag(along)) {
+                            haptics.performHapticFeedback(HapticFeedbackType.SegmentTick)
+                        }
+                    },
+                )
+            }
+        } else {
+            Modifier.pointerInput(index, editing) {
+                awaitPanelLongPress {
+                    haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                    onEdit()
+                }
+            }
+        }
+
+    Box(
+        modifier =
+            Modifier.zIndex(if (dragged) 1f else 0f)
+                // Ahead of the offset below it on purpose: an outer modifier is placed by the
+                // container and an inner one by it, so what is recorded here is the slot the bar
+                // or the rail assigned rather than wherever the finger has since dragged the item.
+                .then(
+                    if (!editing) Modifier
+                    else
+                        Modifier.onGloballyPositioned {
+                            val position = it.positionInParent()
+                            drag.reportSlot(index, if (horizontal) position.x else position.y)
+                        }
+                )
+                // absoluteOffset rather than offset: the displacements are computed from recorded
+                // positions and from a raw drag delta, both of which count pixels rightwards, and
+                // the mirroring `offset` applies in an RTL locale would undo exactly one of them.
+                .absoluteOffset {
+                    val along = if (drag.from == index) drag.offset else shift.value
+                    if (horizontal) IntOffset(along.roundToInt(), 0)
+                    else IntOffset(0, along.roundToInt())
+                }
+                .graphicsLayer {
+                    scaleX = lift.value
+                    scaleY = lift.value
+                }
+                .then(slotGesture),
+        contentAlignment = Alignment.Center,
+    ) {
+        val itemSemantics =
+            if (editing) {
+                // A drag is unreachable by touch exploration, so the two moves it can make are
+                // also offered as actions on the item a screen reader is already focused on.
+                Modifier.semantics {
+                    val moves = mutableListOf<CustomAccessibilityAction>()
+                    if (index > 0) {
+                        moves +=
+                            CustomAccessibilityAction(moveEarlier) {
+                                onMove(index, index - 1)
+                                true
+                            }
+                    }
+                    if (index < count - 1) {
+                        moves +=
+                            CustomAccessibilityAction(moveLater) {
+                                onMove(index, index + 1)
+                                true
+                            }
+                    }
+                    customActions = moves
+                }
+            } else {
+                // Declared rather than detected: the gesture above resolves the long press on the
+                // pointer, which touch exploration never delivers. Nothing on Android teaches
+                // long-press on a navigation bar anyway, so this label is the only place a screen
+                // reader is told the gesture exists at all.
+                Modifier.semantics {
+                    onLongClick(label = rearrange) {
+                        onEdit()
+                        true
+                    }
+                }
+            }
+        val itemModifier =
+            // The bar hands its slot a fixed size, and before this Box stood between them the item
+            // received that size directly; filling it back up keeps the whole slot tappable rather
+            // than only the icon and label in the middle of it. The rail measures loosely and gets
+            // no such modifier — filling there would stretch one item down the whole rail.
+            (if (horizontal) Modifier.fillMaxSize() else Modifier)
+                .graphicsLayer { alpha = if (hidden) HIDDEN_ALPHA else 1f }
+                .then(itemSemantics)
+        // The label doubles as the item's accessibility name, so the icon carries no
+        // contentDescription of its own — otherwise TalkBack announces every selected tab twice.
+        val icon: @Composable () -> Unit = { Icon(destination.icon, contentDescription = null) }
+        val label: @Composable () -> Unit = { Text(name) }
+        // Nothing to select while rearranging: a tap in edit mode is either the badge or the start
+        // of a drag, and moving to another panel underneath the arrangement being edited is not
+        // something anyone asked for.
+        val onClick: () -> Unit = { if (!editing) onSelect() }
+
+        if (horizontal) {
+            ShortNavigationBarItem(
+                selected = selected,
+                onClick = onClick,
+                icon = icon,
+                label = label,
+                modifier = itemModifier,
+            )
+        } else {
+            WideNavigationRailItem(
+                selected = selected,
+                onClick = onClick,
+                icon = icon,
+                label = label,
+                // The suite keeps its rail collapsed; an expanded item here would lay its label
+                // beside the icon in a rail that is not wide enough for it.
+                railExpanded = false,
+                modifier = itemModifier,
+            )
+        }
+
+        if (editing && (hidden || canHide)) {
+            PanelBadge(
+                hidden = hidden,
+                name = name,
+                onClick = {
+                    haptics.performHapticFeedback(HapticFeedbackType.ContextClick)
+                    onToggleHidden(!hidden)
+                },
+            )
+        }
+    }
+}
+
+/**
+ * The minus or plus at the corner of a panel being rearranged.
+ *
+ * Drawn at eighteen points and hit at twenty-four: it has to read as a mark on the item rather than
+ * as a second button beside it, and at 360dp each of four slots is around ninety, so the target it
+ * needs costs nothing. It is offered only where it does something — [NavPanels.canHide] answers
+ * that — because a badge that refuses is worse than no badge.
+ */
+@Composable
+private fun BoxScope.PanelBadge(hidden: Boolean, name: String, onClick: () -> Unit) {
+    val description =
+        stringResource(if (hidden) R.string.panels_show else R.string.panels_hide, name)
+    val container =
+        if (hidden) MaterialTheme.colorScheme.primaryContainer
+        else MaterialTheme.colorScheme.errorContainer
+    val content =
+        if (hidden) MaterialTheme.colorScheme.onPrimaryContainer
+        else MaterialTheme.colorScheme.onErrorContainer
+
+    Box(
+        modifier =
+            Modifier.align(Alignment.TopEnd)
+                .size(24.dp)
+                .clip(CircleShape)
+                .clickable(onClick = onClick)
+                .semantics { contentDescription = description },
+        contentAlignment = Alignment.Center,
+    ) {
+        Surface(
+            modifier = Modifier.size(18.dp),
+            shape = CircleShape,
+            color = container,
+            contentColor = content,
+            // Enough to lift it off the icon underneath without reading as a floating control.
+            shadowElevation = 2.dp,
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(
+                    if (hidden) Icons.Rounded.Add else Icons.Rounded.Remove,
+                    contentDescription = null,
+                    modifier = Modifier.size(12.dp),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Long press to enter edit mode, resolved on the initial pointer pass.
+ *
+ * `combinedClickable` on the slot is the obvious way and it does not work. The item inside carries
+ * its own `selectable`, which is the nearer node and therefore handles the release first, so a long
+ * press on Logs would open edit mode *and* switch to Logs. Watching the pointer on
+ * [PointerEventPass.Initial] gets ahead of it: nothing is consumed while the press might still turn
+ * out to be a tap — in which case the item's own click handles it, ripple and indicator and all —
+ * and everything from the moment the press has been held long enough is consumed, which is what
+ * cancels the click that would otherwise land on the way up.
+ *
+ * Timing it out by hand rather than through foundation's own `waitForLongPress`: that one takes the
+ * pass to watch, which is exactly what is wanted here, but it and its `LongPressResult` are
+ * `internal` — public in the bytecode, invisible to Kotlin.
+ */
+private suspend fun PointerInputScope.awaitPanelLongPress(onLongPress: () -> Unit) {
+    awaitEachGesture {
+        awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+        try {
+            withTimeout(viewConfiguration.longPressTimeoutMillis) {
+                waitForUpOrCancellation(PointerEventPass.Initial)
+            }
+            // Let go, or taken over by something else, before the press became a hold.
+            return@awaitEachGesture
+        } catch (_: PointerEventTimeoutCancellationException) {
+            onLongPress()
+        }
+        while (true) {
+            val event = awaitPointerEvent(PointerEventPass.Initial)
+            event.changes.forEach { it.consume() }
+            if (event.changes.none { it.pressed }) return@awaitEachGesture
+        }
+    }
+}
+
+/**
+ * A reorder in flight, shared by every item in the container.
+ *
+ * The axis never appears here. [PanelBar] hands over the one number that differs between a bottom
+ * bar and a rail — where each slot sits along whichever direction the container runs in — so the
+ * arithmetic below is written once and both layouts get the same behaviour rather than two
+ * implementations that drift.
+ *
+ * Slot positions rather than a single pitch, because the rail spaces its items apart and the bar
+ * does not: the distance between two recorded positions is right in both, whereas an item's own
+ * measured extent is short by the gap in the rail and would leave every shift a few points behind
+ * the finger.
+ */
+@Stable
+private class PanelDrag(count: Int) {
+
+    /** Which item is being carried, as an index into the displayed list, or -1 for none. */
+    var from by mutableIntStateOf(-1)
+        private set
+
+    /** Where it would land if the finger lifted now. */
+    var to by mutableIntStateOf(-1)
+        private set
+
+    /** How far it has travelled from its own slot. Read during placement, so no recomposition. */
+    var offset by mutableFloatStateOf(0f)
+        private set
+
+    // Deliberately not snapshot state: written from a layout callback and read from the gesture,
+    // never composed against. Observing them would invalidate the very layout pass that produced
+    // them — the same reason LogPan keeps its measured widths as plain fields.
+    private val slots = FloatArray(count)
+
+    private val active: Boolean
+        get() = from in slots.indices
+
+    /**
+     * Record where the container placed the item at [index].
+     *
+     * Ignored while a drag is running. The items are displaced then, and reading the displacement
+     * back in as the slot table would walk the targets along under the finger.
+     */
+    fun reportSlot(index: Int, position: Float) {
+        if (!active && index in slots.indices) slots[index] = position
+    }
+
+    fun start(index: Int) {
+        from = index
+        to = index
+        offset = 0f
+    }
+
+    /** Advance by [delta] pixels along the axis. True when the target slot changed. */
+    fun drag(delta: Float): Boolean {
+        if (!active) return false
+        offset += delta
+        val target = nearest(slots[from] + offset)
+        if (target == to) return false
+        to = target
+        return true
+    }
+
+    fun cancel() {
+        from = -1
+        to = -1
+        offset = 0f
+    }
+
+    /**
+     * How far the item at [index] is pushed aside by the drag in flight, in pixels along the axis.
+     *
+     * Every item the dragged one has crossed moves into the slot next to its own, and does so by
+     * the real distance between those two slots rather than by an assumed pitch, so an uneven
+     * arrangement lands as exactly as an even one.
+     */
+    fun displacement(index: Int): Float {
+        if (!active || index == from) return 0f
+        return when {
+            index in (from + 1)..to -> slots[index - 1] - slots[index]
+            index in to until from -> slots[index + 1] - slots[index]
+            else -> 0f
+        }
+    }
+
+    private fun nearest(position: Float): Int {
+        var best = 0
+        var bestDistance = Float.MAX_VALUE
+        for (index in slots.indices) {
+            val distance = abs(slots[index] - position)
+            if (distance < bestDistance) {
+                bestDistance = distance
+                best = index
+            }
+        }
+        return best
+    }
+}

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/navigation/Route.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/navigation/Route.kt
@@ -19,7 +19,19 @@ import org.matrix.vector.manager.R
  */
 @Serializable sealed interface Route : NavKey
 
-/** The four destinations in the navigation bar. Order here is the order on screen. */
+/**
+ * Every panel that exists, and the order a fresh install starts with.
+ *
+ * Not the order on screen: the reader's own order, and which panels they have hidden, live in
+ * SettingsRepository under `nav_panels` and are modelled by NavPanels. What is declared here is the
+ * catalogue and the default.
+ *
+ * Hiding a panel never removes it from this file. The back stack persists NavKeys by class name —
+ * NavKeySerializer resolves them with a bare `Class.forName` and has no fallback — and NavDisplay's
+ * entryProvider throws for a key it was never given, so a saved stack naming a panel that had been
+ * deleted would be a crash rather than a stale tab. Hiding is a fact about the navigation
+ * container, and about nothing else.
+ */
 @Serializable
 sealed interface TopLevelRoute : Route {
     @Serializable data object Home : TopLevelRoute
@@ -72,8 +84,15 @@ sealed interface TopLevelRoute : Route {
 /** GitHub, shown in the built-in viewer rather than handed to a browser. */
 @Serializable data class Web(val url: String) : Route
 
-/** Label and icon for a bar item. Titles come from resources; no hard-coded English. */
+/**
+ * Label and icon for a bar item. Titles come from resources; no hard-coded English.
+ *
+ * [key] is the only stable identity this type has, and so the only thing that is ever written to
+ * preferences: R8 rewrites class names in a release build, and an ordinal would quietly name a
+ * different panel the day a fifth one is declared. See NavPanels for what is stored.
+ */
 data class TopLevelDestination(
+    val key: String,
     val route: TopLevelRoute,
     val icon: ImageVector,
     val labelRes: Int,
@@ -81,10 +100,25 @@ data class TopLevelDestination(
 
 val TOP_LEVEL_DESTINATIONS: List<TopLevelDestination> =
     listOf(
-        TopLevelDestination(TopLevelRoute.Home, Icons.Rounded.Home, R.string.nav_home),
-        TopLevelDestination(TopLevelRoute.Modules, Icons.Rounded.Extension, R.string.nav_modules),
+        TopLevelDestination("home", TopLevelRoute.Home, Icons.Rounded.Home, R.string.nav_home),
+        TopLevelDestination(
+            "modules",
+            TopLevelRoute.Modules,
+            Icons.Rounded.Extension,
+            R.string.nav_modules,
+        ),
         // A cloud, not a shopfront. Nothing here is sold, and the tab's real subject is "modules
         // that live somewhere else and can be brought here".
-        TopLevelDestination(TopLevelRoute.Store, Icons.Rounded.CloudDownload, R.string.nav_store),
-        TopLevelDestination(TopLevelRoute.Logs, Icons.Rounded.ReceiptLong, R.string.nav_logs),
+        TopLevelDestination(
+            "store",
+            TopLevelRoute.Store,
+            Icons.Rounded.CloudDownload,
+            R.string.nav_store,
+        ),
+        TopLevelDestination(
+            "logs",
+            TopLevelRoute.Logs,
+            Icons.Rounded.ReceiptLong,
+            R.string.nav_logs,
+        ),
     )

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/home/HomeAppearanceSheet.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/home/HomeAppearanceSheet.kt
@@ -27,11 +27,13 @@ import androidx.compose.material.icons.rounded.BrightnessAuto
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.Colorize
 import androidx.compose.material.icons.rounded.DarkMode
+import androidx.compose.material.icons.rounded.Dashboard
 import androidx.compose.material.icons.rounded.Dns
 import androidx.compose.material.icons.rounded.History
 import androidx.compose.material.icons.rounded.LightMode
 import androidx.compose.material.icons.rounded.OpenInBrowser
 import androidx.compose.material.icons.rounded.Palette
+import androidx.compose.material.icons.rounded.Reorder
 import androidx.compose.material.icons.rounded.Waves
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
@@ -63,6 +65,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.matrix.vector.manager.ui.theme.LocalizedOverlay
 import org.matrix.vector.manager.R
 import org.matrix.vector.manager.ui.components.ChoiceRow
+import org.matrix.vector.manager.ui.components.SheetAction
 import org.matrix.vector.manager.ui.components.SheetHeading
 import org.matrix.vector.manager.ui.components.StatusNote
 import org.matrix.vector.manager.ui.components.ToggleRow
@@ -70,6 +73,7 @@ import org.matrix.vector.manager.net.DohStatus
 import org.matrix.vector.manager.di.ServiceLocator
 import org.matrix.vector.manager.ui.components.ColorWheel
 import org.matrix.vector.manager.ui.components.ambience.AmbienceKind
+import org.matrix.vector.manager.ui.navigation.LocalNavigator
 import org.matrix.vector.manager.ui.theme.SeedScheme
 import org.matrix.vector.manager.ui.theme.ThemeMode
 
@@ -82,6 +86,14 @@ import org.matrix.vector.manager.ui.theme.ThemeMode
  * catch-all Settings screen at all: a screen that collects unrelated switches is where preferences
  * go to be forgotten, and every one of them has a place it actually belongs.
  *
+ * The navigation section stretches that rule the furthest and still keeps to it. Where the panels
+ * live is not a property of Home — but neither is the theme, and both answer the same question,
+ * which is what this app looks like. What is deliberately *not* here is the arrangement itself:
+ * panels are reordered on the navigation container, by long-pressing one, because a drag only means
+ * something where you can watch the others move aside. The row below is a way in rather than a
+ * second place to do it, and it has to exist because nothing on Android teaches that a navigation
+ * bar can be long-pressed at all.
+ *
  * Everything here takes effect immediately behind the sheet, which is the point of a sheet rather
  * than a screen: change the surface or the theme and you can watch it happen without losing your
  * place.
@@ -90,6 +102,10 @@ import org.matrix.vector.manager.ui.theme.ThemeMode
 @Composable
 fun HomeAppearanceSheet(onDismiss: () -> Unit) {
     val settings = ServiceLocator.settings
+    // Read out here rather than inside the sheet. A ModalBottomSheet is a subcomposition, so the
+    // locals VectorApp provides do reach into it, but the navigator is wanted for one callback and
+    // nothing about it changes between here and there.
+    val navigator = LocalNavigator.current
     val themeMode by settings.themeMode.collectAsStateWithLifecycle()
     val dynamicColor by settings.dynamicColor.collectAsStateWithLifecycle()
     val amoled by settings.amoledBlack.collectAsStateWithLifecycle()
@@ -194,6 +210,26 @@ LocalizedOverlay {
                     )
                 }
             }
+            HorizontalDivider(Modifier.padding(vertical = 8.dp))
+
+            SheetHeading(stringResource(R.string.settings_navigation), Icons.Rounded.Dashboard)
+            SheetAction(
+                title = stringResource(R.string.settings_rearrange_panels),
+                icon = Icons.Rounded.Reorder,
+                onClick = {
+                    // Edit mode and the dismissal in the one click, and deliberately without
+                    // animating the sheet out first: hiding it through its own sheetState would
+                    // leave this dialog's window, scrim and all, over the container for the length
+                    // of the animation, and the first thing anyone does in edit mode is drag an
+                    // item. Dropping the sheet out of composition takes its window with it in the
+                    // same frame the container enters edit mode, so the first touch that lands
+                    // lands on a panel.
+                    navigator.editingPanels = true
+                    onDismiss()
+                },
+                subtitle = stringResource(R.string.settings_rearrange_panels_summary),
+            )
+
             HorizontalDivider(Modifier.padding(vertical = 8.dp))
 
             // Here rather than under the Store's filters, where it used to sit. It was never a

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/home/HomeAppearanceSheet.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/home/HomeAppearanceSheet.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material.icons.rounded.BrightnessAuto
+import androidx.compose.material.icons.rounded.BubbleChart
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.Colorize
 import androidx.compose.material.icons.rounded.DarkMode
@@ -92,7 +93,8 @@ import org.matrix.vector.manager.ui.theme.ThemeMode
  * panels are reordered on the navigation container, by long-pressing one, because a drag only means
  * something where you can watch the others move aside. The row below is a way in rather than a
  * second place to do it, and it has to exist because nothing on Android teaches that a navigation
- * bar can be long-pressed at all.
+ * bar can be long-pressed at all — and with the floating style on, there is no bar left to try it
+ * on.
  *
  * Everything here takes effect immediately behind the sheet, which is the point of a sheet rather
  * than a screen: change the surface or the theme and you can watch it happen without losing your
@@ -111,6 +113,7 @@ fun HomeAppearanceSheet(onDismiss: () -> Unit) {
     val amoled by settings.amoledBlack.collectAsStateWithLifecycle()
     val seed by settings.seedColor.collectAsStateWithLifecycle()
     val ambience by settings.headerAmbience.collectAsStateWithLifecycle()
+    val floating by settings.floatingNav.collectAsStateWithLifecycle()
     val contributorOrder by settings.contributorOrder.collectAsStateWithLifecycle()
     val resolvedDark =
         when (ThemeMode.from(themeMode)) {
@@ -213,6 +216,13 @@ LocalizedOverlay {
             HorizontalDivider(Modifier.padding(vertical = 8.dp))
 
             SheetHeading(stringResource(R.string.settings_navigation), Icons.Rounded.Dashboard)
+            ToggleRow(
+                title = stringResource(R.string.settings_floating_nav),
+                icon = Icons.Rounded.BubbleChart,
+                subtitle = stringResource(R.string.settings_floating_nav_summary),
+                checked = floating,
+                onCheckedChange = settings::setFloatingNav,
+            )
             SheetAction(
                 title = stringResource(R.string.settings_rearrange_panels),
                 icon = Icons.Rounded.Reorder,

--- a/manager/src/main/res/values-ar/strings.xml
+++ b/manager/src/main/res/values-ar/strings.xml
@@ -6,6 +6,14 @@
     <string name="nav_store">الفهرس</string>
     <string name="nav_logs">السجلات</string>
 
+    <string name="panels_done">تمّ</string>
+    <string name="panels_hide">إخفاء %1$s</string>
+    <string name="panels_show">إظهار %1$s</string>
+    <string name="panels_move_earlier">نقل إلى الأمام</string>
+    <string name="panels_move_later">نقل إلى الخلف</string>
+    <string name="panels_ball_open">فتح التنقّل</string>
+    <string name="panels_ball_close">إغلاق التنقّل</string>
+
     <string name="status_active">نشط</string>
     <string name="status_degraded">يحتاج فحصًا</string>
     <string name="status_inactive">غير مُفعَّل</string>
@@ -181,6 +189,12 @@
     <string name="ambience_circuit">دارة</string>
     <string name="ambience_matrix">مطر الشيفرة</string>
     <string name="ambience_none">ساكن</string>
+
+    <string name="settings_navigation">التنقّل</string>
+    <string name="settings_floating_nav">تنقّل عائم</string>
+    <string name="settings_floating_nav_summary">يستعيض عن الشريط بكرة صغيرة يمكن سحبها إلى أي مكان. المس مطوّلًا لنشر الأقسام، أو انقر لإبقائها مفتوحة.</string>
+    <string name="settings_rearrange_panels">إعادة ترتيب الأقسام</string>
+    <string name="settings_rearrange_panels_summary">غيّر ترتيبها، أو أخفِ ما لا تفتحه أبدًا.</string>
 
     <string name="settings_activity">تدفّق النشاط</string>
     <string name="settings_window">التاريخ المعروض في الرئيسية</string>

--- a/manager/src/main/res/values-de/strings.xml
+++ b/manager/src/main/res/values-de/strings.xml
@@ -6,6 +6,14 @@
     <string name="nav_store">Katalog</string>
     <string name="nav_logs">Protokolle</string>
 
+    <string name="panels_done">Fertig</string>
+    <string name="panels_hide">%1$s ausblenden</string>
+    <string name="panels_show">%1$s einblenden</string>
+    <string name="panels_move_earlier">Nach vorne verschieben</string>
+    <string name="panels_move_later">Nach hinten verschieben</string>
+    <string name="panels_ball_open">Navigation öffnen</string>
+    <string name="panels_ball_close">Navigation schließen</string>
+
     <string name="status_active">Aktiv</string>
     <string name="status_degraded">Prüfen nötig</string>
     <string name="status_inactive">Nicht aktiviert</string>
@@ -149,6 +157,12 @@
     <string name="ambience_circuit">Leiterbahnen</string>
     <string name="ambience_matrix">Coderegen</string>
     <string name="ambience_none">Ruhig</string>
+
+    <string name="settings_navigation">Navigation</string>
+    <string name="settings_floating_nav">Schwebende Navigation</string>
+    <string name="settings_floating_nav_summary">Ersetzt die Leiste durch einen kleinen Ball, den du überallhin ziehen kannst. Halte ihn gedrückt, um die Bereiche aufzufächern, oder tippe ihn an, damit sie offen bleiben.</string>
+    <string name="settings_rearrange_panels">Bereiche neu anordnen</string>
+    <string name="settings_rearrange_panels_summary">Ändere ihre Reihenfolge oder blende aus, was du nie öffnest.</string>
 
     <string name="settings_activity">Aktivitätsverlauf</string>
     <string name="settings_window">Auf der Startseite gezeigter Verlauf</string>

--- a/manager/src/main/res/values-es/strings.xml
+++ b/manager/src/main/res/values-es/strings.xml
@@ -6,6 +6,14 @@
     <string name="nav_store">Catálogo</string>
     <string name="nav_logs">Registros</string>
 
+    <string name="panels_done">Listo</string>
+    <string name="panels_hide">Ocultar %1$s</string>
+    <string name="panels_show">Mostrar %1$s</string>
+    <string name="panels_move_earlier">Mover antes</string>
+    <string name="panels_move_later">Mover después</string>
+    <string name="panels_ball_open">Abrir la navegación</string>
+    <string name="panels_ball_close">Cerrar la navegación</string>
+
     <string name="status_active">Activo</string>
     <string name="status_degraded">Revisar</string>
     <string name="status_inactive">Sin activar</string>
@@ -149,6 +157,12 @@
     <string name="ambience_circuit">Circuito</string>
     <string name="ambience_matrix">Lluvia de código</string>
     <string name="ambience_none">Quieta</string>
+
+    <string name="settings_navigation">Navegación</string>
+    <string name="settings_floating_nav">Navegación flotante</string>
+    <string name="settings_floating_nav_summary">Sustituye la barra por una pequeña bola que puedes arrastrar a donde quieras. Mantenla pulsada para desplegar las secciones, o tócala para dejarlas abiertas.</string>
+    <string name="settings_rearrange_panels">Reordenar las secciones</string>
+    <string name="settings_rearrange_panels_summary">Cambia su orden, u oculta las que nunca abres.</string>
 
     <string name="settings_activity">Actividad</string>
     <string name="settings_window">Historial mostrado en Inicio</string>

--- a/manager/src/main/res/values-fa/strings.xml
+++ b/manager/src/main/res/values-fa/strings.xml
@@ -6,6 +6,14 @@
     <string name="nav_store">فهرست</string>
     <string name="nav_logs">گزارش‌ها</string>
 
+    <string name="panels_done">انجام شد</string>
+    <string name="panels_hide">پنهان کردن %1$s</string>
+    <string name="panels_show">نمایش %1$s</string>
+    <string name="panels_move_earlier">انتقال به جلو</string>
+    <string name="panels_move_later">انتقال به عقب</string>
+    <string name="panels_ball_open">باز کردن ناوبری</string>
+    <string name="panels_ball_close">بستن ناوبری</string>
+
     <string name="status_active">فعال</string>
     <string name="status_degraded">نیازمند توجه</string>
     <string name="status_inactive">فعال نشده</string>
@@ -149,6 +157,12 @@
     <string name="ambience_circuit">مدار</string>
     <string name="ambience_matrix">باران کد</string>
     <string name="ambience_none">ساکن</string>
+
+    <string name="settings_navigation">ناوبری</string>
+    <string name="settings_floating_nav">ناوبری شناور</string>
+    <string name="settings_floating_nav_summary">نوار را با توپ کوچکی جایگزین می‌کند که می‌توانید هرجا بکشید. برای بادبزنی شدن بخش‌ها آن را نگه دارید، یا برای باز ماندنشان ضربه بزنید.</string>
+    <string name="settings_rearrange_panels">چیدمان دوبارهٔ بخش‌ها</string>
+    <string name="settings_rearrange_panels_summary">ترتیبشان را تغییر دهید، یا آن‌هایی را که هرگز باز نمی‌کنید پنهان کنید.</string>
 
     <string name="settings_activity">جریان فعالیت</string>
     <string name="settings_window">تاریخچهٔ نمایش‌داده‌شده در خانه</string>

--- a/manager/src/main/res/values-fr/strings.xml
+++ b/manager/src/main/res/values-fr/strings.xml
@@ -6,6 +6,14 @@
     <string name="nav_store">Catalogue</string>
     <string name="nav_logs">Journaux</string>
 
+    <string name="panels_done">Terminé</string>
+    <string name="panels_hide">Masquer %1$s</string>
+    <string name="panels_show">Afficher %1$s</string>
+    <string name="panels_move_earlier">Déplacer avant</string>
+    <string name="panels_move_later">Déplacer après</string>
+    <string name="panels_ball_open">Ouvrir la navigation</string>
+    <string name="panels_ball_close">Fermer la navigation</string>
+
     <string name="status_active">Actif</string>
     <string name="status_degraded">À vérifier</string>
     <string name="status_inactive">Non activé</string>
@@ -149,6 +157,12 @@
     <string name="ambience_circuit">Circuit</string>
     <string name="ambience_matrix">Pluie de code</string>
     <string name="ambience_none">Immobile</string>
+
+    <string name="settings_navigation">Navigation</string>
+    <string name="settings_floating_nav">Navigation flottante</string>
+    <string name="settings_floating_nav_summary">Remplace la barre par une petite boule que vous pouvez déplacer où vous voulez. Maintenez-la pour déployer les sections, ou touchez-la pour les garder ouvertes.</string>
+    <string name="settings_rearrange_panels">Réorganiser les sections</string>
+    <string name="settings_rearrange_panels_summary">Changez leur ordre, ou masquez celles que vous n\'ouvrez jamais.</string>
 
     <string name="settings_activity">Fil d\'activité</string>
     <string name="settings_window">Historique affiché sur l\'accueil</string>

--- a/manager/src/main/res/values-in/strings.xml
+++ b/manager/src/main/res/values-in/strings.xml
@@ -10,6 +10,14 @@
     <string name="nav_store">Katalog</string>
     <string name="nav_logs">Log</string>
 
+    <string name="panels_done">Selesai</string>
+    <string name="panels_hide">Sembunyikan %1$s</string>
+    <string name="panels_show">Tampilkan %1$s</string>
+    <string name="panels_move_earlier">Pindahkan ke depan</string>
+    <string name="panels_move_later">Pindahkan ke belakang</string>
+    <string name="panels_ball_open">Buka navigasi</string>
+    <string name="panels_ball_close">Tutup navigasi</string>
+
     <string name="status_active">Aktif</string>
     <string name="status_degraded">Perlu dicek</string>
     <string name="status_inactive">Belum diaktifkan</string>
@@ -145,6 +153,12 @@
     <string name="ambience_circuit">Sirkuit</string>
     <string name="ambience_matrix">Hujan kode</string>
     <string name="ambience_none">Diam</string>
+
+    <string name="settings_navigation">Navigasi</string>
+    <string name="settings_floating_nav">Navigasi mengambang</string>
+    <string name="settings_floating_nav_summary">Mengganti bilah dengan bola kecil yang bisa diseret ke mana saja. Tahan untuk mengembangkan panel, atau ketuk agar panel tetap terbuka.</string>
+    <string name="settings_rearrange_panels">Atur ulang panel</string>
+    <string name="settings_rearrange_panels_summary">Ubah urutannya, atau sembunyikan yang tidak pernah dibuka.</string>
 
     <string name="settings_activity">Umpan aktivitas</string>
     <string name="settings_window">Riwayat yang ditampilkan di Beranda</string>

--- a/manager/src/main/res/values-it/strings.xml
+++ b/manager/src/main/res/values-it/strings.xml
@@ -6,6 +6,14 @@
     <string name="nav_store">Catalogo</string>
     <string name="nav_logs">Log</string>
 
+    <string name="panels_done">Fatto</string>
+    <string name="panels_hide">Nascondi %1$s</string>
+    <string name="panels_show">Mostra %1$s</string>
+    <string name="panels_move_earlier">Sposta prima</string>
+    <string name="panels_move_later">Sposta dopo</string>
+    <string name="panels_ball_open">Apri la navigazione</string>
+    <string name="panels_ball_close">Chiudi la navigazione</string>
+
     <string name="status_active">Attivo</string>
     <string name="status_degraded">Da verificare</string>
     <string name="status_inactive">Non attivato</string>
@@ -149,6 +157,12 @@
     <string name="ambience_circuit">Circuito</string>
     <string name="ambience_matrix">Pioggia di codice</string>
     <string name="ambience_none">Ferma</string>
+
+    <string name="settings_navigation">Navigazione</string>
+    <string name="settings_floating_nav">Navigazione fluttuante</string>
+    <string name="settings_floating_nav_summary">Sostituisce la barra con una pallina che puoi trascinare dove vuoi. Tienila premuta per aprire a ventaglio le sezioni, o toccala per lasciarle aperte.</string>
+    <string name="settings_rearrange_panels">Riordina le sezioni</string>
+    <string name="settings_rearrange_panels_summary">Cambia il loro ordine, o nascondi quelle che non apri mai.</string>
 
     <string name="settings_activity">Attività</string>
     <string name="settings_window">Cronologia mostrata nella Home</string>

--- a/manager/src/main/res/values-iw/strings.xml
+++ b/manager/src/main/res/values-iw/strings.xml
@@ -10,6 +10,14 @@
     <string name="nav_store">קטלוג</string>
     <string name="nav_logs">יומנים</string>
 
+    <string name="panels_done">סיום</string>
+    <string name="panels_hide">הסתרת %1$s</string>
+    <string name="panels_show">הצגת %1$s</string>
+    <string name="panels_move_earlier">העברה קדימה</string>
+    <string name="panels_move_later">העברה אחורה</string>
+    <string name="panels_ball_open">פתיחת הניווט</string>
+    <string name="panels_ball_close">סגירת הניווט</string>
+
     <string name="status_active">פעיל</string>
     <string name="status_degraded">דורש בדיקה</string>
     <string name="status_inactive">לא הופעל</string>
@@ -169,6 +177,12 @@
     <string name="ambience_circuit">מעגל</string>
     <string name="ambience_matrix">גשם של קוד</string>
     <string name="ambience_none">דומם</string>
+
+    <string name="settings_navigation">ניווט</string>
+    <string name="settings_floating_nav">ניווט צף</string>
+    <string name="settings_floating_nav_summary">מחליף את הסרגל בכדור קטן שאפשר לגרור לכל מקום. לחיצה ארוכה פורשת את המקטעים במניפה, והקשה משאירה אותם פתוחים.</string>
+    <string name="settings_rearrange_panels">סידור המקטעים מחדש</string>
+    <string name="settings_rearrange_panels_summary">אפשר לשנות את סדרם, או להסתיר את מה שאף פעם לא נפתח.</string>
 
     <string name="settings_activity">זרם הפעילות</string>
     <string name="settings_window">ההיסטוריה שמוצגת בבית</string>

--- a/manager/src/main/res/values-ja/strings.xml
+++ b/manager/src/main/res/values-ja/strings.xml
@@ -6,6 +6,14 @@
     <string name="nav_store">カタログ</string>
     <string name="nav_logs">ログ</string>
 
+    <string name="panels_done">完了</string>
+    <string name="panels_hide">%1$s を非表示</string>
+    <string name="panels_show">%1$s を表示</string>
+    <string name="panels_move_earlier">前へ移動</string>
+    <string name="panels_move_later">後ろへ移動</string>
+    <string name="panels_ball_open">ナビゲーションを開く</string>
+    <string name="panels_ball_close">ナビゲーションを閉じる</string>
+
     <string name="status_active">有効</string>
     <string name="status_degraded">確認が必要</string>
     <string name="status_inactive">未有効化</string>
@@ -141,6 +149,12 @@
     <string name="ambience_circuit">回路</string>
     <string name="ambience_matrix">コードの雨</string>
     <string name="ambience_none">静止</string>
+
+    <string name="settings_navigation">ナビゲーション</string>
+    <string name="settings_floating_nav">フローティングナビゲーション</string>
+    <string name="settings_floating_nav_summary">バーの代わりに、どこへでもドラッグできる小さなボールを表示します。長押しするとパネルが扇状に開き、タップすると開いたままになります。</string>
+    <string name="settings_rearrange_panels">パネルを並べ替える</string>
+    <string name="settings_rearrange_panels_summary">並び順を変えたり、開かないものを隠したりできます。</string>
 
     <string name="settings_activity">活動フィード</string>
     <string name="settings_window">ホームに表示する期間</string>

--- a/manager/src/main/res/values-ko/strings.xml
+++ b/manager/src/main/res/values-ko/strings.xml
@@ -6,6 +6,14 @@
     <string name="nav_store">카탈로그</string>
     <string name="nav_logs">로그</string>
 
+    <string name="panels_done">완료</string>
+    <string name="panels_hide">%1$s 숨기기</string>
+    <string name="panels_show">%1$s 표시</string>
+    <string name="panels_move_earlier">앞으로 이동</string>
+    <string name="panels_move_later">뒤로 이동</string>
+    <string name="panels_ball_open">탐색 열기</string>
+    <string name="panels_ball_close">탐색 닫기</string>
+
     <string name="status_active">활성</string>
     <string name="status_degraded">확인 필요</string>
     <string name="status_inactive">활성화되지 않음</string>
@@ -141,6 +149,12 @@
     <string name="ambience_circuit">회로</string>
     <string name="ambience_matrix">코드 비</string>
     <string name="ambience_none">정지</string>
+
+    <string name="settings_navigation">탐색</string>
+    <string name="settings_floating_nav">플로팅 탐색</string>
+    <string name="settings_floating_nav_summary">막대 대신 어디로든 끌 수 있는 작은 공을 띄웁니다. 길게 누르면 패널이 부채꼴로 펼쳐지고, 탭하면 펼친 채로 유지됩니다.</string>
+    <string name="settings_rearrange_panels">패널 순서 바꾸기</string>
+    <string name="settings_rearrange_panels_summary">순서를 바꾸거나, 열지 않는 패널을 숨깁니다.</string>
 
     <string name="settings_activity">활동 피드</string>
     <string name="settings_window">홈에 표시할 기간</string>

--- a/manager/src/main/res/values-pl/strings.xml
+++ b/manager/src/main/res/values-pl/strings.xml
@@ -6,6 +6,14 @@
     <string name="nav_store">Katalog</string>
     <string name="nav_logs">Dzienniki</string>
 
+    <string name="panels_done">Gotowe</string>
+    <string name="panels_hide">Ukryj %1$s</string>
+    <string name="panels_show">Pokaż %1$s</string>
+    <string name="panels_move_earlier">Przesuń wcześniej</string>
+    <string name="panels_move_later">Przesuń później</string>
+    <string name="panels_ball_open">Otwórz nawigację</string>
+    <string name="panels_ball_close">Zamknij nawigację</string>
+
     <string name="status_active">Aktywny</string>
     <string name="status_degraded">Problemy</string>
     <string name="status_inactive">Nieaktywowany</string>
@@ -165,6 +173,12 @@
     <string name="ambience_circuit">Obwód</string>
     <string name="ambience_matrix">Deszcz kodu</string>
     <string name="ambience_none">Nieruchoma</string>
+
+    <string name="settings_navigation">Nawigacja</string>
+    <string name="settings_floating_nav">Pływająca nawigacja</string>
+    <string name="settings_floating_nav_summary">Zastępuje pasek małą kulką, którą można przeciągnąć w dowolne miejsce. Przytrzymaj ją, aby rozłożyć panele w wachlarz, albo dotknij, aby zostały otwarte.</string>
+    <string name="settings_rearrange_panels">Zmień kolejność paneli</string>
+    <string name="settings_rearrange_panels_summary">Zmień ich kolejność albo ukryj te, których nigdy nie otwierasz.</string>
 
     <string name="settings_activity">Strumień aktywności</string>
     <string name="settings_window">Historia pokazywana na stronie startowej</string>

--- a/manager/src/main/res/values-pt-rBR/strings.xml
+++ b/manager/src/main/res/values-pt-rBR/strings.xml
@@ -6,6 +6,14 @@
     <string name="nav_store">Catálogo</string>
     <string name="nav_logs">Registros</string>
 
+    <string name="panels_done">Concluído</string>
+    <string name="panels_hide">Ocultar %1$s</string>
+    <string name="panels_show">Mostrar %1$s</string>
+    <string name="panels_move_earlier">Mover para antes</string>
+    <string name="panels_move_later">Mover para depois</string>
+    <string name="panels_ball_open">Abrir a navegação</string>
+    <string name="panels_ball_close">Fechar a navegação</string>
+
     <string name="status_active">Ativo</string>
     <string name="status_degraded">Verificar</string>
     <string name="status_inactive">Não ativado</string>
@@ -149,6 +157,12 @@
     <string name="ambience_circuit">Circuito</string>
     <string name="ambience_matrix">Chuva de código</string>
     <string name="ambience_none">Parada</string>
+
+    <string name="settings_navigation">Navegação</string>
+    <string name="settings_floating_nav">Navegação flutuante</string>
+    <string name="settings_floating_nav_summary">Substitui a barra por uma bolinha que você pode arrastar para onde quiser. Mantenha-a pressionada para abrir as seções em leque, ou toque nela para deixá-las abertas.</string>
+    <string name="settings_rearrange_panels">Reorganizar as seções</string>
+    <string name="settings_rearrange_panels_summary">Mude a ordem delas, ou oculte as que você nunca abre.</string>
 
     <string name="settings_activity">Feed de atividade</string>
     <string name="settings_window">Histórico mostrado no Início</string>

--- a/manager/src/main/res/values-ru/strings.xml
+++ b/manager/src/main/res/values-ru/strings.xml
@@ -4,6 +4,14 @@
     <string name="nav_modules">Модули</string>
     <string name="nav_store">Репозиторий</string>
     <string name="nav_logs">Журнал</string>
+
+    <string name="panels_done">Готово</string>
+    <string name="panels_hide">Скрыть «%1$s»</string>
+    <string name="panels_show">Показать «%1$s»</string>
+    <string name="panels_move_earlier">Переместить вперёд</string>
+    <string name="panels_move_later">Переместить назад</string>
+    <string name="panels_ball_open">Открыть навигацию</string>
+    <string name="panels_ball_close">Закрыть навигацию</string>
     <string name="status_active">Активен</string>
     <string name="status_degraded">Проблемы</string>
     <string name="status_inactive">Не активирован</string>
@@ -152,6 +160,12 @@
     <string name="ambience_circuit">Схема</string>
     <string name="ambience_matrix">Цифровой дождь</string>
     <string name="ambience_none">Без анимации</string>
+    <string name="settings_navigation">Навигация</string>
+    <string name="settings_floating_nav">Плавающая навигация</string>
+    <string name="settings_floating_nav_summary">Заменяет панель навигации маленьким шариком, который можно перетащить куда угодно. Удерживайте его, чтобы развернуть разделы веером, или коснитесь, чтобы они остались открытыми.</string>
+    <string name="settings_rearrange_panels">Изменить порядок разделов</string>
+    <string name="settings_rearrange_panels_summary">Измените их порядок или скройте те, которые никогда не открываете.</string>
+
     <string name="settings_activity">Лента активности</string>
     <string name="settings_window">Период истории на главной</string>
     <plurals name="settings_window_months">

--- a/manager/src/main/res/values-tr/strings.xml
+++ b/manager/src/main/res/values-tr/strings.xml
@@ -6,6 +6,14 @@
     <string name="nav_store">Katalog</string>
     <string name="nav_logs">Günlükler</string>
 
+    <string name="panels_done">Bitti</string>
+    <string name="panels_hide">%1$s öğesini gizle</string>
+    <string name="panels_show">%1$s öğesini göster</string>
+    <string name="panels_move_earlier">Öne taşı</string>
+    <string name="panels_move_later">Arkaya taşı</string>
+    <string name="panels_ball_open">Gezinmeyi aç</string>
+    <string name="panels_ball_close">Gezinmeyi kapat</string>
+
     <string name="status_active">Etkin</string>
     <string name="status_degraded">Sorun var</string>
     <string name="status_inactive">Etkinleştirilmedi</string>
@@ -149,6 +157,12 @@
     <string name="ambience_circuit">Devre</string>
     <string name="ambience_matrix">Kod yağmuru</string>
     <string name="ambience_none">Durgun</string>
+
+    <string name="settings_navigation">Gezinme</string>
+    <string name="settings_floating_nav">Yüzen gezinme</string>
+    <string name="settings_floating_nav_summary">Çubuğu, istediğiniz yere sürükleyebileceğiniz küçük bir topla değiştirir. Panelleri yelpaze gibi açmak için basılı tutun, açık kalmaları için dokunun.</string>
+    <string name="settings_rearrange_panels">Panelleri yeniden düzenle</string>
+    <string name="settings_rearrange_panels_summary">Sıralarını değiştirin ya da hiç açmadıklarınızı gizleyin.</string>
 
     <string name="settings_activity">Hareket akışı</string>
     <string name="settings_window">Ana sayfada gösterilen geçmiş</string>

--- a/manager/src/main/res/values-uk/strings.xml
+++ b/manager/src/main/res/values-uk/strings.xml
@@ -6,6 +6,14 @@
     <string name="nav_store">Каталог</string>
     <string name="nav_logs">Журнали</string>
 
+    <string name="panels_done">Готово</string>
+    <string name="panels_hide">Сховати «%1$s»</string>
+    <string name="panels_show">Показати «%1$s»</string>
+    <string name="panels_move_earlier">Перемістити вперед</string>
+    <string name="panels_move_later">Перемістити назад</string>
+    <string name="panels_ball_open">Відкрити навігацію</string>
+    <string name="panels_ball_close">Закрити навігацію</string>
+
     <string name="status_active">Активний</string>
     <string name="status_degraded">Проблеми</string>
     <string name="status_inactive">Не активовано</string>
@@ -165,6 +173,12 @@
     <string name="ambience_circuit">Схема</string>
     <string name="ambience_matrix">Дощ із коду</string>
     <string name="ambience_none">Нерухома</string>
+
+    <string name="settings_navigation">Навігація</string>
+    <string name="settings_floating_nav">Плаваюча навігація</string>
+    <string name="settings_floating_nav_summary">Замінює панель навігації маленькою кулькою, яку можна перетягнути будь-куди. Утримуйте її, щоб розгорнути розділи віялом, або торкніться, щоб вони лишилися відкритими.</string>
+    <string name="settings_rearrange_panels">Змінити порядок розділів</string>
+    <string name="settings_rearrange_panels_summary">Змініть їхній порядок або сховайте ті, які ніколи не відкриваєте.</string>
 
     <string name="settings_activity">Стрічка активності</string>
     <string name="settings_window">Історія на головній</string>

--- a/manager/src/main/res/values-vi/strings.xml
+++ b/manager/src/main/res/values-vi/strings.xml
@@ -6,6 +6,14 @@
     <string name="nav_store">Kho mô-đun</string>
     <string name="nav_logs">Nhật ký</string>
 
+    <string name="panels_done">Xong</string>
+    <string name="panels_hide">Ẩn %1$s</string>
+    <string name="panels_show">Hiện %1$s</string>
+    <string name="panels_move_earlier">Chuyển lên trước</string>
+    <string name="panels_move_later">Chuyển ra sau</string>
+    <string name="panels_ball_open">Mở điều hướng</string>
+    <string name="panels_ball_close">Đóng điều hướng</string>
+
     <string name="status_active">Đang hoạt động</string>
     <string name="status_degraded">Cần kiểm tra</string>
     <string name="status_inactive">Chưa kích hoạt</string>
@@ -141,6 +149,12 @@
     <string name="ambience_circuit">Mạch điện</string>
     <string name="ambience_matrix">Mưa mã</string>
     <string name="ambience_none">Đứng yên</string>
+
+    <string name="settings_navigation">Điều hướng</string>
+    <string name="settings_floating_nav">Điều hướng nổi</string>
+    <string name="settings_floating_nav_summary">Thay thanh điều hướng bằng một quả bóng nhỏ có thể kéo tới bất kỳ đâu. Giữ để xòe các mục ra, hoặc chạm để giữ chúng mở.</string>
+    <string name="settings_rearrange_panels">Sắp xếp lại các mục</string>
+    <string name="settings_rearrange_panels_summary">Đổi thứ tự, hoặc ẩn những mục bạn không bao giờ mở.</string>
 
     <string name="settings_activity">Dòng hoạt động</string>
     <string name="settings_window">Lịch sử hiện ở trang chính</string>

--- a/manager/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/src/main/res/values-zh-rCN/strings.xml
@@ -6,6 +6,14 @@
     <string name="nav_store">仓库</string>
     <string name="nav_logs">日志</string>
 
+    <string name="panels_done">完成</string>
+    <string name="panels_hide">隐藏%1$s</string>
+    <string name="panels_show">显示%1$s</string>
+    <string name="panels_move_earlier">向前移动</string>
+    <string name="panels_move_later">向后移动</string>
+    <string name="panels_ball_open">打开导航</string>
+    <string name="panels_ball_close">关闭导航</string>
+
     <string name="status_active">已激活</string>
     <string name="status_degraded">异常</string>
     <string name="status_inactive">未激活</string>
@@ -141,6 +149,12 @@
     <string name="ambience_circuit">电路</string>
     <string name="ambience_matrix">代码雨</string>
     <string name="ambience_none">静止</string>
+
+    <string name="settings_navigation">导航</string>
+    <string name="settings_floating_nav">悬浮导航</string>
+    <string name="settings_floating_nav_summary">用一颗可以拖到任意位置的小球代替导航栏。按住小球会将面板扇形展开，轻点则让它们保持展开。</string>
+    <string name="settings_rearrange_panels">重新排列面板</string>
+    <string name="settings_rearrange_panels_summary">调整顺序，或隐藏从不打开的面板。</string>
 
     <string name="settings_activity">动态</string>
     <string name="settings_window">主页显示的历史范围</string>

--- a/manager/src/main/res/values-zh-rTW/strings.xml
+++ b/manager/src/main/res/values-zh-rTW/strings.xml
@@ -6,6 +6,14 @@
     <string name="nav_store">儲存庫</string>
     <string name="nav_logs">日誌</string>
 
+    <string name="panels_done">完成</string>
+    <string name="panels_hide">隱藏%1$s</string>
+    <string name="panels_show">顯示%1$s</string>
+    <string name="panels_move_earlier">向前移動</string>
+    <string name="panels_move_later">向後移動</string>
+    <string name="panels_ball_open">開啟導覽</string>
+    <string name="panels_ball_close">關閉導覽</string>
+
     <string name="status_active">已啟用</string>
     <string name="status_degraded">異常</string>
     <string name="status_inactive">未啟用</string>
@@ -141,6 +149,12 @@
     <string name="ambience_circuit">電路</string>
     <string name="ambience_matrix">程式碼雨</string>
     <string name="ambience_none">靜止</string>
+
+    <string name="settings_navigation">導覽</string>
+    <string name="settings_floating_nav">懸浮導覽</string>
+    <string name="settings_floating_nav_summary">用一顆可以拖到任意位置的小球取代導覽列。按住小球會將面板呈扇形展開，輕觸則讓它們保持展開。</string>
+    <string name="settings_rearrange_panels">重新排列面板</string>
+    <string name="settings_rearrange_panels_summary">調整順序，或隱藏從不開啟的面板。</string>
 
     <string name="settings_activity">動態</string>
     <string name="settings_window">主畫面顯示的歷史範圍</string>

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -15,6 +15,17 @@
     <string name="nav_store">Store</string>
     <string name="nav_logs">Logs</string>
 
+    <!-- Rearranging the panels, and the ball that can stand in for the bar -->
+    <string name="panels_done">Done</string>
+    <!-- Example: "Hide Store". The name is one of the four panels above. -->
+    <string name="panels_hide">Hide %1$s</string>
+    <string name="panels_show">Show %1$s</string>
+    <!-- Spoken actions while rearranging: a drag cannot be made with touch exploration on -->
+    <string name="panels_move_earlier">Move earlier</string>
+    <string name="panels_move_later">Move later</string>
+    <string name="panels_ball_open">Open navigation</string>
+    <string name="panels_ball_close">Close navigation</string>
+
     <!-- Framework status -->
     <string name="status_active">Active</string>
     <string name="status_degraded">Needs attention</string>
@@ -238,6 +249,11 @@
     <string name="ambience_circuit">Circuit</string>
     <string name="ambience_matrix">Code rain</string>
     <string name="ambience_none">Still</string>
+
+    <!-- Settings: where the panels live. Nothing on Android teaches a long press on a bar. -->
+    <string name="settings_navigation">Navigation</string>
+    <string name="settings_rearrange_panels">Rearrange panels</string>
+    <string name="settings_rearrange_panels_summary">Change their order, or hide the ones you never open.</string>
 
     <!-- Settings: activity feed -->
     <string name="settings_activity">Activity feed</string>

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -252,6 +252,8 @@
 
     <!-- Settings: where the panels live. Nothing on Android teaches a long press on a bar. -->
     <string name="settings_navigation">Navigation</string>
+    <string name="settings_floating_nav">Floating navigation</string>
+    <string name="settings_floating_nav_summary">Replaces the bar with a small ball you can drag anywhere. Hold it to fan the panels out, or tap it to keep them open.</string>
     <string name="settings_rearrange_panels">Rearrange panels</string>
     <string name="settings_rearrange_panels_summary">Change their order, or hide the ones you never open.</string>
 


### PR DESCRIPTION
Two commits:

- **Let the reader arrange the navigation panels** — long-press the navigation container to reorder or hide panels.
- **Offer a floating ball in place of the navigation bar** — an appearance-sheet option, off by default.

The second is separable: the first builds without `FloatingPanelNav.kt`, and reverting the second lands on the first with no conflicts.

## Arranging

Long-press any item to enter edit mode. Each panel gains a badge that hides or restores it; dragging reorders. All four are shown while editing, hidden ones dimmed — the only way to restore one. The last visible panel gets no hide badge, so one always remains. Works on the bar and the rail.

The appearance sheet gains a way in, since nothing on Android teaches that a navigation bar can be long-pressed.

## Floating ball

The suite type becomes `NavigationSuiteType.None`, so the container is never laid out and the strip it costs every screen returns as content. Long-press fans the visible panels into an arc, dragging highlights one, releasing navigates. A tap opens the same arc latched so each panel is an ordinary tappable target — required, as drag-to-select is invisible to TalkBack.

Drawn inside the app window, never a system overlay: parasitically this app is `com.android.shell`, which must not request `SYSTEM_ALERT_WINDOW`.

## Notes

Stored as one string of route keys with `!` marking hidden — `logs,home,!store,modules`. Not a `StringSet`, which does not preserve order; not ordinals or class names, since R8 rewrites class names and an ordinal shifts once a fifth panel is added. `decodeNavPanels` is total: unknown and duplicate keys are dropped, unnamed destinations appended visible.

Hiding is not deletion. `NavKeySerializer` resolves keys with a bare `Class.forName` and `entryProvider` throws for one it was never given, so a back stack saved before a panel was hidden would crash. Every route stays registered.

The start destination, the highlight fallback and a restored root are now the first *visible* panel. `currentTopLevel` keeps its own visibility test alongside `reconcilePanels`, as hiding the current panel recomposes the container a frame before the effect runs.

Three non-obvious points:

- `combinedClickable` cannot carry the long press. `ShortNavigationBarItem` applies `selectable()` internally and handles the release first, so a long press would also switch tab. A pointer-input state machine on the slot watches the Initial pass instead.
- The reorder measures from `onGloballyPositioned` rather than item size, as `WideNavigationRail` folds inter-item spacing into each item's size.
- The dragged item uses `absoluteOffset`; `offset` mirrors under RTL, which `values-ar` makes reachable.

## Testing

Pixel 7a emulator, API 36, via the debug demo host. Edit mode, hide, restore, reorder on both axes, the minimum-one-panel rule, hiding the current panel, back leaving edit mode, and the arrangement surviving a `force-stop`. For the ball: the latched arc, hold-and-drag selection, and arc bounds in landscape.

The rail required forcing `navigationSuiteType` in a throwaway build, as `currentWindowAdaptiveInfo()` ignores `wm size`/`wm density` overrides — the scaffold still selected a bar at `w1200dp-h1800dp`. Rail layout, edit mode and vertical drag are confirmed; the automatic switch on real large-screen hardware is untested.
