### PR TITLE
Load a legacy module into its own process again

### DIFF
--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/data/ConfigCache.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/data/ConfigCache.kt
@@ -270,6 +270,15 @@ object ConfigCache {
       }
 
       val newScopes = mutableMapOf<ProcessScope, MutableList<Module>>()
+
+      // A module can reach the same process by more than one route: self rows in two users each
+      // propagate into the other's, and the scope derived below can name a process a row named as
+      // well. Twice in the list is twice loaded, so every insertion goes through here.
+      fun addToScope(processName: String, uid: Int, module: Module) {
+        val modules = newScopes.getOrPut(ProcessScope(processName, uid)) { mutableListOf() }
+        if (modules.none { it === module }) modules.add(module)
+      }
+
       ModuleDatabase.enabledScopeRows().forEach { scopeRow ->
         val appPkg = scopeRow.appPackage
         val modPkg = scopeRow.modulePackage
@@ -278,7 +287,7 @@ object ConfigCache {
         val module = newModules[modPkg] ?: return@forEach
 
         if (appPkg == "system") {
-          newScopes.getOrPut(ProcessScope("system_server", 1000)) { mutableListOf() }.add(module)
+          addToScope("system_server", 1000, module)
           return@forEach
         }
 
@@ -291,21 +300,39 @@ object ConfigCache {
         val appUid = pkgInfo.applicationInfo!!.uid
 
         for (processName in processNames) {
-          val processScope = ProcessScope(processName, appUid)
-          newScopes.getOrPut(processScope) { mutableListOf() }.add(module)
+          addToScope(processName, appUid, module)
 
           if (modPkg == appPkg) {
             val appId = appUid % PER_USER_RANGE
             userManager?.getRealUsers()?.forEach { user ->
               val moduleUid = user.id * PER_USER_RANGE + appId
-              if (moduleUid != appUid) {
-                val moduleSelf = ProcessScope(processName, moduleUid)
-                newScopes.getOrPut(moduleSelf) { mutableListOf() }.add(module)
-              }
+              if (moduleUid != appUid) addToScope(processName, moduleUid, module)
             }
           }
         }
       }
+
+      // A legacy module reports being active by hooking a method in its own app, so it has to be
+      // in its own scope before it can say anything at all. The manager used to add that row on
+      // every save and hide it again on read; #796 dropped both halves, and every legacy module
+      // has reported itself inactive since (#816).
+      //
+      // Derived here rather than stored, so a configuration written by those builds needs no
+      // repair and nothing that replaces the scope table can drop it again. Legacy is the
+      // loader's own verdict, so a module built against API 101 keeps its own process to itself.
+      newModules.values
+          .filter { it.file?.legacy == true }
+          .forEach { module ->
+            userManager?.getRealUsers()?.forEach { user ->
+              val pkgInfo =
+                  packageManager?.getPackageInfoWithComponents(
+                      module.packageName, MATCH_ALL_FLAGS, user.id) ?: return@forEach
+              val moduleUid = pkgInfo.applicationInfo?.uid ?: return@forEach
+              pkgInfo.fetchProcesses().forEach { processName ->
+                addToScope(processName, moduleUid, module)
+              }
+            }
+          }
 
       // --- ATOMIC STATE SWAP ---
       //

--- a/manager/src/main/kotlin/org/matrix/vector/manager/data/model/AppInfo.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/data/model/AppInfo.kt
@@ -10,6 +10,14 @@ data class AppInfo(
     val isSystemApp: Boolean,
     val isGame: Boolean,
     val isSelectedInScope: Boolean,
+    /**
+     * In the scope without anyone having put it there, and not removable.
+     *
+     * Nothing in the scope table says so — the daemon derives this target while it rebuilds its
+     * configuration — so it is stamped on the row by the screen that knows the rule, exactly as
+     * [isSelectedInScope] and [isRecommended] are.
+     */
+    val isImplicitInScope: Boolean = false,
     val isRecommended: Boolean,
     /** When the package was last installed or updated, for the "recently updated" sort. */
     val lastUpdateTime: Long,

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/modules/ScopeScreen.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/modules/ScopeScreen.kt
@@ -427,16 +427,26 @@ fun ScopeScreen(
                 items(apps, key = { "${it.packageName}:${it.userId}" }) { app ->
                     AppRow(
                         app = app,
-                        enabled = !state.recommended.staticScope,
+                        enabled = !state.recommended.staticScope && !app.isImplicitInScope,
                         origin =
                             when {
+                                app.isImplicitInScope -> ScopeOrigin.Derived
                                 state.recommended.staticScope && app.isRecommended ->
                                     ScopeOrigin.Locked
                                 app.isRecommended -> ScopeOrigin.Requested
                                 else -> ScopeOrigin.Chosen
                             },
-                        sharedNote =
-                            app.packageName == SYSTEM_FRAMEWORK_PACKAGE && state.multipleUsers,
+                        // The framework's note only on a device that has more than one user:
+                        // someone editing a work profile module's scope has no other way to know
+                        // that this target is not scoped to their profile, but on a single-user
+                        // phone it is a sentence about a distinction that does not exist.
+                        note =
+                            when {
+                                app.isImplicitInScope -> R.string.scope_self_hook
+                                app.packageName == SYSTEM_FRAMEWORK_PACKAGE &&
+                                    state.multipleUsers -> R.string.scope_framework_shared
+                                else -> null
+                            },
                         onToggle = { checked ->
                             haptics.performHapticFeedback(
                                 if (checked) HapticFeedbackType.ToggleOn
@@ -808,6 +818,13 @@ private enum class ScopeOrigin {
     Requested,
     /** Nothing asked for it; it is in the scope because someone ticked it. */
     Chosen,
+    /**
+     * The framework put it there, and no row in the scope table records it.
+     *
+     * A legacy module's own app: the daemon derives that target every time it rebuilds its
+     * configuration, so the tick is neither the user's nor the module's to give.
+     */
+    Derived,
 }
 
 @Composable
@@ -818,6 +835,9 @@ private fun ScopeOrigin.color(): Color =
         ScopeOrigin.Locked -> MaterialTheme.colorScheme.outline
         ScopeOrigin.Requested -> MaterialTheme.colorScheme.primary
         ScopeOrigin.Chosen -> Color.Transparent
+        // The same outline as Locked, and for the same reason: it is a tick nobody on this screen
+        // owns. The caption below it says which of the two kinds of "not yours" this one is.
+        ScopeOrigin.Derived -> MaterialTheme.colorScheme.outline
     }
 
 private fun ScopeOrigin.labelRes(): Int =
@@ -825,6 +845,7 @@ private fun ScopeOrigin.labelRes(): Int =
         ScopeOrigin.Locked -> R.string.scope_origin_locked
         ScopeOrigin.Requested -> R.string.scope_recommended
         ScopeOrigin.Chosen -> R.string.scope_origin_chosen
+        ScopeOrigin.Derived -> R.string.scope_origin_derived
     }
 
 @Composable
@@ -832,7 +853,14 @@ private fun AppRow(
     app: AppInfo,
     enabled: Boolean,
     origin: ScopeOrigin,
-    sharedNote: Boolean,
+    /**
+     * A sentence under the package name, for a row whose behaviour a label cannot carry.
+     *
+     * One slot rather than one flag per case: the two rows that have something to explain — the
+     * framework, and a legacy module's own app — are never the same row, and a boolean apiece
+     * would grow with every one that follows.
+     */
+    note: Int?,
     onToggle: (Boolean) -> Unit,
     onAction: (PackageActionResult) -> Unit,
 ) {
@@ -879,13 +907,12 @@ private fun AppRow(
                         color = ring,
                     )
                 }
-                // The one row on this screen that is not an app, and the one row offered
-                // identically to every user. Someone editing a work profile module's scope has no
-                // other way to know that this target is not scoped to their profile — but on a
-                // single-user device that is a sentence about a distinction that does not exist.
-                if (sharedNote) {
+                // Why this row does not behave like the rest: the framework is one process shared
+                // by every user, and a legacy module's own app is in the scope without anyone
+                // having put it there. Both are things a checkbox cannot say.
+                if (note != null) {
                     Text(
-                        text = stringResource(R.string.scope_framework_shared),
+                        text = stringResource(note),
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/modules/ScopeViewModel.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/modules/ScopeViewModel.kt
@@ -58,6 +58,16 @@ data class ScopeUiState(
      * about a distinction that does not exist, so it is not shown.
      */
     val multipleUsers: Boolean = false,
+    /**
+     * Whether the module is loaded into its own process whatever the scope table says.
+     *
+     * A legacy module reports being active by hooking a method in its own app, so it has to be in
+     * its own scope before it can say anything at all, and the daemon derives that one target
+     * rather than storing it. Nothing comes back from `getModuleScope` to say so — so without
+     * this, the one row the module certainly hooks is the one row shown unticked, and with the
+     * module filter at its default it is not shown at all.
+     */
+    val selfHooked: Boolean = false,
 )
 
 class ScopeViewModel(
@@ -225,6 +235,14 @@ class ScopeViewModel(
                 // the other few hundred apps beneath uncheckable checkboxes offered a choice that
                 // does not exist. This one stays absolute: there is no choice to preserve.
                 val locked = view.state.recommended.staticScope
+                // The row the daemon hooks whether or not the table names it. Matched on the user
+                // as well as the package: the same module in a work profile is another copy with
+                // its own row, and only the copy this screen is editing is the one being loaded
+                // into the process in front of it.
+                fun implicit(app: AppInfo) =
+                    view.state.selfHooked &&
+                        app.packageName == modulePackageName &&
+                        app.userId == userId
                 filters.apps
                     .asSequence()
                     .filter { app -> !locked || app.packageName in recommended }
@@ -236,7 +254,12 @@ class ScopeViewModel(
                         // An app already in the scope is never filtered away. Otherwise a default
                         // filter can hide a target the user deliberately chose, and the list then
                         // disagrees with what the module is actually hooking.
-                        val chosen = ScopeTarget(app.packageName, app.userId) in filters.draft
+                        // Derived counts as chosen throughout, so the module's own row survives
+                        // every filter — including the module filter, which is off by default and
+                        // would otherwise hide the row this whole exemption exists to show.
+                        val chosen =
+                            implicit(app) ||
+                                ScopeTarget(app.packageName, app.userId) in filters.draft
                         if (filters.recommendedOnly) {
                             // Answers one question — what does this module want, and what have I
                             // given it — and the other filters have no say in it. Chrome is a
@@ -262,7 +285,9 @@ class ScopeViewModel(
                     .map { app ->
                         app.copy(
                             isSelectedInScope =
-                                ScopeTarget(app.packageName, app.userId) in filters.draft,
+                                implicit(app) ||
+                                    ScopeTarget(app.packageName, app.userId) in filters.draft,
+                            isImplicitInScope = implicit(app),
                             isRecommended = app.packageName in recommended,
                         )
                     }
@@ -297,8 +322,14 @@ class ScopeViewModel(
                         // cannot be found by scrolling, so it has to lead the group it is being
                         // picked from — and once it is in the scope it is a member like any other,
                         // with no claim to sit above targets that are already in force.
+                        // A derived row is in force by definition: it is not waiting on an apply,
+                        // and grouping it with the newly ticked would promise a write that will
+                        // never happen.
                         val (inForce, newlyTicked) =
-                            chosen.partition { ScopeTarget(it.packageName, it.userId) in filters.saved }
+                            chosen.partition {
+                                it.isImplicitInScope ||
+                                    ScopeTarget(it.packageName, it.userId) in filters.saved
+                            }
                         inForce + frameworkFirst(newlyTicked) + frameworkFirst(rest)
                     }
             }
@@ -422,13 +453,15 @@ class ScopeViewModel(
                         }
                         .getOrNull()
                 }
-            val recommended =
+            // One inspection, two answers: what the module asks to hook, and which generation of
+            // module it is. Both come out of the same pass over the APK, and opening it is the
+            // expensive part.
+            val manifest =
                 info?.let {
-                    withContext(Dispatchers.IO) {
-                        val manifest = ModuleDetection.inspect(it, packageManager)
-                        RecommendedScope(manifest.scope, manifest.staticScope)
-                    }
-                } ?: RecommendedScope.NONE
+                    withContext(Dispatchers.IO) { ModuleDetection.inspect(it, packageManager) }
+                }
+            val recommended =
+                manifest?.let { RecommendedScope(it.scope, it.staticScope) } ?: RecommendedScope.NONE
 
             _uiState.value =
                 ScopeUiState(
@@ -440,6 +473,11 @@ class ScopeViewModel(
                     recommended = recommended,
                     loading = false,
                     multipleUsers = userCount > 1,
+                    // The manager's own reading of the APK, not the daemon's. The daemon settles
+                    // this while it loads the module and never tells anyone — and it only holds an
+                    // answer for a module that is enabled, which is precisely not the state a
+                    // module is in while its scope is being chosen for the first time.
+                    selfHooked = manifest?.isLegacy == true,
                 )
         }
     }
@@ -468,21 +506,33 @@ class ScopeViewModel(
 
     /** Local only. Nothing reaches the daemon until [apply]. */
     fun toggle(app: AppInfo, selected: Boolean) {
+        // A derived row is not the scope table's to give or to take away. Writing a row of our own
+        // for it would neither add the target — it is already there — nor let it be removed, and
+        // unticking it would draw an empty box beside a process the module is still loaded into.
+        if (app.isImplicitInScope) return
         val target = ScopeTarget(app.packageName, app.userId)
         draftScope.value =
             if (selected) draftScope.value + target else draftScope.value - target
     }
 
+    // Both skip the derived row for the reason [toggle] gives: it is shown among the visible rows
+    // but it is not one of the ones being written, and either of these sweeping it up would report
+    // a change to a row whose tick nothing here decides.
     fun selectAllVisible() {
         draftScope.value =
             draftScope.value +
-                filteredApps.value.map { ScopeTarget(it.packageName, it.userId) }
+                filteredApps.value
+                    .filterNot { it.isImplicitInScope }
+                    .map { ScopeTarget(it.packageName, it.userId) }
     }
 
     fun clearAllVisible() {
         draftScope.value =
             draftScope.value -
-                filteredApps.value.map { ScopeTarget(it.packageName, it.userId) }.toSet()
+                filteredApps.value
+                    .filterNot { it.isImplicitInScope }
+                    .map { ScopeTarget(it.packageName, it.userId) }
+                    .toSet()
     }
 
     /** Replace the draft with exactly what the module asked for. */

--- a/manager/src/main/res/values-ar/strings.xml
+++ b/manager/src/main/res/values-ar/strings.xml
@@ -256,6 +256,7 @@
     <string name="modules_scope_framework">يربط إطار النظام</string>
     <string name="scope_origin_locked">ثابت من الوحدة</string>
     <string name="scope_origin_chosen">اختيارك</string>
+    <string name="scope_origin_derived">دائمًا في النطاق</string>
     <string name="modules_selection_clear">إلغاء التحديد</string>
     <plurals name="modules_selected">
         <item quantity="zero">لم يُحدَّد شيء</item>
@@ -332,6 +333,7 @@
     <string name="store_mute_updates_summary">لن تُحتسب قديمة بعد الآن، لا هنا ولا في قائمة الوحدات</string>
     <string name="store_options">خيارات</string>
     <string name="scope_framework_shared">عملية واحدة يتشاركها جميع المستخدمين، لذا يؤثر هذا في الجهاز كله</string>
+    <string name="scope_self_hook">تُحمَّل هذه الوحدة داخل تطبيقها الخاص، وبهذا تُبلغ أنها فعّالة</string>
     <string name="update_no_output">لم يُخرج برنامج التثبيت أي شيء.</string>
     <string name="update_variant_release">نهائي</string>
     <string name="update_variant_debug">تنقيح</string>

--- a/manager/src/main/res/values-de/strings.xml
+++ b/manager/src/main/res/values-de/strings.xml
@@ -220,6 +220,7 @@
     <string name="modules_scope_framework">Hookt das System-Framework</string>
     <string name="scope_origin_locked">Vom Modul festgelegt</string>
     <string name="scope_origin_chosen">Deine Wahl</string>
+    <string name="scope_origin_derived">Immer im Geltungsbereich</string>
     <string name="modules_selection_clear">Auswahl aufheben</string>
     <plurals name="modules_selected">
         <item quantity="one">%1$d ausgewählt</item>
@@ -288,6 +289,7 @@
     <string name="store_mute_updates_summary">Es gilt hier und in der Modulliste nicht mehr als veraltet</string>
     <string name="store_options">Optionen</string>
     <string name="scope_framework_shared">Ein Prozess, den sich alle Benutzer teilen — das betrifft das ganze Gerät</string>
+    <string name="scope_self_hook">Dieses Modul wird in seine eigene App geladen — so meldet es, dass es aktiv ist</string>
     <string name="update_no_output">Das Installationsprogramm hat nichts ausgegeben.</string>
     <string name="update_variant_release">Release</string>
     <string name="update_variant_debug">Debug</string>

--- a/manager/src/main/res/values-es/strings.xml
+++ b/manager/src/main/res/values-es/strings.xml
@@ -220,6 +220,7 @@
     <string name="modules_scope_framework">Hookea el framework del sistema</string>
     <string name="scope_origin_locked">Fijada por el módulo</string>
     <string name="scope_origin_chosen">Tu elección</string>
+    <string name="scope_origin_derived">Siempre en el ámbito</string>
     <string name="modules_selection_clear">Borrar la selección</string>
     <plurals name="modules_selected">
         <item quantity="one">%1$d seleccionado</item>
@@ -288,6 +289,7 @@
     <string name="store_mute_updates_summary">Deja de contar como desactualizado, aquí y en la lista de módulos</string>
     <string name="store_options">Opciones</string>
     <string name="scope_framework_shared">Un único proceso compartido por todos los usuarios: afecta a todo el dispositivo</string>
+    <string name="scope_self_hook">Este módulo se carga en su propia app: así es como informa de que está activo</string>
     <string name="update_no_output">El instalador no produjo ninguna salida.</string>
     <string name="update_variant_release">Estable</string>
     <string name="update_variant_debug">Depuración</string>

--- a/manager/src/main/res/values-fa/strings.xml
+++ b/manager/src/main/res/values-fa/strings.xml
@@ -220,6 +220,7 @@
     <string name="modules_scope_framework">به چارچوب سامانه قلاب می‌زند</string>
     <string name="scope_origin_locked">ثابت‌شده از سوی ماژول</string>
     <string name="scope_origin_chosen">گزینش شما</string>
+    <string name="scope_origin_derived">همیشه در دامنه</string>
     <string name="modules_selection_clear">برداشتن گزینش</string>
     <plurals name="modules_selected">
         <item quantity="one">%1$d گزیده</item>
@@ -288,6 +289,7 @@
     <string name="store_mute_updates_summary">دیگر نه اینجا و نه در فهرست ماژول‌ها قدیمی شمرده نمی‌شود</string>
     <string name="store_options">گزینه‌ها</string>
     <string name="scope_framework_shared">یک فرایند که همهٔ کاربران در آن شریک‌اند، پس این کل دستگاه را تحت تأثیر می‌گذارد</string>
+    <string name="scope_self_hook">این ماژول در برنامهٔ خودش بارگذاری می‌شود و به همین شکل فعال‌بودنش را گزارش می‌کند</string>
     <string name="update_no_output">نصب‌کننده چیزی چاپ نکرد.</string>
     <string name="update_variant_release">نهایی</string>
     <string name="update_variant_debug">اشکال‌زدایی</string>

--- a/manager/src/main/res/values-fr/strings.xml
+++ b/manager/src/main/res/values-fr/strings.xml
@@ -220,6 +220,7 @@
     <string name="modules_scope_framework">Hooke le framework système</string>
     <string name="scope_origin_locked">Fixé par le module</string>
     <string name="scope_origin_chosen">Votre choix</string>
+    <string name="scope_origin_derived">Toujours dans la portée</string>
     <string name="modules_selection_clear">Effacer la sélection</string>
     <plurals name="modules_selected">
         <item quantity="one">%1$d sélectionné</item>
@@ -288,6 +289,7 @@
     <string name="store_mute_updates_summary">Il ne comptera plus comme obsolète, ici comme dans la liste des modules</string>
     <string name="store_options">Options</string>
     <string name="scope_framework_shared">Un seul processus partagé par tous les utilisateurs : cela concerne tout l\'appareil</string>
+    <string name="scope_self_hook">Ce module est chargé dans sa propre application : c\'est ainsi qu\'il signale qu\'il est actif</string>
     <string name="update_no_output">L\'installateur n\'a rien affiché.</string>
     <string name="update_variant_release">Version finale</string>
     <string name="update_variant_debug">Débogage</string>

--- a/manager/src/main/res/values-in/strings.xml
+++ b/manager/src/main/res/values-in/strings.xml
@@ -215,6 +215,7 @@
     <string name="modules_scope_framework">Meng-hook framework sistem</string>
     <string name="scope_origin_locked">Ditetapkan oleh modul</string>
     <string name="scope_origin_chosen">Pilihan Anda</string>
+    <string name="scope_origin_derived">Selalu dalam cakupan</string>
     <string name="modules_selection_clear">Batalkan pilihan</string>
     <plurals name="modules_selected">
         <item quantity="other">%1$d dipilih</item>
@@ -281,6 +282,7 @@
     <string name="store_mute_updates_summary">Ia berhenti dihitung usang, di sini maupun di daftar modul</string>
     <string name="store_options">Opsi</string>
     <string name="scope_framework_shared">Satu proses yang dipakai bersama semua pengguna, jadi ini memengaruhi seluruh perangkat</string>
+    <string name="scope_self_hook">Modul ini dimuat ke dalam aplikasinya sendiri, begitulah cara ia melaporkan bahwa dirinya aktif</string>
     <string name="update_no_output">Pemasang tidak mengeluarkan apa pun.</string>
     <string name="update_variant_release">Rilis</string>
     <string name="update_variant_debug">Debug</string>

--- a/manager/src/main/res/values-it/strings.xml
+++ b/manager/src/main/res/values-it/strings.xml
@@ -220,6 +220,7 @@
     <string name="modules_scope_framework">Aggancia il framework di sistema</string>
     <string name="scope_origin_locked">Fissata dal modulo</string>
     <string name="scope_origin_chosen">Scelta tua</string>
+    <string name="scope_origin_derived">Sempre nell\'ambito</string>
     <string name="modules_selection_clear">Annulla la selezione</string>
     <plurals name="modules_selected">
         <item quantity="one">%1$d selezionato</item>
@@ -288,6 +289,7 @@
     <string name="store_mute_updates_summary">Smette di contare come non aggiornato, qui e nell\'elenco dei moduli</string>
     <string name="store_options">Opzioni</string>
     <string name="scope_framework_shared">Un solo processo condiviso da tutti gli utenti: riguarda l\'intero dispositivo</string>
+    <string name="scope_self_hook">Questo modulo viene caricato nella sua stessa app: è così che segnala di essere attivo</string>
     <string name="update_no_output">Il programma di installazione non ha prodotto output.</string>
     <string name="update_variant_release">Stabile</string>
     <string name="update_variant_debug">Debug</string>

--- a/manager/src/main/res/values-iw/strings.xml
+++ b/manager/src/main/res/values-iw/strings.xml
@@ -242,6 +242,7 @@
     <string name="modules_scope_framework">מתחבר למסגרת המערכת</string>
     <string name="scope_origin_locked">נקבע על ידי המודול</string>
     <string name="scope_origin_chosen">הבחירה שלכם</string>
+    <string name="scope_origin_derived">תמיד בתחום</string>
     <string name="modules_selection_clear">ניקוי הבחירה</string>
     <plurals name="modules_selected">
         <item quantity="one">נבחר אחד</item>
@@ -314,6 +315,7 @@
     <string name="store_mute_updates_summary">הוא יפסיק להיחשב מיושן, כאן וברשימת המודולים</string>
     <string name="store_options">אפשרויות</string>
     <string name="scope_framework_shared">תהליך אחד שכל המשתמשים חולקים, ולכן זה משפיע על כל המכשיר</string>
+    <string name="scope_self_hook">המודול הזה נטען לתוך האפליקציה של עצמו, וכך הוא מדווח שהוא פעיל</string>
     <string name="update_no_output">תוכנית ההתקנה לא הדפיסה דבר.</string>
     <string name="update_variant_release">יציבה</string>
     <string name="update_variant_debug">ניפוי שגיאות</string>

--- a/manager/src/main/res/values-ja/strings.xml
+++ b/manager/src/main/res/values-ja/strings.xml
@@ -211,6 +211,7 @@
     <string name="modules_scope_framework">システムフレームワークをフック</string>
     <string name="scope_origin_locked">モジュールが固定</string>
     <string name="scope_origin_chosen">あなたの選択</string>
+    <string name="scope_origin_derived">常に適用範囲内</string>
     <string name="modules_selection_clear">選択を解除</string>
     <plurals name="modules_selected">
         <item quantity="other">%1$d 個選択中</item>
@@ -277,6 +278,7 @@
     <string name="store_mute_updates_summary">ここでもモジュール一覧でも、古いものとして数えられなくなります</string>
     <string name="store_options">オプション</string>
     <string name="scope_framework_shared">すべてのユーザーが共有する 1 つのプロセスなので、端末全体に影響します</string>
+    <string name="scope_self_hook">このモジュールは自分自身のアプリに読み込まれ、そうやって有効であることを伝えます</string>
     <string name="update_no_output">インストーラーは何も出力しませんでした。</string>
     <string name="update_variant_release">正式版</string>
     <string name="update_variant_debug">デバッグ版</string>

--- a/manager/src/main/res/values-ko/strings.xml
+++ b/manager/src/main/res/values-ko/strings.xml
@@ -211,6 +211,7 @@
     <string name="modules_scope_framework">시스템 프레임워크를 후킹함</string>
     <string name="scope_origin_locked">모듈이 고정함</string>
     <string name="scope_origin_chosen">직접 선택함</string>
+    <string name="scope_origin_derived">항상 적용 범위에 포함</string>
     <string name="modules_selection_clear">선택 해제</string>
     <plurals name="modules_selected">
         <item quantity="other">%1$d개 선택됨</item>
@@ -277,6 +278,7 @@
     <string name="store_mute_updates_summary">여기서도 모듈 목록에서도 더 이상 오래된 것으로 세지 않습니다</string>
     <string name="store_options">옵션</string>
     <string name="scope_framework_shared">모든 사용자가 함께 쓰는 하나의 프로세스라, 기기 전체에 영향을 줍니다</string>
+    <string name="scope_self_hook">이 모듈은 자기 앱에 로드되며, 그렇게 해서 활성 상태임을 알립니다</string>
     <string name="update_no_output">설치 프로그램이 아무것도 출력하지 않았습니다.</string>
     <string name="update_variant_release">정식</string>
     <string name="update_variant_debug">디버그</string>

--- a/manager/src/main/res/values-pl/strings.xml
+++ b/manager/src/main/res/values-pl/strings.xml
@@ -238,6 +238,7 @@
     <string name="modules_scope_framework">Podpina się pod szkielet systemu</string>
     <string name="scope_origin_locked">Ustalone przez moduł</string>
     <string name="scope_origin_chosen">Twój wybór</string>
+    <string name="scope_origin_derived">Zawsze w zakresie</string>
     <string name="modules_selection_clear">Wyczyść zaznaczenie</string>
     <plurals name="modules_selected">
         <item quantity="one">Zaznaczono %1$d</item>
@@ -310,6 +311,7 @@
     <string name="store_mute_updates_summary">Przestaje liczyć się jako nieaktualny, tutaj i na liście modułów</string>
     <string name="store_options">Opcje</string>
     <string name="scope_framework_shared">Jeden proces wspólny dla wszystkich użytkowników, więc dotyczy to całego urządzenia</string>
+    <string name="scope_self_hook">Ten moduł jest ładowany do własnej aplikacji i w ten sposób zgłasza, że działa</string>
     <string name="update_no_output">Instalator nie wypisał nic.</string>
     <string name="update_variant_release">Stabilna</string>
     <string name="update_variant_debug">Debug</string>

--- a/manager/src/main/res/values-pt-rBR/strings.xml
+++ b/manager/src/main/res/values-pt-rBR/strings.xml
@@ -220,6 +220,7 @@
     <string name="modules_scope_framework">Dá hook no framework do sistema</string>
     <string name="scope_origin_locked">Fixado pelo módulo</string>
     <string name="scope_origin_chosen">Escolha sua</string>
+    <string name="scope_origin_derived">Sempre no escopo</string>
     <string name="modules_selection_clear">Limpar a seleção</string>
     <plurals name="modules_selected">
         <item quantity="one">%1$d selecionado</item>
@@ -288,6 +289,7 @@
     <string name="store_mute_updates_summary">Ele deixa de contar como desatualizado, aqui e na lista de módulos</string>
     <string name="store_options">Opções</string>
     <string name="scope_framework_shared">Um único processo compartilhado por todos os usuários: isso afeta o aparelho inteiro</string>
+    <string name="scope_self_hook">Este módulo é carregado no próprio app: é assim que ele informa que está ativo</string>
     <string name="update_no_output">O instalador não produziu nenhuma saída.</string>
     <string name="update_variant_release">Estável</string>
     <string name="update_variant_debug">Depuração</string>

--- a/manager/src/main/res/values-ru/strings.xml
+++ b/manager/src/main/res/values-ru/strings.xml
@@ -220,6 +220,7 @@
     <string name="modules_scope_framework">Перехватывает системный фреймворк</string>
     <string name="scope_origin_locked">Задано модулем</string>
     <string name="scope_origin_chosen">Ваш выбор</string>
+    <string name="scope_origin_derived">Всегда в области действия</string>
     <string name="modules_selection_clear">Снять выделение</string>
     <plurals name="modules_selected">
         <item quantity="one">Выбран %1$d</item>
@@ -291,6 +292,7 @@
     <string name="store_mute_updates_summary">Он перестанет считаться устаревшим и здесь, и в списке модулей</string>
     <string name="store_options">Параметры</string>
     <string name="scope_framework_shared">Один процесс на всех пользователей — это затрагивает всё устройство</string>
+    <string name="scope_self_hook">Модуль загружается в собственное приложение — так он и сообщает, что активен</string>
     <string name="update_no_output">Установщик ничего не вывел.</string>
     <string name="update_variant_release">Стабильная</string>
     <string name="update_variant_debug">Отладочная</string>

--- a/manager/src/main/res/values-tr/strings.xml
+++ b/manager/src/main/res/values-tr/strings.xml
@@ -220,6 +220,7 @@
     <string name="modules_scope_framework">Sistem çatısına hook takar</string>
     <string name="scope_origin_locked">Modül tarafından sabitlendi</string>
     <string name="scope_origin_chosen">Sizin seçiminiz</string>
+    <string name="scope_origin_derived">Her zaman kapsamda</string>
     <string name="modules_selection_clear">Seçimi temizle</string>
     <plurals name="modules_selected">
         <item quantity="one">%1$d seçildi</item>
@@ -288,6 +289,7 @@
     <string name="store_mute_updates_summary">Ne burada ne de modül listesinde artık eski sayılır</string>
     <string name="store_options">Seçenekler</string>
     <string name="scope_framework_shared">Tüm kullanıcıların paylaştığı tek bir süreç, dolayısıyla bu cihazın tamamını etkiler</string>
+    <string name="scope_self_hook">Bu modül kendi uygulamasına yüklenir, etkin olduğunu böyle bildirir</string>
     <string name="update_no_output">Kurulum programı hiçbir çıktı üretmedi.</string>
     <string name="update_variant_release">Kararlı</string>
     <string name="update_variant_debug">Hata ayıklama</string>

--- a/manager/src/main/res/values-uk/strings.xml
+++ b/manager/src/main/res/values-uk/strings.xml
@@ -238,6 +238,7 @@
     <string name="modules_scope_framework">Перехоплює системний фреймворк</string>
     <string name="scope_origin_locked">Задано модулем</string>
     <string name="scope_origin_chosen">Ваш вибір</string>
+    <string name="scope_origin_derived">Завжди в області дії</string>
     <string name="modules_selection_clear">Зняти вибір</string>
     <plurals name="modules_selected">
         <item quantity="one">Вибрано %1$d</item>
@@ -310,6 +311,7 @@
     <string name="store_mute_updates_summary">Він перестане рахуватися застарілим — і тут, і в переліку модулів</string>
     <string name="store_options">Параметри</string>
     <string name="scope_framework_shared">Один процес, спільний для всіх користувачів, тож це стосується всього пристрою</string>
+    <string name="scope_self_hook">Цей модуль завантажується у власний застосунок — так він і повідомляє, що активний</string>
     <string name="update_no_output">Встановлювач нічого не вивів.</string>
     <string name="update_variant_release">Стабільна</string>
     <string name="update_variant_debug">Зневаджувальна</string>

--- a/manager/src/main/res/values-vi/strings.xml
+++ b/manager/src/main/res/values-vi/strings.xml
@@ -211,6 +211,7 @@
     <string name="modules_scope_framework">Hook framework hệ thống</string>
     <string name="scope_origin_locked">Do mô-đun cố định</string>
     <string name="scope_origin_chosen">Bạn chọn</string>
+    <string name="scope_origin_derived">Luôn trong phạm vi</string>
     <string name="modules_selection_clear">Bỏ chọn</string>
     <plurals name="modules_selected">
         <item quantity="other">Đã chọn %1$d</item>
@@ -277,6 +278,7 @@
     <string name="store_mute_updates_summary">Nó thôi bị tính là cũ, ở đây và trong danh sách mô-đun</string>
     <string name="store_options">Tuỳ chọn</string>
     <string name="scope_framework_shared">Một tiến trình dùng chung cho mọi người dùng, nên việc này ảnh hưởng toàn thiết bị</string>
+    <string name="scope_self_hook">Mô-đun này được nạp vào chính ứng dụng của nó, đó là cách nó báo rằng mình đang hoạt động</string>
     <string name="update_no_output">Trình cài đặt không xuất ra gì cả.</string>
     <string name="update_variant_release">Chính thức</string>
     <string name="update_variant_debug">Gỡ lỗi</string>

--- a/manager/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/src/main/res/values-zh-rCN/strings.xml
@@ -211,6 +211,7 @@
     <string name="modules_scope_framework">挂钩系统框架</string>
     <string name="scope_origin_locked">由模块固定</string>
     <string name="scope_origin_chosen">你的选择</string>
+    <string name="scope_origin_derived">始终在作用域内</string>
     <string name="modules_selection_clear">取消选择</string>
     <plurals name="modules_selected">
         <item quantity="other">已选 %1$d 个</item>
@@ -278,6 +279,7 @@
     <string name="store_mute_updates_summary">在此处与模块列表中都不再计为过期</string>
     <string name="store_options">选项</string>
     <string name="scope_framework_shared">所有用户共用的同一个进程，因此这会影响整台设备</string>
+    <string name="scope_self_hook">此模块会被加载到自己的应用中，它正是以此报告自己已生效</string>
     <string name="update_no_output">安装程序没有任何输出。</string>
     <string name="update_variant_release">正式版</string>
     <string name="update_variant_debug">调试版</string>

--- a/manager/src/main/res/values-zh-rTW/strings.xml
+++ b/manager/src/main/res/values-zh-rTW/strings.xml
@@ -211,6 +211,7 @@
     <string name="modules_scope_framework">掛鉤系統框架</string>
     <string name="scope_origin_locked">由模組固定</string>
     <string name="scope_origin_chosen">你的選擇</string>
+    <string name="scope_origin_derived">永遠在範圍內</string>
     <string name="modules_selection_clear">取消選取</string>
     <plurals name="modules_selected">
         <item quantity="other">已選取 %1$d 個</item>
@@ -278,6 +279,7 @@
     <string name="store_mute_updates_summary">在此處與模組列表中都不再計為過期</string>
     <string name="store_options">選項</string>
     <string name="scope_framework_shared">所有使用者共用的同一個行程，因此這會影響整台裝置</string>
+    <string name="scope_self_hook">此模組會載入自己的應用程式，它正是以此回報自己已生效</string>
     <string name="update_no_output">安裝程式沒有任何輸出。</string>
     <string name="update_variant_release">正式版</string>
     <string name="update_variant_debug">偵錯版</string>

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -313,6 +313,7 @@
     <string name="modules_scope_framework">Hooks the system framework</string>
     <string name="scope_origin_locked">Fixed by the module</string>
     <string name="scope_origin_chosen">Your choice</string>
+    <string name="scope_origin_derived">Always in scope</string>
     <string name="modules_selection_clear">Clear the selection</string>
     <plurals name="modules_selected">
         <item quantity="one">%1$d selected</item>
@@ -410,6 +411,7 @@
     <string name="store_mute_updates_summary">It stops counting as out of date, here and on the modules list</string>
     <string name="store_options">Options</string>
     <string name="scope_framework_shared">One process shared by every user, so this affects the whole device</string>
+    <string name="scope_self_hook">This module is loaded into its own app, which is how it reports that it is active</string>
     <string name="update_no_output">The installer produced no output.</string>
     <string name="update_variant_release">Release</string>
     <string name="update_variant_debug">Debug</string>


### PR DESCRIPTION
A legacy module reports being active by hooking a method in its own app, so it has to be in its own scope before it can say anything at all. The View-era manager added that row on every save -- `if (legacy) list.add(self)` -- and hid it again on read. #796 dropped both halves: `ScopeViewModel.apply` writes the draft verbatim, and `ConfigCache` builds its scope map from the stored rows alone. Every legacy module has reported itself inactive since (#816).

`ConfigCache` now derives the scope during the rebuild, so configurations written by those builds need no repair and nothing that replaces the scope table can drop it again. Legacy is the loader's own verdict, the strategy `FileSystem.loadModule` settled on, so an API 101 module keeps its own process to itself. Insertions go through one helper, because a module can now reach the same process by more than one route.
