### PR TITLE
Put the commit first in the build stamp, and compare only that

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,18 +61,26 @@ abstract class GitLatestTagValueSource : ValueSource<String, ValueSourceParamete
 }
 
 /**
- * Which build this is, in one string: where it was built and from what commit.
+ * Which build this is, in one string: what commit it came from and where it was built.
  *
  * The version code is the commit count on origin/master, so every branch build carries master's
  * number: a build flashed from a feature branch and one flashed from master both report "v2.0
  * (3052)" and cannot be told apart on the device. That is not hypothetical — it cost a real
  * investigation to establish which of the two was installed.
  *
- * Two shapes, because "where did this binary come from" has two different answers:
+ * **The commit always comes first, and what follows always says where.** Both readers of this string
+ * want the commit and nothing else — the manager compares it against the SHA a release was cut from
+ * to answer "am I running this build", and the status page sets it in a type the rest is not given
+ * — and for both it is now simply the head of the string. No rule has to work out which part is
+ * which, so none can get it wrong when a repository or a machine turns out to have a hyphen in its
+ * name.
  *
- * *On GitHub Actions*, `JingMatrix-Vector-93d66473` — the repository the code came from, then the
- * commit. Forks build the same code from the same commits, so the hash alone identifies a
- * *revision* and not a *build*, and a fork's artifact was indistinguishable from ours.
+ * The separator says which kind of "where" follows, because they mean opposite things about whether
+ * the commit describes the binary:
+ *
+ * *On GitHub Actions*, `93d66473-JingMatrix-Vector` — the commit, then the repository the code came
+ * from. Forks build the same code from the same commits, so the hash alone identifies a *revision*
+ * and not a *build*, and a fork's artifact was indistinguishable from ours.
  *
  * Both halves are the *head* ones, and neither is read from the environment GitHub sets by default,
  * because on a pull request both defaults name something other than the code that was built:
@@ -91,11 +99,17 @@ abstract class GitLatestTagValueSource : ValueSource<String, ValueSourceParamete
  * when there is not — outside a pull request the two agree anyway. Absent either, this falls back to
  * what the environment says and to `HEAD`, which covers a workflow too old to set them.
  *
- * *Locally*, the bare `93d66473`, or `93d66473-thinkpad` when the tree has uncommitted changes.
- * That build corresponds to no commit at all, so naming the commit alone would name something the
- * binary does not match — and whoever is looking at it is far better served by the machine it was
- * built on than by the word "dirty", since a device that has a hand-built framework on it usually
- * has exactly one candidate author.
+ * *Locally*, the bare `93d66473`, or `93d66473+thinkpad` when the tree has uncommitted changes. That
+ * build corresponds to no commit at all, so naming the commit alone would name something the binary
+ * does not match — and whoever is looking at it is far better served by the machine it was built on
+ * than by the word "dirty", since a device that has a hand-built framework on it usually has exactly
+ * one candidate author.
+ *
+ * `+` rather than `-` for that one, in semver's sense of build metadata: after a `-` is a repository
+ * that holds this exact commit, and after a `+` is a change that is in no repository at all. That is
+ * the one distinction a reader of the stamp cannot afford to lose — a modified build matches no
+ * release, and read as a CI build it would claim to be the release it was merely started from.
+ * Neither character can occur inside a host name or an `owner/repo`, so the two shapes stay apart.
  *
  * The dirty check is deliberately not applied on CI. The workflow's own "Write key" step appends
  * the signing credentials to the tracked `gradle.properties` before Gradle starts, so every master
@@ -165,7 +179,7 @@ abstract class GitCommitHashValueSource : ValueSource<String, GitCommitHashValue
         val repository = parameters.buildRepository.getOrElse("")
         if (repository.isBlank()) {
             val dirty = capture("git", "status", "--porcelain", "--untracked-files=no") != null
-            return if (dirty) "$head-${hostname()}" else head
+            return if (dirty) "$head+${hostname()}" else head
         }
 
         // The pushed commit is an ancestor of the merge that was checked out, so it is in the
@@ -174,7 +188,7 @@ abstract class GitCommitHashValueSource : ValueSource<String, GitCommitHashValue
         val pushed = parameters.buildCommit.getOrElse("").takeIf { it.isNotBlank() }
         val short =
             pushed?.let { capture("git", "rev-parse", "--short", it) ?: it.take(head.length) } ?: head
-        return repository.replace('/', '-') + "-" + short
+        return short + "-" + repository.replace('/', '-')
     }
 }
 

--- a/manager/README.md
+++ b/manager/README.md
@@ -86,8 +86,11 @@ asserting the old meaning until someone notices, which can be a long time.
 ```
 
 The version code is `git rev-list --count refs/remotes/origin/master`, so a branch build and a
-master build can share one; `module.prop` carries the commit, marked `-dirty` when the tree was not
-clean, which is often the only way to tell two builds apart on a device.
+master build can share one; `module.prop` and the status page carry a build stamp, which is often
+the only way to tell two builds apart on a device. It names where the build came from as well as
+what it was built from. The commit leads and what follows says where: `93d66473-JingMatrix-Vector`
+for a CI build, the bare `93d66473` for a local one, and `93d66473+thinkpad` — the machine that made
+it — when the tree was not clean.
 
 Debug builds add a second launcher activity — a demo mode with scripted device states, in
 `src/debug` and absent from release builds, so it cannot be used to make a release report a healthy

--- a/manager/src/main/kotlin/org/matrix/vector/manager/data/model/BuildStamp.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/data/model/BuildStamp.kt
@@ -1,0 +1,74 @@
+package org.matrix.vector.manager.data.model
+
+/**
+ * A build stamp, taken apart: which commit a build came from, and where it was built.
+ *
+ * The framework and the manager both report one — `BuildConfig.VERSION_HASH`, and
+ * `getFrameworkCommit()` across the binder — because the version code cannot tell two builds apart:
+ * it is the commit count on origin/master, so every branch build at the same depth wears the same
+ * number as the official build it was never made from.
+ *
+ * Only the commit is taken out. Where a build was made is for a person to read, and it is exactly
+ * the rest of the string — a caller that wants it takes what follows the commit, separator and all.
+ *
+ * @property commit the commit the build was made from, abbreviated as git abbreviated it, or null
+ *   when the stamp names none — "unknown" from a build made outside a git checkout, and anything
+ *   else this does not recognise. That is a third answer, distinct from "these differ".
+ * @property modified whether the tree had uncommitted changes. Such a build was made from no commit
+ *   at all: [commit] names the one it departed from, not one the binary corresponds to.
+ */
+data class BuildStamp(val commit: String?, val modified: Boolean) {
+
+    /**
+     * Whether this build and [other] were made from the same commit.
+     *
+     * A modified tree matches nothing, including itself. Otherwise it is a prefix test in either
+     * direction, because the two sides need not be abbreviated to the same length: a stamp carries
+     * git's short form and a GitHub release carries the full SHA.
+     *
+     * **Where the build was made is deliberately not compared.** A fork building the same commit
+     * builds the same code; the repository is in the stamp to identify a *binary* to someone
+     * reading a bug report, which is a different question from "is this the build that release
+     * published".
+     */
+    fun isCommit(other: String?): Boolean {
+        if (modified || other == null) return false
+        val ours = commit ?: return false
+        return other.startsWith(ours) || ours.startsWith(other)
+    }
+}
+
+/**
+ * Reads a build stamp.
+ *
+ * The commit leads, always, and the separator says what follows it — `-` a repository that holds
+ * this exact commit, `+` a machine that holds changes no repository does. So the commit is the head
+ * and there is nothing to guess: neither character can occur inside a host name or an `owner/repo`,
+ * and a hyphen inside either is harmless because everything after the first one is the origin.
+ *
+ * - `93d66473` — a local build of a clean tree.
+ * - `93d66473-JingMatrix-Vector` — CI, from `JingMatrix/Vector`.
+ * - `93d66473+thinkpad` — a local build with uncommitted changes, named by the machine that made it.
+ *
+ * A stamp that does not start with a commit yields a null one, which everywhere it is asked means
+ * "I cannot tell" rather than "these differ". That covers the shape shipped between #809 and this
+ * change, `JingMatrix-Vector-93d66473`, which is what the canaries already on people's devices
+ * carry: they are shown as they were recorded and claimed to be neither installed nor divergent,
+ * which is the truthful answer for a build whose stamp this cannot read.
+ */
+fun buildStamp(reported: String): BuildStamp {
+    val stamp = reported.trim()
+    val head = stamp.takeWhile { it != '-' && it != '+' }
+    if (!head.isAbbreviatedSha()) return BuildStamp(null, modified = false)
+    return BuildStamp(commit = head, modified = stamp.getOrNull(head.length) == '+')
+}
+
+/**
+ * Whether this could be a commit as git abbreviates one.
+ *
+ * Seven is git's own floor for an abbreviation and forty is a full SHA. Lower case only, which git
+ * emits and which is what keeps the word "unknown" — a build made where git could not be asked —
+ * from being mistaken for one.
+ */
+private fun String.isAbbreviatedSha(): Boolean =
+    length in 7..40 && all { it.isDigit() || it in 'a'..'f' }

--- a/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/FrameworkUpdateRepository.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/FrameworkUpdateRepository.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import org.matrix.vector.manager.data.github.FrameworkRelease
 import org.matrix.vector.manager.data.github.GitHubRepository
+import org.matrix.vector.manager.data.model.buildStamp
 
 /**
  * Whether a newer build of the framework exists, and which one this reader may be offered.
@@ -70,7 +71,12 @@ class FrameworkUpdateRepository(private val github: GitHubRepository) {
  */
 data class FrameworkUpdateState(
     val installedVersionCode: Long = 0,
-    /** The commit the running daemon was built from, when it recorded one. */
+    /**
+     * The build stamp the running daemon reports, when it recorded one.
+     *
+     * Not a bare hash: it names where the build came from as well as what commit it was made from,
+     * in one of the shapes [buildStamp] reads. Nothing here compares it as a string.
+     */
     val installedCommit: String? = null,
     val available: FrameworkRelease? = null,
     /** Every release on this channel, newest first — including ones older than the installed one. */
@@ -93,12 +99,16 @@ enum class ReleaseDirection {
  * Only askable when both sides recorded a commit: the canaries carry a SHA, a hand-made release
  * carries a branch name, and a build made before this existed carries nothing. "I cannot tell" is a
  * third answer and is reported as false rather than as divergence.
+ *
+ * What the framework reports is a *build stamp*, not a bare hash, so the commit is read out of it
+ * before anything is compared. Comparing the whole stamp is what #809 left behind: a CI stamp
+ * carries the repository as well, no release SHA matches that, and so every canary reader was told
+ * they were running "same number, other build" against the very release they had flashed, with no
+ * row anywhere marked as installed.
  */
 fun FrameworkUpdateState.divergesFrom(release: FrameworkRelease?): Boolean {
     if (release == null || release.versionCode != installedVersionCode) return false
-    val mine = installedCommit ?: return false
-    val theirs = release.commit ?: return false
-    // A dirty build matches nothing by definition — it was not built from any commit.
-    if (mine.endsWith("-dirty")) return true
-    return !theirs.startsWith(mine)
+    val mine = buildStamp(installedCommit ?: return false)
+    if (mine.commit == null || release.commit == null) return false
+    return !mine.isCommit(release.commit)
 }

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/home/HomeViewModel.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/home/HomeViewModel.kt
@@ -47,13 +47,14 @@ data class FrameworkStatus(
     val sepolicyLoaded: Boolean = false,
     val systemServerInjected: Boolean = false,
     /**
-     * Which build the running framework is: where it came from and from what commit.
+     * Which build the running framework is: what commit it came from and where it was built.
      *
      * The version code is a commit count, so it cannot tell a branch build from the official build
      * of the same depth — and the framework and the manager are flashed separately, so they are
      * not always the same build. Naming both is the difference between a bug report that can be
-     * placed and one that cannot. A CI build reads `JingMatrix-Vector-93d66473`, a clean local one
-     * the bare hash, and a local build from a modified tree adds the machine that made it.
+     * placed and one that cannot. The commit leads: a CI build reads `93d66473-JingMatrix-Vector`,
+     * a clean local one the bare hash, and a local build from a modified tree marks the machine
+     * that made it with a `+`. Taken apart by `buildStamp`; nothing compares it as a string.
      */
     val commit: String? = null,
 ) {

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/home/SystemStatusScreen.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/home/SystemStatusScreen.kt
@@ -46,7 +46,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -65,6 +68,7 @@ import org.matrix.vector.manager.R
 import org.matrix.vector.manager.ui.components.FrameworkState
 import org.matrix.vector.manager.data.log.CrashRecorder
 import org.matrix.vector.manager.data.model.XposedApi
+import org.matrix.vector.manager.data.model.buildStamp
 import org.matrix.vector.manager.data.repository.ManagerInstallStep
 import org.matrix.vector.manager.ui.components.SnackbarTone
 import org.matrix.vector.manager.ui.components.VectorSnackbarHost
@@ -149,7 +153,12 @@ fun SystemStatusScreen(
                                 context,
                                 englishSections.joinToString("\n\n") { (heading, items) ->
                                     heading +
-                                        items.joinToString("") { "\n  ${it.label}: ${it.value}" }
+                                        items.joinToString("") {
+                                            // With the detail, which the screen only sets apart
+                                            // rather than shortens. Where a build came from is
+                                            // half of what makes the stamp worth pasting.
+                                            "\n  ${it.label}: ${it.value}${it.detail.orEmpty()}"
+                                        }
                                 },
                             )
                             scope.launch { snackbars.show(copied, SnackbarTone.Success) }
@@ -564,6 +573,12 @@ private fun CrashCard(report: String, onCopy: () -> Unit, onClear: () -> Unit) {
  *
  * A fact that can be good or bad says which by its colour, so the page answers "is anything wrong"
  * before it is read at all.
+ *
+ * A row may end in a [InfoItem.detail], set smaller and in the muted colour. It is part of the same
+ * value and stays in the same line — a reader copying a version out by hand still gets all of it —
+ * but it is not what the row is looked up for. On the build rows that is where the stamp came from;
+ * the commit is what someone comparing two devices reads, and the repository or machine after it is
+ * two thirds of the characters and almost never the answer.
  */
 @Composable
 private fun InfoRow(row: InfoItem) {
@@ -580,7 +595,15 @@ private fun InfoRow(row: InfoItem) {
             )
             Spacer(Modifier.height(2.dp))
             Text(
-                text = row.value,
+                text =
+                    buildAnnotatedString {
+                        append(row.value)
+                        row.detail?.let { detail ->
+                            val muted =
+                                SpanStyle(fontSize = 12.sp, color = colors.onSurfaceVariant)
+                            withStyle(muted) { append(detail) }
+                        }
+                    },
                 style =
                     if (row.monospace) VectorMono.copy(fontSize = 15.sp)
                     else MaterialTheme.typography.bodyLarge,
@@ -616,10 +639,29 @@ private enum class Health {
 private data class InfoItem(
     val label: String,
     val value: String,
+    /** The tail of the value that is context rather than identity; set apart, never dropped. */
+    val detail: String? = null,
     val health: Health = Health.Neutral,
     /** True where the value is an identifier to be compared character by character. */
     val monospace: Boolean = true,
 )
+
+/**
+ * A build row: the version number, the commit, and — set apart — where that build was made.
+ *
+ * The stamp leads with the commit and says where after it, so the split is the commit's own length
+ * and needs no second opinion about which half is which. What is left includes the separator, which
+ * is worth keeping visible: `-` is a repository that holds this exact commit and `+` is a machine
+ * holding changes that no repository does.
+ *
+ * A stamp that names no commit — "unknown", from a build made where git could not be asked — is not
+ * cut at all. It goes to the muted half whole, because none of it is an identifier.
+ */
+private fun buildRow(label: String, number: String, reported: String?): InfoItem {
+    val stamp = reported?.takeIf { it.isNotBlank() } ?: return InfoItem(label, number)
+    val commit = buildStamp(stamp).commit.orEmpty()
+    return InfoItem(label, "$number  ·  $commit", detail = stamp.removePrefix(commit))
+}
 
 /** A heading, so the page reads as three short lists rather than one long one. */
 @Composable
@@ -649,24 +691,23 @@ private fun buildSections(
     return listOf(
         str(R.string.info_section_build) to
             listOf(
-                InfoItem(
+                // The exact build, not just its number. Two builds share a version code whenever
+                // they sit at the same depth on different branches, so the stamp names where the
+                // build came from as well as the commit: the repository for a CI build, the machine
+                // for a local one from a modified tree. That is what a bug report needs and what
+                // the number alone cannot give.
+                buildRow(
                     str(R.string.info_framework_version),
-                    buildString {
-                        append(status.versionLabel ?: unknown)
-                        // The exact build, not just its number. Two builds share a version code
-                        // whenever they sit at the same depth on different branches, so this names
-                        // where the build came from as well as the commit: the repository for a CI
-                        // build, the machine for a local one from a modified tree. That is what a
-                        // bug report needs and what the number alone cannot give.
-                        status.commit?.takeIf { it.isNotBlank() }?.let { append("  ·  ").append(it) }
-                    },
+                    status.versionLabel ?: unknown,
+                    status.commit,
                 ),
                 // Named separately from the framework, because they are flashed separately and are
                 // not always the same build. When these two disagree, that is the answer to a whole
                 // class of "it behaves oddly" reports.
-                InfoItem(
+                buildRow(
                     str(R.string.info_manager_version),
-                    "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})  ·  ${BuildConfig.VERSION_HASH}",
+                    "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
+                    BuildConfig.VERSION_HASH,
                 ),
                 // Named by which scale the number is on. The two share a field and nothing else: 93
                 // is a legacy Xposed API, 101 is a libxposed one, and calling both "Xposed API" is

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/update/FrameworkUpdateScreen.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/update/FrameworkUpdateScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.rounded.RadioButtonChecked
 import androidx.compose.material.icons.rounded.History
 import org.matrix.vector.manager.data.github.ZipVariant
 import org.matrix.vector.manager.data.github.CanaryArtifact
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.SegmentedButtonDefaults
@@ -546,6 +547,16 @@ private fun VariantPicker(
 }
 
 /**
+ * How much of a version row the status on its right may take.
+ *
+ * Wide enough for "Installed" and "Older" on one line in every language shipped, and narrow enough
+ * that what is left still holds a build's name and its date without wrapping on a phone. The
+ * divergence clause is longer than that and wraps inside this width, which is the point of fixing
+ * it: one row's wordier status must not move where the next row's name begins.
+ */
+private val STATUS_WIDTH = 96.dp
+
+/**
  * Every build on this channel, so "no update available" is not a dead end.
  *
  * The same list that answers "is there anything newer" also answers "what could I go back to",
@@ -591,7 +602,13 @@ private fun VersionsSheet(
                                 onSelect(release)
                                 onDismiss()
                             },
-                        headlineContent = { Text(release.title) },
+                        // One line each, always. What names the build is the same shape in every
+                        // row — "Vector v2.0 canary 3060", then its date and channel — and a row
+                        // that wraps because of what is beside it reads as a different kind of
+                        // entry when it is not.
+                        headlineContent = {
+                            Text(release.title, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        },
                         supportingContent = {
                             Text(
                                 listOfNotNull(
@@ -603,7 +620,9 @@ private fun VersionsSheet(
                                             stringResource(R.string.update_channel_release)
                                         },
                                     )
-                                    .joinToString("  ·  ")
+                                    .joinToString("  ·  "),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
                             )
                         },
                         leadingContent = {
@@ -625,6 +644,13 @@ private fun VersionsSheet(
                                     },
                             )
                         },
+                        // A column of its own width, kept even when this row has nothing to say.
+                        // The status is one word on most rows and a whole clause on the divergent
+                        // one; sized to its content it would take the room the build's name needs
+                        // and wrap that row alone, and a slot that disappears when empty would
+                        // start each row's name in a different place. The label wraps inside its
+                        // column instead, where it costs nothing: three lines of it are still
+                        // shorter than the two the name and its date already occupy.
                         trailingContent = {
                             val label =
                                 when {
@@ -633,17 +659,23 @@ private fun VersionsSheet(
                                     older -> stringResource(R.string.update_older)
                                     else -> null
                                 }
-                            if (label != null) {
-                                Text(
-                                    label,
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color =
-                                        when {
-                                            installed -> colors.primary
-                                            diverged -> colors.tertiary
-                                            else -> colors.onSurfaceVariant
-                                        },
-                                )
+                            Box(
+                                modifier = Modifier.width(STATUS_WIDTH),
+                                contentAlignment = Alignment.CenterEnd,
+                            ) {
+                                if (label != null) {
+                                    Text(
+                                        label,
+                                        style = MaterialTheme.typography.labelSmall,
+                                        textAlign = TextAlign.End,
+                                        color =
+                                            when {
+                                                installed -> colors.primary
+                                                diverged -> colors.tertiary
+                                                else -> colors.onSurfaceVariant
+                                            },
+                                    )
+                                }
                             }
                         },
                         colors = sheetRowColors,

--- a/services/manager-service/src/main/aidl/org/lsposed/lspd/ILSPManagerService.aidl
+++ b/services/manager-service/src/main/aidl/org/lsposed/lspd/ILSPManagerService.aidl
@@ -148,10 +148,17 @@ interface ILSPManagerService {
     void installFrameworkZip(String zipPath, IFrameworkInstallCallback callback) = 57;
 
     /**
-     * The commit this daemon was built from, short, or null when it was not recorded.
+     * Which build this daemon is, or null when it was not recorded.
      *
      * The version code is the commit count on origin/master, so a branch build and the official
      * build of the same count are indistinguishable by number alone. This is what tells them apart.
+     *
+     * Not a bare hash, despite the name: it is the build stamp, which names where the build came
+     * from as well as what commit it was made from — `93d66473-JingMatrix-Vector` from CI,
+     * `93d66473` from a clean local tree, `93d66473+thinkpad` from a modified one. The commit
+     * always leads, so a caller that wants it takes the head and not the whole string; `-` is
+     * followed by the repository that holds that commit, `+` by the machine holding changes that
+     * no repository does.
      */
     String getFrameworkCommit() = 58;
 


### PR DESCRIPTION
#809 added a second half to the build stamp and left `divergesFrom` comparing the whole string. A canary reports `JingMatrix-Vector-93d66473`, no release SHA starts with that, so every canary was reported as "same number, other build" against the release it was flashed from — and since `installed = sameNumber && !diverged`, no row was ever marked installed. The `-dirty` test it still carried was unreachable.

The stamp now leads with the commit, so reading it back is a prefix:

| where built | stamp |
| :-- | :-- |
| GitHub Actions | `93d66473-JingMatrix-Vector` |
| local, clean tree | `93d66473` |
| local, modified tree | `93d66473+thinkpad` |

`+` rather than `-` for the last one: with the commit leading it is the only thing separating a modified tree from a CI build, and a modified build must not claim to be the release it started from.

`buildStamp` takes one apart; `isCommit` compares as a prefix either way, since a stamp carries git's short form and a release the full SHA. Where a build was made is not compared — a fork at the same commit builds the same code. A stamp naming no commit, including the shape published between #809 and here, reads as "I cannot tell" rather than divergence.

On the status page the commit keeps full size and the rest is muted; copy-all still yields the whole stamp.
