### PR TITLE
Install and update modules under the host, and let its browser load a page (#823)

### DIFF
--- a/manager/src/main/kotlin/org/matrix/vector/manager/data/model/RepoModels.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/data/model/RepoModels.kt
@@ -174,20 +174,21 @@ data class RepoVersion(val versionCode: Long, val versionName: String) {
 /**
  * A release this manager installed, and what the device said the module was afterwards.
  *
- * Two versions, because they are not the same kind of fact and for some modules not the same
- * number: [release] is what a tag claimed, [installed] is what the APK inside it turned out to be.
+ * Two versions, because they are not the same kind of fact and need not be the same number:
+ * [release] is what a tag claimed, [installed] is what the APK inside it turned out to be.
  *
  * That difference is the whole reason this is recorded. The comparison above believes the tag, and
- * for most modules it may — of the 745 catalogue entries whose newest release carries a single APK,
- * 741 state the code their APK really has. For the rest the offer cannot be satisfied by installing
- * it: `top.cbug.adbx` is tagged `4115-1.1.1` around an APK that is versionCode 4, so `4115 > 4`
- * stays true however many times it is installed, and the update sheet reads `1.1.1 → 1.1.1` for
- * ever. Seven others are stuck the same way, six of them through the name half of the tag rather
- * than the code. Nothing in the two numbers distinguishes that from a rebuild the reader does want
- * — 17 modules publish the same versionName under several codes, and 31 keep one code across every
- * release they have ever published, so the code signal is dead for those and the name signal is
- * dead for these. Rather than parse the tag harder, the Store remembers what it installed and
- * answers "you already have this one".
+ * nothing obliges an author to tag a release with the version their manifest actually states. Where
+ * the two disagree the offer cannot be satisfied by taking it: installing leaves the device on a
+ * version the tag still claims to beat, so the row asks again, and again, for ever.
+ *
+ * Nor can it be settled by reading the two numbers harder, because both halves of the comparison
+ * are load-bearing for someone: a module that never changes its tag code is only ever seen to
+ * update through the name clause, and one that reuses a versionName across several codes only
+ * through the code clause. Any rule over `(code, name)` is wrong for one of them.
+ *
+ * So the Store stops inferring and records instead. An offer it has already installed, on a device
+ * still reporting what that install produced, is one the reader has taken.
  *
  * [installed] is what makes the record expire on its own: it is checked against what the device
  * reports now, so a module replaced from anywhere else stops matching and the offer comes back.

--- a/manager/src/main/kotlin/org/matrix/vector/manager/data/model/RepoModels.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/data/model/RepoModels.kt
@@ -145,6 +145,21 @@ data class RepoVersion(val versionCode: Long, val versionName: String) {
         versionCode > installedCode ||
             (versionCode == installedCode && installedName.replace(' ', '_') != versionName)
 
+    /**
+     * Whether installing this would leave the reader on the version they already have, by name.
+     *
+     * Which is all the offer can be worded as when it is true. Two different things reach here — a
+     * rebuild of the same version under a higher code, and a tag whose code is simply not the APK's
+     * — and nothing in either number tells them apart, so the wording has to be true of both. What
+     * is certain in both is where the reader ends up: on this version name again.
+     *
+     * The underscores are the same normalisation [upgradableOver] applies, and for the same reason:
+     * a git tag cannot carry a space, so an author whose versionName has one writes it with an
+     * underscore.
+     */
+    fun sameVersionAs(installed: RepoVersion?): Boolean =
+        installed != null && installed.versionName.replace(' ', '_') == versionName
+
     companion object {
         fun parse(raw: String?): RepoVersion? {
             val text = raw?.takeIf { it.isNotBlank() } ?: return null
@@ -203,6 +218,16 @@ data class StoreEntry(
     /** The newest release is one we installed, and the device still reports what it left behind. */
     private val alreadyInstalled: Boolean
         get() = storeInstall?.satisfies(latest, installed) == true
+
+    /**
+     * The offer would not change which version this device says it has. See [sameVersionAs].
+     *
+     * Read by everything that *words* an offer, because `1.1.1 → 1.1.1` is a sentence the app cannot
+     * mean. [upgradable] deliberately does not consult it: whether to offer at all is a different
+     * question from what to call it, and a rebuild is worth offering.
+     */
+    val sameVersion: Boolean
+        get() = latest?.sameVersionAs(installed) == true
 
     /**
      * There is a newer version *and* the reader wants to hear about it.

--- a/manager/src/main/kotlin/org/matrix/vector/manager/data/model/RepoModels.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/data/model/RepoModels.kt
@@ -137,6 +137,10 @@ data class ReleaseAsset(
  */
 data class RepoVersion(val versionCode: Long, val versionName: String) {
 
+    /** The tag this was read from, which is also how [StoreInstall] writes one back down. */
+    val tag: String
+        get() = "$versionCode-$versionName"
+
     fun upgradableOver(installedCode: Long, installedName: String): Boolean =
         versionCode > installedCode ||
             (versionCode == installedCode && installedName.replace(' ', '_') != versionName)
@@ -153,6 +157,34 @@ data class RepoVersion(val versionCode: Long, val versionName: String) {
 }
 
 /**
+ * A release this manager installed, and what the device said the module was afterwards.
+ *
+ * Two versions, because they are not the same kind of fact and for some modules not the same
+ * number: [release] is what a tag claimed, [installed] is what the APK inside it turned out to be.
+ *
+ * That difference is the whole reason this is recorded. The comparison above believes the tag, and
+ * for most modules it may — of the 745 catalogue entries whose newest release carries a single APK,
+ * 741 state the code their APK really has. For the rest the offer cannot be satisfied by installing
+ * it: `top.cbug.adbx` is tagged `4115-1.1.1` around an APK that is versionCode 4, so `4115 > 4`
+ * stays true however many times it is installed, and the update sheet reads `1.1.1 → 1.1.1` for
+ * ever. Seven others are stuck the same way, six of them through the name half of the tag rather
+ * than the code. Nothing in the two numbers distinguishes that from a rebuild the reader does want
+ * — 17 modules publish the same versionName under several codes, and 31 keep one code across every
+ * release they have ever published, so the code signal is dead for those and the name signal is
+ * dead for these. Rather than parse the tag harder, the Store remembers what it installed and
+ * answers "you already have this one".
+ *
+ * [installed] is what makes the record expire on its own: it is checked against what the device
+ * reports now, so a module replaced from anywhere else stops matching and the offer comes back.
+ */
+data class StoreInstall(val release: RepoVersion, val installed: RepoVersion) {
+
+    /** Whether this note says [latest] is already here, as [current]. */
+    fun satisfies(latest: RepoVersion?, current: RepoVersion?): Boolean =
+        release == latest && installed == current
+}
+
+/**
  * One row of the Store: a catalogue entry, plus what this device has to say about it.
  *
  * The join lives in the ViewModel rather than in either repository, so the network layer stays
@@ -164,9 +196,19 @@ data class StoreEntry(
     val installed: RepoVersion?,
     /** The reader asked not to be told about this one again. */
     val updatesMuted: Boolean = false,
+    /** What this manager last installed here, if this manager is what installed it. */
+    val storeInstall: StoreInstall? = null,
 ) {
+
+    /** The newest release is one we installed, and the device still reports what it left behind. */
+    private val alreadyInstalled: Boolean
+        get() = storeInstall?.satisfies(latest, installed) == true
+
     /**
      * There is a newer version *and* the reader wants to hear about it.
+     *
+     * A release this manager itself installed is not a newer version, whatever the two numbers say;
+     * see [StoreInstall].
      *
      * Muting is folded in here rather than at each place that reads this, because every list and
      * count that mentions updates reads it — the Store's header count, its updates filter, its row
@@ -184,6 +226,7 @@ data class StoreEntry(
             !updatesMuted &&
                 installed != null &&
                 latest != null &&
+                !alreadyInstalled &&
                 latest.upgradableOver(installed.versionCode, installed.versionName)
 }
 

--- a/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/ManagerInstaller.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/ManagerInstaller.kt
@@ -1,27 +1,20 @@
 package org.matrix.vector.manager.data.repository
 
-import android.app.PendingIntent
-import android.content.BroadcastReceiver
 import android.content.Context
-import android.content.Intent
-import android.content.IntentFilter
 import android.content.pm.PackageInstaller
-import android.os.Build
 import android.util.Log
-import androidx.core.content.ContextCompat
-import androidx.core.content.IntentCompat
 import java.io.FileInputStream
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import org.matrix.vector.manager.BuildConfig
 import org.matrix.vector.manager.Constants
 import org.matrix.vector.manager.ipc.DaemonClient
+import org.matrix.vector.manager.ipc.commitForResult
 
 /** Where installing the manager as an app has got to. */
 sealed interface ManagerInstallStep {
@@ -179,85 +172,25 @@ class ManagerInstaller(private val context: Context, private val daemon: DaemonC
     /**
      * Commits the session and waits for the platform's verdict.
      *
-     * Registered at runtime rather than declared, because parasitically nothing in this app's
-     * manifest exists and a declared receiver would never fire. `STATUS_PENDING_USER_ACTION` is not
-     * terminal — it means the system is asking, and the real status follows the answer. It should
-     * not arise here: the host holds `INSTALL_PACKAGES`, so the commit is silent. It is handled
-     * anyway, because the same code runs from a manager that is already installed and updating
-     * itself, where the prompt is exactly what the platform will do.
+     * `STATUS_PENDING_USER_ACTION` should not arise here — the host holds `INSTALL_PACKAGES`, so
+     * the commit is silent — but it is handled anyway, because the same code runs from a manager
+     * that is already installed and updating itself, where the prompt is exactly what the platform
+     * will do.
+     *
+     * @see commitForResult
      */
     private suspend fun commit(
         session: PackageInstaller.Session,
         sessionId: Int,
-    ): Pair<Int, String?> = suspendCancellableCoroutine { continuation ->
-        val action = "$RESULT_ACTION.$sessionId"
-        val receiver =
-            object : BroadcastReceiver() {
-                override fun onReceive(received: Context, intent: Intent) {
-                    val status =
-                        intent.getIntExtra(
-                            PackageInstaller.EXTRA_STATUS,
-                            PackageInstaller.STATUS_FAILURE,
-                        )
-                    if (status == PackageInstaller.STATUS_PENDING_USER_ACTION) {
-                        IntentCompat.getParcelableExtra(
-                                intent,
-                                Intent.EXTRA_INTENT,
-                                Intent::class.java,
-                            )
-                            ?.let { confirm ->
-                                runCatching {
-                                        context.startActivity(
-                                            confirm.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                                        )
-                                    }
-                                    .onFailure { e ->
-                                        Log.e(
-                                            Constants.TAG,
-                                            "actions: manager install prompt could not be started",
-                                            e,
-                                        )
-                                    }
-                            }
-                        return
-                    }
-                    runCatching { context.unregisterReceiver(this) }
-                    if (continuation.isActive) {
-                        continuation.resumeWith(
-                            Result.success(
-                                status to
-                                    intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
-                            )
-                        )
-                    }
-                }
-            }
-
-        ContextCompat.registerReceiver(
-            context,
-            receiver,
-            IntentFilter(action),
-            ContextCompat.RECEIVER_NOT_EXPORTED,
+    ): Pair<Int, String?> =
+        context.commitForResult(
+            session,
+            sessionId,
+            promptFailure = "actions: manager install prompt could not be started",
         )
-        continuation.invokeOnCancellation { runCatching { context.unregisterReceiver(receiver) } }
-
-        val flags =
-            PendingIntent.FLAG_UPDATE_CURRENT or
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE
-                else 0
-        val pending =
-            PendingIntent.getBroadcast(
-                context,
-                sessionId,
-                Intent(action).setPackage(context.packageName),
-                flags,
-            )
-        session.commit(pending.intentSender)
-    }
 
     private companion object {
         const val WRITE_NAME = "manager.apk"
-        const val RESULT_ACTION = "org.matrix.vector.manager.INSTALL_MANAGER_RESULT"
 
         /** What the platform calls it in `EXTRA_STATUS_MESSAGE`; see PackageManagerException. */
         const val SIGNATURE_CONFLICT = "INSTALL_FAILED_UPDATE_INCOMPATIBLE"

--- a/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/ManagerInstaller.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/ManagerInstaller.kt
@@ -15,6 +15,7 @@ import org.matrix.vector.manager.BuildConfig
 import org.matrix.vector.manager.Constants
 import org.matrix.vector.manager.ipc.DaemonClient
 import org.matrix.vector.manager.ipc.commitForResult
+import org.matrix.vector.manager.ipc.requestReplaceExisting
 
 /** Where installing the manager as an app has got to. */
 sealed interface ManagerInstallStep {
@@ -125,6 +126,9 @@ class ManagerInstaller(private val context: Context, private val daemon: DaemonC
                             // with it. A daemon serving something else cannot install it as Vector.
                             setAppPackageName(BuildConfig.MANAGER_PACKAGE_NAME)
                             if (size > 0) setSize(size)
+                            // Updating an installed manager from the host is a replace, and
+                            // parasitically the platform does not make it one for us.
+                            requestReplaceExisting()
                         }
                 sessionId = packageInstaller.createSession(params)
 

--- a/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/ModuleInstaller.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/ModuleInstaller.kt
@@ -74,6 +74,11 @@ class ModuleInstaller(private val context: Context, private val client: OkHttpCl
      * Returns true only when the platform reports the package installed. There is no resume: a
      * dropped connection costs the whole transfer, which is an acceptable trade for module APKs
      * (tens to a few hundred kilobytes) in exchange for never touching the filesystem.
+     *
+     * What became of it is recorded by the caller rather than here — see RepoRepository.readInstalled
+     * and SettingsRepository.noteStoreInstall — because the version to record has to be read the way
+     * the Store reads it, across every user, and this class talks to the platform rather than to the
+     * daemon.
      */
     suspend fun install(packageName: String, asset: ReleaseAsset): Boolean =
         withContext(Dispatchers.IO) {

--- a/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/ModuleInstaller.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/ModuleInstaller.kt
@@ -17,6 +17,7 @@ import okhttp3.Request
 import org.matrix.vector.manager.Constants
 import org.matrix.vector.manager.data.model.ReleaseAsset
 import org.matrix.vector.manager.ipc.commitForResult
+import org.matrix.vector.manager.ipc.requestReplaceExisting
 
 /** Where an install has got to. One at a time, because a user installs one module at a time. */
 sealed interface InstallStep {
@@ -95,6 +96,7 @@ class ModuleInstaller(private val context: Context, private val client: OkHttpCl
                         .apply {
                             setAppPackageName(packageName)
                             if (asset.size > 0) setSize(asset.size)
+                            requestReplaceExisting()
                         }
                 sessionId = packageInstaller.createSession(params)
 

--- a/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/ModuleInstaller.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/ModuleInstaller.kt
@@ -1,15 +1,8 @@
 package org.matrix.vector.manager.data.repository
 
-import android.app.PendingIntent
-import android.content.BroadcastReceiver
 import android.content.Context
-import android.content.Intent
-import android.content.IntentFilter
 import android.content.pm.PackageInstaller
-import android.os.Build
 import android.util.Log
-import androidx.core.content.ContextCompat
-import androidx.core.content.IntentCompat
 import java.io.IOException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -18,12 +11,12 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.matrix.vector.manager.Constants
 import org.matrix.vector.manager.data.model.ReleaseAsset
+import org.matrix.vector.manager.ipc.commitForResult
 
 /** Where an install has got to. One at a time, because a user installs one module at a time. */
 sealed interface InstallStep {
@@ -182,82 +175,24 @@ class ModuleInstaller(private val context: Context, private val client: OkHttpCl
     /**
      * Commits the session and waits for the platform's verdict.
      *
-     * The result arrives as a broadcast, and the receiver is registered at runtime rather than
-     * declared: parasitically nothing in the manifest exists, so a declared receiver would simply
-     * never fire. `STATUS_PENDING_USER_ACTION` is not terminal — it means the system is asking the
-     * user, and the real status follows once they answer.
+     * @see commitForResult
      */
     private suspend fun commit(
         session: PackageInstaller.Session,
         sessionId: Int,
         packageName: String,
-    ): Pair<Int, String?> = suspendCancellableCoroutine { continuation ->
-        val action = "$RESULT_ACTION.$sessionId"
-        val receiver =
-            object : BroadcastReceiver() {
-                override fun onReceive(received: Context, intent: Intent) {
-                    val status =
-                        intent.getIntExtra(
-                            PackageInstaller.EXTRA_STATUS,
-                            PackageInstaller.STATUS_FAILURE,
-                        )
-                    if (status == PackageInstaller.STATUS_PENDING_USER_ACTION) {
-                        _state.value = InstallStep.Confirming(packageName)
-                        IntentCompat.getParcelableExtra(intent, Intent.EXTRA_INTENT, Intent::class.java)
-                            ?.let { confirm ->
-                                runCatching {
-                                        context.startActivity(
-                                            confirm.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                                        )
-                                    }
-                                    .onFailure { e ->
-                                        Log.e(
-                                            Constants.TAG,
-                                            "store: install prompt for $packageName could not be started",
-                                            e,
-                                        )
-                                    }
-                            }
-                        return
-                    }
-                    runCatching { context.unregisterReceiver(this) }
-                    if (continuation.isActive) {
-                        continuation.resumeWith(
-                            Result.success(
-                                status to
-                                    intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
-                            )
-                        )
-                    }
-                }
-            }
-
-        ContextCompat.registerReceiver(
-            context,
-            receiver,
-            IntentFilter(action),
-            ContextCompat.RECEIVER_NOT_EXPORTED,
-        )
-        continuation.invokeOnCancellation { runCatching { context.unregisterReceiver(receiver) } }
-
-        val flags =
-            PendingIntent.FLAG_UPDATE_CURRENT or
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE
-                else 0
-        val pending =
-            PendingIntent.getBroadcast(
-                context,
-                sessionId,
-                Intent(action).setPackage(context.packageName),
-                flags,
-            )
-        session.commit(pending.intentSender)
-    }
+    ): Pair<Int, String?> =
+        context.commitForResult(
+            session,
+            sessionId,
+            promptFailure = "store: install prompt for $packageName could not be started",
+        ) {
+            _state.value = InstallStep.Confirming(packageName)
+        }
 
     private companion object {
         const val WRITE_NAME = "module.apk"
         const val CHUNK_BYTES = 64 * 1024
         const val PROGRESS_STEP_BYTES = 256L * 1024
-        const val RESULT_ACTION = "org.matrix.vector.manager.INSTALL_RESULT"
     }
 }

--- a/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/ModuleUpdateQueue.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/ModuleUpdateQueue.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.matrix.vector.manager.data.model.ReleaseAsset
+import org.matrix.vector.manager.data.model.RepoVersion
+import org.matrix.vector.manager.data.model.StoreInstall
 
 /**
  * Several module updates, installed one after another.
@@ -27,11 +29,22 @@ class ModuleUpdateQueue(
     private val installer: ModuleInstaller,
     private val store: RepoRepository,
     private val modules: ModuleRepository,
+    private val settings: SettingsRepository,
     private val scope: CoroutineScope,
 ) {
 
-    /** One module to update, resolved before the run starts so nothing is looked up mid-flight. */
-    data class Item(val packageName: String, val title: String, val asset: ReleaseAsset)
+    /**
+     * One module to update, resolved before the run starts so nothing is looked up mid-flight.
+     *
+     * [release] is the version of the release [asset] came from, carried so that the installer can
+     * record what it put on the device. See ModuleInstaller.install.
+     */
+    data class Item(
+        val packageName: String,
+        val title: String,
+        val asset: ReleaseAsset,
+        val release: RepoVersion?,
+    )
 
     data class State(
         val queued: List<Item> = emptyList(),
@@ -82,12 +95,29 @@ class ModuleUpdateQueue(
                 // Once, at the end, rather than after each install: every version read comes from
                 // one daemon call over every installed package, and paying that four times to
                 // watch four badges settle a second earlier each is not a trade worth making.
-                store.refreshInstalled()
+                // Awaited, because the notes below are written from that same read.
+                note(items, store.readInstalled())
                 // Told rather than overheard. A replaced package does broadcast, and the manager
                 // does listen, but this is the one install path the app performed itself: there is
                 // no reason for the list to wait on a delivery the system owns.
                 modules.notePackagesChanged()
             }
+    }
+
+    /**
+     * Records what landed, so the Store stops offering a release it has already installed.
+     *
+     * Only the items that succeeded, and only against what the device reports now — which is why
+     * [installed] is passed in rather than read here. See [StoreInstall].
+     */
+    private fun note(items: List<Item>, installed: Map<String, RepoVersion>) {
+        val landed = _state.value.done
+        for (item in items) {
+            if (item.packageName !in landed) continue
+            val release = item.release ?: continue
+            val version = installed[item.packageName] ?: continue
+            settings.noteStoreInstall(item.packageName, StoreInstall(release, version))
+        }
     }
 
     /**

--- a/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/RepoRepository.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/RepoRepository.kt
@@ -158,6 +158,23 @@ class RepoRepository(
         scope.launch { loadInstalled() }
     }
 
+    /**
+     * The same read, awaited and handed back, for a caller that has to act on what it finds.
+     *
+     * Which is how an install records what it produced: the note that suppresses a satisfied offer
+     * is compared against [installedVersions], so it has to be written from that same reading. A
+     * local `getPackageInfo` would answer for user 0 while this map answers with the highest version
+     * across every user, and on a device with a work profile the two differ — leaving a note that can
+     * never match and a row that nags for ever.
+     *
+     * Returns the last known map when the daemon cannot be reached, which is the safe direction: a
+     * note written from a stale version simply fails to match, and the offer stays.
+     */
+    suspend fun readInstalled(): Map<String, RepoVersion> {
+        loadInstalled()
+        return _installed.value
+    }
+
     private suspend fun loadInstalled() {
         val packages =
             daemon

--- a/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/SettingsRepository.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/SettingsRepository.kt
@@ -5,6 +5,8 @@ import android.content.SharedPreferences
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import org.matrix.vector.manager.data.model.RepoVersion
+import org.matrix.vector.manager.data.model.StoreInstall
 
 /**
  * The manager's own preferences: how it looks, what it shows, and what it has been told to stop
@@ -196,6 +198,50 @@ class SettingsRepository(context: Context) {
         prefs.edit().putStringSet("muted_updates", HashSet(next)).apply()
         _mutedUpdates.value = next
     }
+
+    /**
+     * Which catalogue release the Store put on this device, per package. See [StoreInstall].
+     *
+     * Here rather than in the daemon for the reason the mute above is: the daemon has never heard
+     * of the catalogue, and this is a fact about what *this* app did rather than about the module.
+     * It has to survive a process death for the same reason too — parasitically the process is the
+     * shell's, and it is killed constantly, so an in-memory note would forget by the next visit and
+     * the offer it silenced would be back.
+     *
+     * A string set, like the mute, rather than a serialised map: three fields per row, joined by
+     * newlines, which no package name or tag contains. A row that no longer parses is dropped,
+     * which is the right answer for a note whose only job is to suppress an offer — the worst a
+     * lost row can do is offer an update again. Rows are never pruned either, for the same reason:
+     * one is a few dozen bytes, a device carries tens of modules, and a note left behind by a
+     * module that has since been uninstalled says nothing until that module is back at that exact
+     * version.
+     */
+    private val _storeInstalls = MutableStateFlow(readStoreInstalls())
+    val storeInstalls: StateFlow<Map<String, StoreInstall>> = _storeInstalls.asStateFlow()
+
+    /** Records what the Store installed for [packageName], replacing any earlier note of it. */
+    fun noteStoreInstall(packageName: String, install: StoreInstall) {
+        val next = _storeInstalls.value + (packageName to install)
+        val rows = next.mapTo(HashSet()) { (name, noted) -> encode(name, noted) }
+        prefs.edit().putStringSet("store_installs", rows).apply()
+        _storeInstalls.value = next
+    }
+
+    private fun encode(packageName: String, install: StoreInstall): String =
+        "$packageName\n${install.release.tag}\n${install.installed.tag}"
+
+    private fun readStoreInstalls(): Map<String, StoreInstall> =
+        prefs
+            .getStringSet("store_installs", emptySet())
+            .orEmpty()
+            .mapNotNull { row ->
+                val parts = row.split('\n')
+                if (parts.size != 3) return@mapNotNull null
+                val release = RepoVersion.parse(parts[1]) ?: return@mapNotNull null
+                val installed = RepoVersion.parse(parts[2]) ?: return@mapNotNull null
+                parts[0] to StoreInstall(release, installed)
+            }
+            .toMap()
 
     /** Which living surface the status header draws. See AmbienceKind. */
     private val _headerAmbience =

--- a/manager/src/main/kotlin/org/matrix/vector/manager/di/ServiceLocator.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/di/ServiceLocator.kt
@@ -135,7 +135,8 @@ object ServiceLocator {
                 store.installedVersions,
                 settings.updateChannel,
                 settings.mutedUpdates,
-            ) { catalog, installed, channelPreference, muted ->
+                settings.storeInstalls,
+            ) { catalog, installed, channelPreference, muted, storeInstalls ->
                 val channel = StoreChannel.of(channelPreference)
                 catalog.modules
                     .filter { it.name in installed }
@@ -146,6 +147,7 @@ object ServiceLocator {
                                 latest = module.latestOn(channel),
                                 installed = installed[module.name],
                                 updatesMuted = module.name in muted,
+                                storeInstall = storeInstalls[module.name],
                             )
                     }
             }
@@ -186,7 +188,7 @@ object ServiceLocator {
     }
 
     /** Sequential module updates, outliving the sheet that started them. */
-    val moduleUpdates: ModuleUpdateQueue by lazy { ModuleUpdateQueue(installer, store, modules, appScope) }
+    val moduleUpdates: ModuleUpdateQueue by lazy { ModuleUpdateQueue(installer, store, modules, settings, appScope) }
 
     val frameworkInstaller: FrameworkInstaller by lazy { FrameworkInstaller(context, http, daemon) }
 

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ipc/InstallResult.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ipc/InstallResult.kt
@@ -14,6 +14,34 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import org.matrix.vector.manager.Constants
 
 /**
+ * Asks for an install that replaces whatever copy of the package is already on the device.
+ *
+ * `MODE_FULL_INSTALL` does not say that, and parasitically nothing else does either.
+ * `PackageInstallerService.createSessionInternal` sets `INSTALL_REPLACE_EXISTING` itself for every
+ * ordinary caller, and takes a separate branch for `SHELL_UID` and `ROOT_UID` which adds
+ * `INSTALL_FROM_ADB` and leaves the rest of the flags as they came. `pm install` sets the flag in
+ * its own argument parsing, which is why an adb install still replaces and why `-r` is accepted and
+ * ignored; a caller of the framework API gets no such help. Under the host the manager *is* that
+ * uid, so `PackageManagerService` treats a module the device already has as a first install and
+ * fails it with `INSTALL_FAILED_ALREADY_EXISTS: Attempt to re-install <package> without first
+ * uninstalling`. That branch reads the same from API 27, this app's minimum, to AOSP main, so
+ * updating a module through the store has never worked parasitically on any release, and neither
+ * has updating an installed manager from the host.
+ *
+ * Standalone this changes nothing, because the platform has already set the flag by the time a
+ * session exists — which is why failing to set it is worth no more than a warning. The field is
+ * `@hide` but greylisted (`@UnsupportedAppUsage` carrying no `maxTargetSdk`), so the reflection is
+ * permitted in both modes rather than only under the platform-signed host.
+ */
+fun PackageInstaller.SessionParams.requestReplaceExisting() {
+    runCatching {
+            val flags = PackageInstaller.SessionParams::class.java.getDeclaredField("installFlags")
+            flags.setInt(this, flags.getInt(this) or INSTALL_REPLACE_EXISTING)
+        }
+        .onFailure { Log.w(Constants.TAG, "ipc: install session could not request a replace", it) }
+}
+
+/**
  * Commits [session] and suspends until the platform says what became of it.
  *
  * The verdict arrives as a broadcast, and the receiver is registered here rather than declared:
@@ -95,3 +123,6 @@ suspend fun Context.commitForResult(
 
 /** Only ever a prefix; the session id and a UUID follow. */
 private const val RESULT_ACTION = "org.matrix.vector.manager.INSTALL_RESULT"
+
+/** `PackageManager.INSTALL_REPLACE_EXISTING`, `@hide` like the field it belongs in. */
+private const val INSTALL_REPLACE_EXISTING = 0x00000002

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ipc/InstallResult.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ipc/InstallResult.kt
@@ -1,0 +1,97 @@
+package org.matrix.vector.manager.ipc
+
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageInstaller
+import android.os.Build
+import android.util.Log
+import androidx.core.content.IntentCompat
+import java.util.UUID
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.matrix.vector.manager.Constants
+
+/**
+ * Commits [session] and suspends until the platform says what became of it.
+ *
+ * The verdict arrives as a broadcast, and the receiver is registered here rather than declared:
+ * parasitically the manager's manifest is never installed, so a declared receiver would never fire.
+ * `STATUS_PENDING_USER_ACTION` is not terminal — it means the system is asking the user, and the
+ * real status follows their answer. [onPrompt] is the caller's chance to say so on screen, and
+ * [promptFailure] is what to log if the prompt cannot be started.
+ *
+ * **The UUID in the action is what keeps the verdict ours, and below API 33 nothing else can.** A
+ * registered receiver has no exported flag before then, so anything installed can broadcast to one
+ * whose action it knows. `ContextCompat.registerReceiver` only appears to answer that: below 33 it
+ * stands in for the missing flag by demanding `<package>.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION`
+ * of this process — a signature permission declared by a manifest that parasitically was never
+ * installed, looked up under the host's package name — so it threw instead of registering, and
+ * every install on API 27..32 failed before it began. Requiring a permission of the *sender* is no
+ * better: a `PendingIntent` broadcast is sent as whoever created it, so that is this process, and
+ * no permission is held both under the host and standalone.
+ *
+ * A forged verdict is worth ruling out rather than merely tidy. A fake `STATUS_SUCCESS` reports an
+ * install that never happened and skips the caller's `abandonSession`; a fake
+ * `STATUS_PENDING_USER_ACTION` hands us an arbitrary intent to start, and parasitically we would
+ * start it as `com.android.shell`. The session id is not a secret to lean on either — the platform
+ * announces every new session to every app in the user, and asks no permission to listen.
+ */
+suspend fun Context.commitForResult(
+    session: PackageInstaller.Session,
+    sessionId: Int,
+    promptFailure: String,
+    onPrompt: () -> Unit = {},
+): Pair<Int, String?> = suspendCancellableCoroutine { continuation ->
+    val action = "$RESULT_ACTION.$sessionId.${UUID.randomUUID()}"
+    val receiver =
+        object : BroadcastReceiver() {
+            override fun onReceive(received: Context, intent: Intent) {
+                if (intent.action != action) return
+                val status =
+                    intent.getIntExtra(
+                        PackageInstaller.EXTRA_STATUS,
+                        PackageInstaller.STATUS_FAILURE,
+                    )
+                if (status == PackageInstaller.STATUS_PENDING_USER_ACTION) {
+                    onPrompt()
+                    IntentCompat.getParcelableExtra(intent, Intent.EXTRA_INTENT, Intent::class.java)
+                        ?.let { confirm ->
+                            runCatching {
+                                    startActivity(confirm.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+                                }
+                                .onFailure { Log.e(Constants.TAG, promptFailure, it) }
+                        }
+                    return
+                }
+                runCatching { unregisterReceiver(this) }
+                if (continuation.isActive) {
+                    continuation.resumeWith(
+                        Result.success(
+                            status to intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
+                        )
+                    )
+                }
+            }
+        }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        registerReceiver(receiver, IntentFilter(action), Context.RECEIVER_NOT_EXPORTED)
+    } else {
+        registerReceiver(receiver, IntentFilter(action))
+    }
+    continuation.invokeOnCancellation { runCatching { unregisterReceiver(receiver) } }
+
+    val flags =
+        PendingIntent.FLAG_UPDATE_CURRENT or
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
+    // The package restriction names the host parasitically, and has to: the receiver belongs to
+    // this process, so a broadcast confined to the manager's own package would reach nobody.
+    val pending =
+        PendingIntent.getBroadcast(this, sessionId, Intent(action).setPackage(packageName), flags)
+    session.commit(pending.intentSender)
+}
+
+/** Only ever a prefix; the session id and a UUID follow. */
+private const val RESULT_ACTION = "org.matrix.vector.manager.INSTALL_RESULT"

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/components/PackageActionMenu.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/components/PackageActionMenu.kt
@@ -587,7 +587,11 @@ private fun ModuleUpdateSection(
         ActionRow(
             icon = Icons.Rounded.ArrowCircleUp,
             title =
-                stringResource(R.string.action_update_to, entry.latest?.versionName.orEmpty()),
+                stringResource(
+                    if (entry.sameVersion) R.string.store_badge_reinstall
+                    else R.string.action_update_to,
+                    entry.latest?.versionName.orEmpty(),
+                ),
             subtitle =
                 when {
                     busy -> stringResource(R.string.action_update_running)
@@ -596,6 +600,13 @@ private fun ModuleUpdateSection(
                     // them needs the names and sizes the store page already lays out. Sending the
                     // reader there is better than picking one on their behalf.
                     apks.size > 1 -> stringResource(R.string.action_update_choose)
+                    // The title already names the version; saying "from 1.1.1" under "Reinstall
+                    // 1.1.1" would only invite the reader to look for the difference.
+                    entry.sameVersion ->
+                        stringResource(
+                            R.string.action_reinstall_same,
+                            Formatter.formatShortFileSize(context, apks.first().size),
+                        )
                     else ->
                         stringResource(
                             R.string.action_update_from,

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/components/PackageActionMenu.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/components/PackageActionMenu.kt
@@ -657,6 +657,7 @@ private fun ModuleUpdateSection(
                             packageName = packageName,
                             title = entry.module.title,
                             asset = asset,
+                            release = release?.version,
                         )
                     )
                 )

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/modules/ModulesScreen.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/modules/ModulesScreen.kt
@@ -1373,6 +1373,16 @@ private fun ModuleUpdatesSheet(
                                         when {
                                             row.asset == null ->
                                                 stringResource(R.string.action_update_choose)
+                                            // "1.1.1 → 1.1.1" is not a thing to say to anyone.
+                                            row.entry.sameVersion ->
+                                                stringResource(
+                                                    R.string.modules_update_reinstall,
+                                                    row.entry.latest?.versionName.orEmpty(),
+                                                    Formatter.formatShortFileSize(
+                                                        context,
+                                                        row.asset.size,
+                                                    ),
+                                                )
                                             else ->
                                                 stringResource(
                                                     R.string.modules_update_versions,

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/modules/ModulesScreen.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/modules/ModulesScreen.kt
@@ -98,6 +98,7 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.rememberModalBottomSheetState
 import org.matrix.vector.manager.data.model.ReleaseAsset
+import org.matrix.vector.manager.data.model.RepoVersion
 import org.matrix.vector.manager.data.model.StoreEntry
 import org.matrix.vector.manager.data.repository.ModuleUpdateQueue
 import org.matrix.vector.manager.ui.components.SheetHeading
@@ -1315,20 +1316,20 @@ private fun ModuleUpdatesSheet(
 
     // One APK is installable from here; several is a choice this sheet has no room to make, so
     // those keep their row, uncheckable, pointing at the store page that does.
-    data class Row(val entry: StoreEntry, val asset: ReleaseAsset?, val muted: Boolean)
+    data class Row(
+        val entry: StoreEntry,
+        val release: RepoVersion?,
+        val asset: ReleaseAsset?,
+        val muted: Boolean,
+    )
 
     val rows =
         remember(entries, upgradable, mutedUpgradable, channel) {
             (upgradable + mutedUpgradable).mapNotNull { name ->
                 val entry = entries[name] ?: return@mapNotNull null
-                val apks =
-                    entry.module
-                        .releasesOn(channel)
-                        .firstOrNull()
-                        ?.releaseAssets
-                        .orEmpty()
-                        .filter { it.isApk }
-                Row(entry, apks.singleOrNull(), name in mutedUpgradable)
+                val release = entry.module.releasesOn(channel).firstOrNull()
+                val apks = release?.releaseAssets.orEmpty().filter { it.isApk }
+                Row(entry, release?.version, apks.singleOrNull(), name in mutedUpgradable)
             }
                 .sortedWith(compareBy({ it.muted }, { it.entry.module.title.lowercase() }))
         }
@@ -1420,6 +1421,7 @@ private fun ModuleUpdatesSheet(
                                         packageName = it.entry.module.name,
                                         title = it.entry.module.title,
                                         asset = it.asset!!,
+                                        release = it.release,
                                     )
                                 }
                         )

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/repo/RepoDetailsScreen.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/repo/RepoDetailsScreen.kt
@@ -154,7 +154,9 @@ fun RepoDetailsScreen(packageName: String, onNavigateBack: () -> Unit) {
 
     var choosing by remember { mutableStateOf<Release?>(null) }
     var optionsOpen by remember { mutableStateOf(false) }
-    var confirming by remember { mutableStateOf<ReleaseAsset?>(null) }
+    // The release travels with the asset: what is installed is recorded against the release it came
+    // from, and picking an older release from the list must not silence the newest one.
+    var confirming by remember { mutableStateOf<Pair<Release, ReleaseAsset>?>(null) }
 
     Scaffold(
         topBar = {
@@ -209,7 +211,8 @@ fun RepoDetailsScreen(packageName: String, onNavigateBack: () -> Unit) {
                     // One file is the overwhelmingly common case, and asking which of one is
                     // noise. More than one and the choice is the user's — some modules ship a
                     // variant per architecture.
-                    if (assets.size == 1) confirming = assets.first() else choosing = release
+                    if (assets.size == 1) confirming = release to assets.first()
+                    else choosing = release
                 },
                 onAcknowledge = viewModel::acknowledgeInstall,
             )
@@ -306,7 +309,7 @@ fun RepoDetailsScreen(packageName: String, onNavigateBack: () -> Unit) {
                             onOpenUrl = openUrl,
                             onInstall = { release ->
                                 val assets = release.apks
-                                if (assets.size == 1) confirming = assets.first()
+                                if (assets.size == 1) confirming = release to assets.first()
                                 else choosing = release
                             },
                         )
@@ -347,12 +350,12 @@ fun RepoDetailsScreen(packageName: String, onNavigateBack: () -> Unit) {
             onDismiss = { choosing = null },
             onPick = { asset ->
                 choosing = null
-                confirming = asset
+                confirming = release to asset
             },
         )
     }
 
-    confirming?.let { asset ->
+    confirming?.let { (release, asset) ->
         ConfirmInstall(
             module = state.module,
             packageName = packageName,
@@ -360,7 +363,7 @@ fun RepoDetailsScreen(packageName: String, onNavigateBack: () -> Unit) {
             onDismiss = { confirming = null },
             onConfirm = {
                 confirming = null
-                viewModel.install(asset)
+                viewModel.install(asset, release.version)
             },
         )
     }

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/repo/RepoDetailsScreen.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/repo/RepoDetailsScreen.kt
@@ -469,7 +469,8 @@ private fun InstallBar(
                             when {
                                 state.upgradable ->
                                     stringResource(
-                                        R.string.store_badge_update,
+                                        if (state.sameVersion) R.string.store_badge_reinstall
+                                        else R.string.store_badge_update,
                                         state.latest?.versionName.orEmpty(),
                                     )
                                 state.installed != null -> stringResource(R.string.store_reinstall)

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/repo/RepoDetailsViewModel.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/repo/RepoDetailsViewModel.kt
@@ -62,6 +62,10 @@ data class RepoDetailsState(
                 latest != null &&
                 storeInstall?.satisfies(latest, installed) != true &&
                 latest.upgradableOver(installed.versionCode, installed.versionName)
+
+    /** As `StoreEntry.sameVersion`: what the bar may call the offer, not whether to make it. */
+    val sameVersion: Boolean
+        get() = latest?.sameVersionAs(installed) == true
 }
 
 class RepoDetailsViewModel(

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/repo/RepoDetailsViewModel.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/repo/RepoDetailsViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -17,6 +18,7 @@ import org.matrix.vector.manager.data.model.OnlineModule
 import org.matrix.vector.manager.data.model.Release
 import org.matrix.vector.manager.data.model.ReleaseAsset
 import org.matrix.vector.manager.data.model.RepoVersion
+import org.matrix.vector.manager.data.model.StoreInstall
 import org.matrix.vector.manager.data.repository.InstallStep
 import org.matrix.vector.manager.data.repository.ModuleInstaller
 import org.matrix.vector.manager.data.repository.RepoRepository
@@ -45,11 +47,20 @@ data class RepoDetailsState(
     val latest: RepoVersion? = null,
     val fetch: DetailFetch = DetailFetch.Loading,
     val channel: StoreChannel = StoreChannel.Stable,
+    /** What the Store last installed for this module, if the Store is what installed it. */
+    val storeInstall: StoreInstall? = null,
 ) {
+    /**
+     * As `StoreEntry.upgradable`, minus the mute: this page is a module the reader went looking for.
+     *
+     * The note is honoured here as well, and has to be. It is the one thing that keeps this badge
+     * from disagreeing with the list that led to it — see [StoreInstall].
+     */
     val upgradable: Boolean
         get() =
             installed != null &&
                 latest != null &&
+                storeInstall?.satisfies(latest, installed) != true &&
                 latest.upgradableOver(installed.versionCode, installed.versionName)
 }
 
@@ -110,17 +121,30 @@ class RepoDetailsViewModel(
 
     fun setUpdatesMuted(muted: Boolean) = settings.setUpdatesMuted(packageName, muted)
 
+    /**
+     * The two preferences this page reads, as one value.
+     *
+     * Paired rather than passed separately because `combine` takes five flows and this page already
+     * watches five things of its own.
+     */
+    private data class Preferences(val channel: StoreChannel, val storeInstall: StoreInstall?)
+
+    private fun preferences(): Flow<Preferences> =
+        combine(settings.updateChannel, settings.storeInstalls) { channelPreference, installs ->
+            Preferences(StoreChannel.of(channelPreference), installs[packageName])
+        }
+
     val state: StateFlow<RepoDetailsState> =
         combine(
                 repository.catalog,
                 _detail,
                 _fetch,
                 repository.installedVersions,
-                settings.updateChannel,
-            ) { catalog, detail, fetch, installed, channelPreference ->
+                preferences(),
+            ) { catalog, detail, fetch, installed, preferences ->
                 val seed = catalog.modules.firstOrNull { it.name == packageName }
                 val module = detail ?: seed
-                val channel = StoreChannel.of(channelPreference)
+                val channel = preferences.channel
                 RepoDetailsState(
                     module = module,
                     releases = releasesFor(module, channel),
@@ -128,6 +152,7 @@ class RepoDetailsViewModel(
                     latest = latestFor(module, channel),
                     fetch = fetch,
                     channel = channel,
+                    storeInstall = preferences.storeInstall,
                 )
             }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), RepoDetailsState())
@@ -156,9 +181,15 @@ class RepoDetailsViewModel(
      * change of mind. The installer's state is a single shared flow, so coming back re-attaches to
      * the progress that kept running.
      */
-    fun install(asset: ReleaseAsset) {
+    fun install(asset: ReleaseAsset, release: RepoVersion?) {
         backgroundScope.launch {
-            if (installer.install(packageName, asset)) repository.refreshInstalled()
+            if (!installer.install(packageName, asset)) return@launch
+            // The version has to come from this read rather than from the platform directly: it is
+            // the one the offer is compared against. See RepoRepository.readInstalled.
+            val installed = repository.readInstalled()[packageName]
+            if (release != null && installed != null) {
+                settings.noteStoreInstall(packageName, StoreInstall(release, installed))
+            }
         }
     }
 

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/repo/RepoScreen.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/repo/RepoScreen.kt
@@ -396,7 +396,8 @@ private fun StoreRow(entry: StoreEntry, onClick: () -> Unit) {
                         icon = Icons.Rounded.Upgrade,
                         text =
                             stringResource(
-                                R.string.store_badge_update,
+                                if (entry.sameVersion) R.string.store_badge_reinstall
+                                else R.string.store_badge_update,
                                 entry.latest?.versionName.orEmpty(),
                             ),
                         tint = colors.primary,

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/repo/RepoViewModel.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/repo/RepoViewModel.kt
@@ -20,6 +20,7 @@ import org.matrix.vector.manager.data.model.Release
 import org.matrix.vector.manager.data.model.RepoVersion
 import org.matrix.vector.manager.data.model.StoreCatalog
 import org.matrix.vector.manager.data.model.StoreEntry
+import org.matrix.vector.manager.data.model.StoreInstall
 import org.matrix.vector.manager.data.repository.RepoRepository
 import org.matrix.vector.manager.data.repository.SettingsRepository
 
@@ -148,12 +149,14 @@ class RepoViewModel(
      * and it walks 809 entries.
      */
     private val allEntries: StateFlow<List<StoreEntry>> =
-        combine(repository.catalog, repository.installedVersions, channel, settings.mutedUpdates) {
-                catalog,
-                installed,
+        combine(
+                repository.catalog,
+                repository.installedVersions,
                 channel,
-                muted ->
-                catalog.modules.map { entryFor(it, installed, channel, muted) }
+                settings.mutedUpdates,
+                settings.storeInstalls,
+            ) { catalog, installed, channel, muted, storeInstalls ->
+                catalog.modules.map { entryFor(it, installed, channel, muted, storeInstalls) }
             }
             .flowOn(Dispatchers.Default)
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
@@ -231,12 +234,14 @@ class RepoViewModel(
         installed: Map<String, RepoVersion>,
         channel: StoreChannel,
         muted: Set<String>,
+        storeInstalls: Map<String, StoreInstall>,
     ): StoreEntry =
         StoreEntry(
             module = module,
             latest = module.latestOn(channel),
             installed = installed[module.name],
             updatesMuted = module.name in muted,
+            storeInstall = storeInstalls[module.name],
         )
 
     private fun StoreEntry.matches(query: String): Boolean {

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/repo/StoreHtml.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/repo/StoreHtml.kt
@@ -1,7 +1,5 @@
 package org.matrix.vector.manager.ui.screens.repo
 
-import android.content.Context
-import android.content.res.Configuration
 import android.annotation.SuppressLint
 import android.view.MotionEvent
 import android.view.ViewConfiguration
@@ -28,6 +26,7 @@ import java.io.ByteArrayInputStream
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.matrix.vector.manager.di.ServiceLocator
+import org.matrix.vector.manager.ui.screens.web.forWebView
 
 /**
  * Repository-supplied HTML — a README, or a release's notes — rendered inside Vector.
@@ -91,8 +90,9 @@ private fun HtmlPane(
 
     // A WebView reads prefers-color-scheme from the configuration of the context it was built
     // with. The stylesheet below covers our own markup, but a README using <picture> with a
-    // dark-mode <source> picks its image from this.
-    val themedContext = remember(dark) { context.forNightMode(dark) }
+    // dark-mode <source> picks its image from this. The same context is what decides whether the
+    // pane may fetch anything, which parasitically it otherwise may not — see [forWebView].
+    val themedContext = remember(dark) { context.forWebView(dark) }
 
     val webView =
         remember(themedContext) {
@@ -214,16 +214,6 @@ private val TRANSPARENT_GIF =
         0x02, 0x02, 0x44, 0x01, 0x00, // one pixel of LZW
         0x3B, // trailer
     )
-
-private fun Context.forNightMode(dark: Boolean): Context {
-    val configuration =
-        Configuration(resources.configuration).apply {
-            uiMode =
-                (uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or
-                    if (dark) Configuration.UI_MODE_NIGHT_YES else Configuration.UI_MODE_NIGHT_NO
-        }
-    return createConfigurationContext(configuration)
-}
 
 private fun Color.isDark(): Boolean = (0.299f * red + 0.587f * green + 0.114f * blue) < 0.5f
 

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/web/WebScreen.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/web/WebScreen.kt
@@ -2,7 +2,6 @@ package org.matrix.vector.manager.ui.screens.web
 
 import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.net.Uri
 import android.view.ViewGroup
@@ -93,19 +92,9 @@ fun WebScreen(url: String, onNavigateBack: () -> Unit) {
     var secure by remember { mutableStateOf(url.startsWith("https")) }
     var barVisible by remember { mutableStateOf(true) }
 
-    // The night bit is read from the context the WebView is constructed with, so forcing it here is
-    // what makes the page follow Vector's own theme rather than the system's.
-    val themedContext =
-        remember(dark) {
-            val config =
-                Configuration(context.resources.configuration).apply {
-                    uiMode =
-                        (uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or
-                            if (dark) Configuration.UI_MODE_NIGHT_YES
-                            else Configuration.UI_MODE_NIGHT_NO
-                }
-            context.createConfigurationContext(config)
-        }
+    // Both the page's colour scheme and whether it may reach the network at all are decided by the
+    // context this is built with, and cannot be changed afterwards. See [forWebView].
+    val themedContext = remember(dark) { context.forWebView(dark) }
 
     val webView =
         remember(themedContext) {

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/web/WebViewContext.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/web/WebViewContext.kt
@@ -1,0 +1,63 @@
+package org.matrix.vector.manager.ui.screens.web
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.pm.PackageManager
+import android.content.res.Configuration
+import android.os.Process
+
+/**
+ * The context a `WebView` has to be built with, because both of these are read once, at
+ * construction, and cannot be set afterwards.
+ *
+ * **The theme.** A `WebView` resolves `prefers-color-scheme` through the configuration of the
+ * context it was constructed with, so the activity's own context renders a black GitHub page under
+ * a white app bar whenever the app's theme disagrees with the system's. The night bit is forced to
+ * match the Compose theme instead.
+ *
+ * **Whether it may use the network at all.** `AwSettings` sets `mBlockNetworkLoads` from
+ * `context.checkSelfPermission(INTERNET)` in its constructor, and a blocked load is implemented as
+ * `LOAD_ONLY_FROM_CACHE`, so an empty cache makes every page fail as Chromium's own
+ * `net::ERR_CACHE_MISS` error page — on a device whose networking is perfectly fine.
+ *
+ * That check is by uid, and parasitically our uid is 2000. AOSP's `packages/Shell` did not request
+ * `INTERNET` until Android 12, and `PermissionManagerService.checkUidPermission` reads the grants
+ * of the package that owns the uid — consulting `platform.xml`'s `assign-permission … uid="shell"`
+ * only when *no* package owns it, which is never true here. So below Android 12 the platform's
+ * honest answer for the host is DENIED, and the in-app browser could not load a single page.
+ *
+ * The process does have networking: the zygisk module adds `GID_INET` to the manager's fork and
+ * makes `Zygote` set `setAllowNetworkingForProcess`, which is why OkHttp fetches the catalogue and
+ * downloads module APKs in this same process. None of that changes what the platform *answers*, and
+ * the answer is all `AwSettings` looks at. `setBlockNetworkLoads(false)` is not a way round it
+ * either — it throws `SecurityException` while the permission is missing.
+ *
+ * So this context answers the one question, and only where the platform says no: not gated on the
+ * SDK level, because an OEM that strips the permission from its own shell package needs the same
+ * treatment. Nothing outside the two `WebView`s is affected, and a genuine network failure still
+ * arrives as a genuine network error rather than as a cache miss.
+ */
+internal fun Context.forWebView(dark: Boolean): Context {
+    val configuration =
+        Configuration(resources.configuration).apply {
+            uiMode =
+                (uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or
+                    if (dark) Configuration.UI_MODE_NIGHT_YES else Configuration.UI_MODE_NIGHT_NO
+        }
+    val themed = createConfigurationContext(configuration)
+    if (themed.checkSelfPermission(INTERNET) == PackageManager.PERMISSION_GRANTED) return themed
+
+    return object : ContextWrapper(themed) {
+        override fun checkSelfPermission(permission: String): Int =
+            if (permission == INTERNET) PackageManager.PERMISSION_GRANTED
+            else super.checkSelfPermission(permission)
+
+        // Older WebView builds ask this instead, about this process. A question about any other
+        // uid is somebody else's business and is passed through.
+        override fun checkPermission(permission: String, pid: Int, uid: Int): Int =
+            if (permission == INTERNET && uid == Process.myUid()) PackageManager.PERMISSION_GRANTED
+            else super.checkPermission(permission, pid, uid)
+    }
+}
+
+private const val INTERNET = "android.permission.INTERNET"

--- a/manager/src/main/res/values-ar/strings.xml
+++ b/manager/src/main/res/values-ar/strings.xml
@@ -358,6 +358,7 @@
     <string name="action_not_in_store_summary">لا يمكن التحقق من تحديثات هذه الوحدة</string>
     <string name="action_update_to">التحديث إلى %1$s</string>
     <string name="action_update_from">من %1$s · %2$s</string>
+    <string name="action_reinstall_same">الإصدار نفسه · %1$s</string>
     <string name="action_update_running">جارٍ التثبيت…</string>
     <string name="action_update_no_apk">هذا الإصدار لا يحتوي على APK للتثبيت</string>
     <string name="action_update_choose">عدة إصدارات — اختر واحدًا في المتجر</string>
@@ -366,6 +367,7 @@
     <string name="modules_updating">جارٍ تحديث %1$s — %2$d من %3$d</string>
     <string name="modules_updates_title">وحدات للتحديث</string>
     <string name="modules_update_versions">%1$s ← %2$s · %3$s</string>
+    <string name="modules_update_reinstall">إعادة تثبيت %1$s · %2$s</string>
     <string name="modules_update_ignored">مُتجاهَلة</string>
     <string name="modules_update_selected">تحديث %1$d</string>
     <plurals name="modules_updates">

--- a/manager/src/main/res/values-ar/strings_store.xml
+++ b/manager/src/main/res/values-ar/strings_store.xml
@@ -30,6 +30,7 @@
     <string name="store_offline">يُعرض الفهرس المحفوظ</string>
 
     <string name="store_badge_update">التحديث إلى %1$s</string>
+    <string name="store_badge_reinstall">إعادة تثبيت %1$s</string>
     <string name="store_badge_installed">مثبَّتة</string>
     <string name="store_badge_prerelease">إصدار تجريبي</string>
     <string name="store_updated_on">حُدِّثت في %1$s</string>

--- a/manager/src/main/res/values-de/strings.xml
+++ b/manager/src/main/res/values-de/strings.xml
@@ -314,6 +314,7 @@
     <string name="action_not_in_store_summary">Updates für dieses Modul können nicht geprüft werden</string>
     <string name="action_update_to">Auf %1$s aktualisieren</string>
     <string name="action_update_from">Von %1$s · %2$s</string>
+    <string name="action_reinstall_same">Gleiche Version · %1$s</string>
     <string name="action_update_running">Wird installiert…</string>
     <string name="action_update_no_apk">Diese Version enthält kein installierbares APK</string>
     <string name="action_update_choose">Mehrere Builds — im Store auswählen</string>
@@ -322,6 +323,7 @@
     <string name="modules_updating">%1$s wird aktualisiert — %2$d von %3$d</string>
     <string name="modules_updates_title">Module zum Aktualisieren</string>
     <string name="modules_update_versions">%1$s → %2$s · %3$s</string>
+    <string name="modules_update_reinstall">%1$s neu installieren · %2$s</string>
     <string name="modules_update_ignored">Ignoriert</string>
     <string name="modules_update_selected">%1$d aktualisieren</string>
     <plurals name="modules_updates">

--- a/manager/src/main/res/values-de/strings_store.xml
+++ b/manager/src/main/res/values-de/strings_store.xml
@@ -22,6 +22,7 @@
     <string name="store_offline">Gespeicherter Katalog</string>
 
     <string name="store_badge_update">Update auf %1$s</string>
+    <string name="store_badge_reinstall">%1$s neu installieren</string>
     <string name="store_badge_installed">Installiert</string>
     <string name="store_badge_prerelease">Vorabversion</string>
     <string name="store_updated_on">Aktualisiert %1$s</string>

--- a/manager/src/main/res/values-es/strings.xml
+++ b/manager/src/main/res/values-es/strings.xml
@@ -314,6 +314,7 @@
     <string name="action_not_in_store_summary">No se pueden comprobar actualizaciones de este módulo</string>
     <string name="action_update_to">Actualizar a %1$s</string>
     <string name="action_update_from">Desde %1$s · %2$s</string>
+    <string name="action_reinstall_same">Misma versión · %1$s</string>
     <string name="action_update_running">Instalando…</string>
     <string name="action_update_no_apk">Esta versión no incluye ningún APK</string>
     <string name="action_update_choose">Varias compilaciones: elige una en la tienda</string>
@@ -322,6 +323,7 @@
     <string name="modules_updating">Actualizando %1$s: %2$d de %3$d</string>
     <string name="modules_updates_title">Módulos para actualizar</string>
     <string name="modules_update_versions">%1$s → %2$s · %3$s</string>
+    <string name="modules_update_reinstall">Reinstalar %1$s · %2$s</string>
     <string name="modules_update_ignored">Ignorado</string>
     <string name="modules_update_selected">Actualizar %1$d</string>
     <plurals name="modules_updates">

--- a/manager/src/main/res/values-es/strings_store.xml
+++ b/manager/src/main/res/values-es/strings_store.xml
@@ -22,6 +22,7 @@
     <string name="store_offline">Mostrando el catálogo guardado</string>
 
     <string name="store_badge_update">Actualizar a %1$s</string>
+    <string name="store_badge_reinstall">Reinstalar %1$s</string>
     <string name="store_badge_installed">Instalado</string>
     <string name="store_badge_prerelease">Preversión</string>
     <string name="store_updated_on">Actualizado el %1$s</string>

--- a/manager/src/main/res/values-fa/strings.xml
+++ b/manager/src/main/res/values-fa/strings.xml
@@ -314,6 +314,7 @@
     <string name="action_not_in_store_summary">به‌روزرسانی‌های این ماژول بررسی‌شدنی نیست</string>
     <string name="action_update_to">به‌روزرسانی به %1$s</string>
     <string name="action_update_from">از %1$s · %2$s</string>
+    <string name="action_reinstall_same">همان نسخه · %1$s</string>
     <string name="action_update_running">در حال نصب…</string>
     <string name="action_update_no_apk">این انتشار APK قابل نصبی ندارد</string>
     <string name="action_update_choose">چند ساخت — یکی را در فروشگاه انتخاب کنید</string>
@@ -322,6 +323,7 @@
     <string name="modules_updating">به‌روزرسانی %1$s — %2$d از %3$d</string>
     <string name="modules_updates_title">ماژول‌های قابل به‌روزرسانی</string>
     <string name="modules_update_versions">%1$s ← %2$s · %3$s</string>
+    <string name="modules_update_reinstall">نصب دوباره %1$s · %2$s</string>
     <string name="modules_update_ignored">نادیده‌گرفته</string>
     <string name="modules_update_selected">به‌روزرسانی %1$d</string>
     <plurals name="modules_updates">

--- a/manager/src/main/res/values-fa/strings_store.xml
+++ b/manager/src/main/res/values-fa/strings_store.xml
@@ -22,6 +22,7 @@
     <string name="store_offline">فهرست ذخیره‌شده نمایش داده می‌شود</string>
 
     <string name="store_badge_update">به‌روزرسانی به %1$s</string>
+    <string name="store_badge_reinstall">نصب دوباره %1$s</string>
     <string name="store_badge_installed">نصب‌شده</string>
     <string name="store_badge_prerelease">پیش‌انتشار</string>
     <string name="store_updated_on">به‌روز شده در %1$s</string>

--- a/manager/src/main/res/values-fr/strings.xml
+++ b/manager/src/main/res/values-fr/strings.xml
@@ -314,6 +314,7 @@
     <string name="action_not_in_store_summary">Les mises à jour de ce module ne peuvent pas être vérifiées</string>
     <string name="action_update_to">Mettre à jour vers %1$s</string>
     <string name="action_update_from">Depuis %1$s · %2$s</string>
+    <string name="action_reinstall_same">Même version · %1$s</string>
     <string name="action_update_running">Installation…</string>
     <string name="action_update_no_apk">Cette version ne contient aucun APK</string>
     <string name="action_update_choose">Plusieurs versions — à choisir dans le dépôt</string>
@@ -322,6 +323,7 @@
     <string name="modules_updating">Mise à jour de %1$s — %2$d sur %3$d</string>
     <string name="modules_updates_title">Modules à mettre à jour</string>
     <string name="modules_update_versions">%1$s → %2$s · %3$s</string>
+    <string name="modules_update_reinstall">Réinstaller %1$s · %2$s</string>
     <string name="modules_update_ignored">Ignoré</string>
     <string name="modules_update_selected">Mettre à jour %1$d</string>
     <plurals name="modules_updates">

--- a/manager/src/main/res/values-fr/strings_store.xml
+++ b/manager/src/main/res/values-fr/strings_store.xml
@@ -22,6 +22,7 @@
     <string name="store_offline">Catalogue enregistré</string>
 
     <string name="store_badge_update">Mettre à jour vers %1$s</string>
+    <string name="store_badge_reinstall">Réinstaller %1$s</string>
     <string name="store_badge_installed">Installé</string>
     <string name="store_badge_prerelease">Préversion</string>
     <string name="store_updated_on">Mis à jour le %1$s</string>

--- a/manager/src/main/res/values-in/strings.xml
+++ b/manager/src/main/res/values-in/strings.xml
@@ -307,6 +307,7 @@
     <string name="action_not_in_store_summary">Pembaruan modul ini tidak dapat diperiksa</string>
     <string name="action_update_to">Perbarui ke %1$s</string>
     <string name="action_update_from">Dari %1$s · %2$s</string>
+    <string name="action_reinstall_same">Versi sama · %1$s</string>
     <string name="action_update_running">Memasang…</string>
     <string name="action_update_no_apk">Rilis ini tidak memuat APK</string>
     <string name="action_update_choose">Beberapa build — pilih satu di toko</string>
@@ -315,6 +316,7 @@
     <string name="modules_updating">Memperbarui %1$s — %2$d dari %3$d</string>
     <string name="modules_updates_title">Modul untuk diperbarui</string>
     <string name="modules_update_versions">%1$s → %2$s · %3$s</string>
+    <string name="modules_update_reinstall">Pasang ulang %1$s · %2$s</string>
     <string name="modules_update_ignored">Diabaikan</string>
     <string name="modules_update_selected">Perbarui %1$d</string>
     <plurals name="modules_updates">

--- a/manager/src/main/res/values-in/strings_store.xml
+++ b/manager/src/main/res/values-in/strings_store.xml
@@ -20,6 +20,7 @@
     <string name="store_offline">Menampilkan katalog tersimpan</string>
 
     <string name="store_badge_update">Perbarui ke %1$s</string>
+    <string name="store_badge_reinstall">Pasang ulang %1$s</string>
     <string name="store_badge_installed">Terpasang</string>
     <string name="store_badge_prerelease">Pra-rilis</string>
     <string name="store_updated_on">Diperbarui %1$s</string>

--- a/manager/src/main/res/values-it/strings.xml
+++ b/manager/src/main/res/values-it/strings.xml
@@ -314,6 +314,7 @@
     <string name="action_not_in_store_summary">Non è possibile controllare gli aggiornamenti di questo modulo</string>
     <string name="action_update_to">Aggiorna alla %1$s</string>
     <string name="action_update_from">Da %1$s · %2$s</string>
+    <string name="action_reinstall_same">Stessa versione · %1$s</string>
     <string name="action_update_running">Installazione…</string>
     <string name="action_update_no_apk">Questa versione non contiene APK</string>
     <string name="action_update_choose">Più build — scegline una nel repository</string>
@@ -322,6 +323,7 @@
     <string name="modules_updating">Aggiornamento di %1$s — %2$d di %3$d</string>
     <string name="modules_updates_title">Moduli da aggiornare</string>
     <string name="modules_update_versions">%1$s → %2$s · %3$s</string>
+    <string name="modules_update_reinstall">Reinstalla %1$s · %2$s</string>
     <string name="modules_update_ignored">Ignorato</string>
     <string name="modules_update_selected">Aggiorna %1$d</string>
     <plurals name="modules_updates">

--- a/manager/src/main/res/values-it/strings_store.xml
+++ b/manager/src/main/res/values-it/strings_store.xml
@@ -22,6 +22,7 @@
     <string name="store_offline">Catalogo salvato</string>
 
     <string name="store_badge_update">Aggiorna a %1$s</string>
+    <string name="store_badge_reinstall">Reinstalla %1$s</string>
     <string name="store_badge_installed">Installato</string>
     <string name="store_badge_prerelease">Preversione</string>
     <string name="store_updated_on">Aggiornato il %1$s</string>

--- a/manager/src/main/res/values-iw/strings.xml
+++ b/manager/src/main/res/values-iw/strings.xml
@@ -340,6 +340,7 @@
     <string name="action_not_in_store_summary">לא ניתן לבדוק עדכונים למודול הזה</string>
     <string name="action_update_to">עדכון ל-%1$s</string>
     <string name="action_update_from">מ-%1$s · %2$s</string>
+    <string name="action_reinstall_same">אותה גרסה · %1$s</string>
     <string name="action_update_running">מתקין…</string>
     <string name="action_update_no_apk">למהדורה הזו אין APK להתקנה</string>
     <string name="action_update_choose">כמה גרסאות — בחר אחת בחנות</string>
@@ -348,6 +349,7 @@
     <string name="modules_updating">מעדכן את %1$s — %2$d מתוך %3$d</string>
     <string name="modules_updates_title">מודולים לעדכון</string>
     <string name="modules_update_versions">%1$s ← %2$s · %3$s</string>
+    <string name="modules_update_reinstall">התקנה מחדש של %1$s · %2$s</string>
     <string name="modules_update_ignored">מתעלמים</string>
     <string name="modules_update_selected">עדכון %1$d</string>
     <plurals name="modules_updates">

--- a/manager/src/main/res/values-iw/strings_store.xml
+++ b/manager/src/main/res/values-iw/strings_store.xml
@@ -26,6 +26,7 @@
     <string name="store_offline">מוצג הקטלוג השמור</string>
 
     <string name="store_badge_update">עדכון ל-%1$s</string>
+    <string name="store_badge_reinstall">התקנה מחדש של %1$s</string>
     <string name="store_badge_installed">מותקן</string>
     <string name="store_badge_prerelease">גרסה מקדימה</string>
     <string name="store_updated_on">עודכן ב-%1$s</string>

--- a/manager/src/main/res/values-ja/strings.xml
+++ b/manager/src/main/res/values-ja/strings.xml
@@ -303,6 +303,7 @@
     <string name="action_not_in_store_summary">このモジュールの更新は確認できません</string>
     <string name="action_update_to">%1$s に更新</string>
     <string name="action_update_from">%1$s から · %2$s</string>
+    <string name="action_reinstall_same">同じバージョン · %1$s</string>
     <string name="action_update_running">インストール中…</string>
     <string name="action_update_no_apk">このリリースにインストールできる APK がありません</string>
     <string name="action_update_choose">複数のビルドがあります — ストアで選択</string>
@@ -311,6 +312,7 @@
     <string name="modules_updating">%1$s を更新中 — %3$d 件中 %2$d 件目</string>
     <string name="modules_updates_title">更新するモジュール</string>
     <string name="modules_update_versions">%1$s → %2$s · %3$s</string>
+    <string name="modules_update_reinstall">%1$s を再インストール · %2$s</string>
     <string name="modules_update_ignored">無視中</string>
     <string name="modules_update_selected">%1$d 件を更新</string>
     <plurals name="modules_updates">

--- a/manager/src/main/res/values-ja/strings_store.xml
+++ b/manager/src/main/res/values-ja/strings_store.xml
@@ -20,6 +20,7 @@
     <string name="store_offline">保存済みのカタログを表示しています</string>
 
     <string name="store_badge_update">%1$s に更新</string>
+    <string name="store_badge_reinstall">%1$s を再インストール</string>
     <string name="store_badge_installed">インストール済み</string>
     <string name="store_badge_prerelease">プレリリース</string>
     <string name="store_updated_on">%1$s に更新</string>

--- a/manager/src/main/res/values-ko/strings.xml
+++ b/manager/src/main/res/values-ko/strings.xml
@@ -303,6 +303,7 @@
     <string name="action_not_in_store_summary">이 모듈의 업데이트는 확인할 수 없습니다</string>
     <string name="action_update_to">%1$s(으)로 업데이트</string>
     <string name="action_update_from">%1$s에서 · %2$s</string>
+    <string name="action_reinstall_same">같은 버전 · %1$s</string>
     <string name="action_update_running">설치 중…</string>
     <string name="action_update_no_apk">이 릴리스에는 설치할 APK가 없습니다</string>
     <string name="action_update_choose">빌드가 여러 개입니다 — 스토어에서 선택하세요</string>
@@ -311,6 +312,7 @@
     <string name="modules_updating">%1$s 업데이트 중 — %3$d개 중 %2$d개</string>
     <string name="modules_updates_title">업데이트할 모듈</string>
     <string name="modules_update_versions">%1$s → %2$s · %3$s</string>
+    <string name="modules_update_reinstall">%1$s 다시 설치 · %2$s</string>
     <string name="modules_update_ignored">무시함</string>
     <string name="modules_update_selected">%1$d개 업데이트</string>
     <plurals name="modules_updates">

--- a/manager/src/main/res/values-ko/strings_store.xml
+++ b/manager/src/main/res/values-ko/strings_store.xml
@@ -20,6 +20,7 @@
     <string name="store_offline">저장된 카탈로그를 표시합니다</string>
 
     <string name="store_badge_update">%1$s(으)로 업데이트</string>
+    <string name="store_badge_reinstall">%1$s 다시 설치</string>
     <string name="store_badge_installed">설치됨</string>
     <string name="store_badge_prerelease">사전 릴리스</string>
     <string name="store_updated_on">%1$s 업데이트</string>

--- a/manager/src/main/res/values-pl/strings.xml
+++ b/manager/src/main/res/values-pl/strings.xml
@@ -336,6 +336,7 @@
     <string name="action_not_in_store_summary">Nie można sprawdzić aktualizacji tego modułu</string>
     <string name="action_update_to">Aktualizuj do %1$s</string>
     <string name="action_update_from">Z %1$s · %2$s</string>
+    <string name="action_reinstall_same">Ta sama wersja · %1$s</string>
     <string name="action_update_running">Instalowanie…</string>
     <string name="action_update_no_apk">To wydanie nie zawiera pliku APK</string>
     <string name="action_update_choose">Kilka wydań — wybierz w repozytorium</string>
@@ -344,6 +345,7 @@
     <string name="modules_updating">Aktualizowanie %1$s — %2$d z %3$d</string>
     <string name="modules_updates_title">Moduły do aktualizacji</string>
     <string name="modules_update_versions">%1$s → %2$s · %3$s</string>
+    <string name="modules_update_reinstall">Zainstaluj ponownie %1$s · %2$s</string>
     <string name="modules_update_ignored">Ignorowany</string>
     <string name="modules_update_selected">Aktualizuj %1$d</string>
     <plurals name="modules_updates">

--- a/manager/src/main/res/values-pl/strings_store.xml
+++ b/manager/src/main/res/values-pl/strings_store.xml
@@ -26,6 +26,7 @@
     <string name="store_offline">Pokazano zapisany katalog</string>
 
     <string name="store_badge_update">Aktualizuj do %1$s</string>
+    <string name="store_badge_reinstall">Zainstaluj ponownie %1$s</string>
     <string name="store_badge_installed">Zainstalowany</string>
     <string name="store_badge_prerelease">Wydanie wstępne</string>
     <string name="store_updated_on">Zaktualizowano %1$s</string>

--- a/manager/src/main/res/values-pt-rBR/strings.xml
+++ b/manager/src/main/res/values-pt-rBR/strings.xml
@@ -314,6 +314,7 @@
     <string name="action_not_in_store_summary">Não é possível verificar atualizações deste módulo</string>
     <string name="action_update_to">Atualizar para %1$s</string>
     <string name="action_update_from">De %1$s · %2$s</string>
+    <string name="action_reinstall_same">Mesma versão · %1$s</string>
     <string name="action_update_running">Instalando…</string>
     <string name="action_update_no_apk">Esta versão não traz nenhum APK</string>
     <string name="action_update_choose">Várias builds — escolha uma na loja</string>
@@ -322,6 +323,7 @@
     <string name="modules_updating">Atualizando %1$s — %2$d de %3$d</string>
     <string name="modules_updates_title">Módulos para atualizar</string>
     <string name="modules_update_versions">%1$s → %2$s · %3$s</string>
+    <string name="modules_update_reinstall">Reinstalar %1$s · %2$s</string>
     <string name="modules_update_ignored">Ignorado</string>
     <string name="modules_update_selected">Atualizar %1$d</string>
     <plurals name="modules_updates">

--- a/manager/src/main/res/values-pt-rBR/strings_store.xml
+++ b/manager/src/main/res/values-pt-rBR/strings_store.xml
@@ -22,6 +22,7 @@
     <string name="store_offline">Mostrando o catálogo salvo</string>
 
     <string name="store_badge_update">Atualizar para %1$s</string>
+    <string name="store_badge_reinstall">Reinstalar %1$s</string>
     <string name="store_badge_installed">Instalado</string>
     <string name="store_badge_prerelease">Pré-lançamento</string>
     <string name="store_updated_on">Atualizado em %1$s</string>

--- a/manager/src/main/res/values-ru/strings.xml
+++ b/manager/src/main/res/values-ru/strings.xml
@@ -317,6 +317,7 @@
     <string name="action_not_in_store_summary">Обновления этого модуля проверить нельзя</string>
     <string name="action_update_to">Обновить до %1$s</string>
     <string name="action_update_from">С %1$s · %2$s</string>
+    <string name="action_reinstall_same">Та же версия · %1$s</string>
     <string name="action_update_running">Установка…</string>
     <string name="action_update_no_apk">В этом выпуске нет APK для установки</string>
     <string name="action_update_choose">Несколько сборок — выберите в репозитории</string>
@@ -325,6 +326,7 @@
     <string name="modules_updating">Обновление %1$s — %2$d из %3$d</string>
     <string name="modules_updates_title">Модули для обновления</string>
     <string name="modules_update_versions">%1$s → %2$s · %3$s</string>
+    <string name="modules_update_reinstall">Переустановить %1$s · %2$s</string>
     <string name="modules_update_ignored">Игнорируется</string>
     <string name="modules_update_selected">Обновить %1$d</string>
     <plurals name="modules_updates">

--- a/manager/src/main/res/values-ru/strings_store.xml
+++ b/manager/src/main/res/values-ru/strings_store.xml
@@ -23,6 +23,7 @@
     <string name="store_all_current">всё установленное актуально</string>
     <string name="store_offline">Показан сохранённый каталог</string>
     <string name="store_badge_update">Обновить до %1$s</string>
+    <string name="store_badge_reinstall">Переустановить %1$s</string>
     <string name="store_badge_installed">Установлен</string>
     <string name="store_badge_prerelease">Предварительный</string>
     <string name="store_updated_on">Обновлён %1$s</string>

--- a/manager/src/main/res/values-tr/strings.xml
+++ b/manager/src/main/res/values-tr/strings.xml
@@ -314,6 +314,7 @@
     <string name="action_not_in_store_summary">Bu modülün güncellemeleri denetlenemez</string>
     <string name="action_update_to">%1$s sürümüne güncelle</string>
     <string name="action_update_from">%1$s sürümünden · %2$s</string>
+    <string name="action_reinstall_same">Aynı sürüm · %1$s</string>
     <string name="action_update_running">Yükleniyor…</string>
     <string name="action_update_no_apk">Bu sürümde yüklenecek APK yok</string>
     <string name="action_update_choose">Birden çok yapı — depodan seçin</string>
@@ -322,6 +323,7 @@
     <string name="modules_updating">%1$s güncelleniyor — %3$d modülden %2$d.</string>
     <string name="modules_updates_title">Güncellenecek modüller</string>
     <string name="modules_update_versions">%1$s → %2$s · %3$s</string>
+    <string name="modules_update_reinstall">%1$s sürümünü yeniden kur · %2$s</string>
     <string name="modules_update_ignored">Yok sayılıyor</string>
     <string name="modules_update_selected">%1$d modülü güncelle</string>
     <plurals name="modules_updates">

--- a/manager/src/main/res/values-tr/strings_store.xml
+++ b/manager/src/main/res/values-tr/strings_store.xml
@@ -22,6 +22,7 @@
     <string name="store_offline">Kayıtlı katalog gösteriliyor</string>
 
     <string name="store_badge_update">%1$s sürümüne güncelle</string>
+    <string name="store_badge_reinstall">%1$s sürümünü yeniden kur</string>
     <string name="store_badge_installed">Kurulu</string>
     <string name="store_badge_prerelease">Ön sürüm</string>
     <string name="store_updated_on">%1$s tarihinde güncellendi</string>

--- a/manager/src/main/res/values-uk/strings.xml
+++ b/manager/src/main/res/values-uk/strings.xml
@@ -336,6 +336,7 @@
     <string name="action_not_in_store_summary">Оновлення цього модуля перевірити не можна</string>
     <string name="action_update_to">Оновити до %1$s</string>
     <string name="action_update_from">З %1$s · %2$s</string>
+    <string name="action_reinstall_same">Та сама версія · %1$s</string>
     <string name="action_update_running">Встановлення…</string>
     <string name="action_update_no_apk">У цьому випуску немає APK для встановлення</string>
     <string name="action_update_choose">Кілька збірок — виберіть у сховищі</string>
@@ -344,6 +345,7 @@
     <string name="modules_updating">Оновлення %1$s — %2$d з %3$d</string>
     <string name="modules_updates_title">Модулі для оновлення</string>
     <string name="modules_update_versions">%1$s → %2$s · %3$s</string>
+    <string name="modules_update_reinstall">Перевстановити %1$s · %2$s</string>
     <string name="modules_update_ignored">Ігнорується</string>
     <string name="modules_update_selected">Оновити %1$d</string>
     <plurals name="modules_updates">

--- a/manager/src/main/res/values-uk/strings_store.xml
+++ b/manager/src/main/res/values-uk/strings_store.xml
@@ -26,6 +26,7 @@
     <string name="store_offline">Показано збережений каталог</string>
 
     <string name="store_badge_update">Оновити до %1$s</string>
+    <string name="store_badge_reinstall">Перевстановити %1$s</string>
     <string name="store_badge_installed">Встановлено</string>
     <string name="store_badge_prerelease">Попередній випуск</string>
     <string name="store_updated_on">Оновлено %1$s</string>

--- a/manager/src/main/res/values-vi/strings.xml
+++ b/manager/src/main/res/values-vi/strings.xml
@@ -303,6 +303,7 @@
     <string name="action_not_in_store_summary">Không thể kiểm tra bản cập nhật cho mô-đun này</string>
     <string name="action_update_to">Cập nhật lên %1$s</string>
     <string name="action_update_from">Từ %1$s · %2$s</string>
+    <string name="action_reinstall_same">Cùng phiên bản · %1$s</string>
     <string name="action_update_running">Đang cài đặt…</string>
     <string name="action_update_no_apk">Bản phát hành này không có APK</string>
     <string name="action_update_choose">Có nhiều bản dựng — chọn trong kho</string>
@@ -311,6 +312,7 @@
     <string name="modules_updating">Đang cập nhật %1$s — %2$d trên %3$d</string>
     <string name="modules_updates_title">Mô-đun cần cập nhật</string>
     <string name="modules_update_versions">%1$s → %2$s · %3$s</string>
+    <string name="modules_update_reinstall">Cài lại %1$s · %2$s</string>
     <string name="modules_update_ignored">Đang bỏ qua</string>
     <string name="modules_update_selected">Cập nhật %1$d</string>
     <plurals name="modules_updates">

--- a/manager/src/main/res/values-vi/strings_store.xml
+++ b/manager/src/main/res/values-vi/strings_store.xml
@@ -20,6 +20,7 @@
     <string name="store_offline">Đang hiện danh mục đã lưu</string>
 
     <string name="store_badge_update">Cập nhật lên %1$s</string>
+    <string name="store_badge_reinstall">Cài lại %1$s</string>
     <string name="store_badge_installed">Đã cài</string>
     <string name="store_badge_prerelease">Phát hành thử</string>
     <string name="store_updated_on">Cập nhật %1$s</string>

--- a/manager/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/src/main/res/values-zh-rCN/strings.xml
@@ -304,6 +304,7 @@
     <string name="action_not_in_store_summary">无法检查此模块的更新</string>
     <string name="action_update_to">更新到 %1$s</string>
     <string name="action_update_from">当前 %1$s · %2$s</string>
+    <string name="action_reinstall_same">同一版本 · %1$s</string>
     <string name="action_update_running">正在安装…</string>
     <string name="action_update_no_apk">此版本没有可安装的 APK</string>
     <string name="action_update_choose">有多个构建 — 请在仓库中选择</string>
@@ -312,6 +313,7 @@
     <string name="modules_updating">正在更新 %1$s — 第 %2$d 个，共 %3$d 个</string>
     <string name="modules_updates_title">待更新的模块</string>
     <string name="modules_update_versions">%1$s → %2$s · %3$s</string>
+    <string name="modules_update_reinstall">重新安装 %1$s · %2$s</string>
     <string name="modules_update_ignored">已忽略</string>
     <string name="modules_update_selected">更新 %1$d 个</string>
     <plurals name="modules_updates">

--- a/manager/src/main/res/values-zh-rCN/strings_store.xml
+++ b/manager/src/main/res/values-zh-rCN/strings_store.xml
@@ -20,6 +20,7 @@
     <string name="store_offline">正在显示已保存的目录</string>
 
     <string name="store_badge_update">可更新至 %1$s</string>
+    <string name="store_badge_reinstall">重新安装 %1$s</string>
     <string name="store_badge_installed">已安装</string>
     <string name="store_badge_prerelease">预发布</string>
     <string name="store_updated_on">更新于 %1$s</string>

--- a/manager/src/main/res/values-zh-rTW/strings.xml
+++ b/manager/src/main/res/values-zh-rTW/strings.xml
@@ -304,6 +304,7 @@
     <string name="action_not_in_store_summary">無法檢查此模組的更新</string>
     <string name="action_update_to">更新到 %1$s</string>
     <string name="action_update_from">目前 %1$s · %2$s</string>
+    <string name="action_reinstall_same">同一版本 · %1$s</string>
     <string name="action_update_running">正在安裝…</string>
     <string name="action_update_no_apk">此版本沒有可安裝的 APK</string>
     <string name="action_update_choose">有多個建置 — 請在倉庫中選擇</string>
@@ -312,6 +313,7 @@
     <string name="modules_updating">正在更新 %1$s — 第 %2$d 個，共 %3$d 個</string>
     <string name="modules_updates_title">待更新的模組</string>
     <string name="modules_update_versions">%1$s → %2$s · %3$s</string>
+    <string name="modules_update_reinstall">重新安裝 %1$s · %2$s</string>
     <string name="modules_update_ignored">已忽略</string>
     <string name="modules_update_selected">更新 %1$d 個</string>
     <plurals name="modules_updates">

--- a/manager/src/main/res/values-zh-rTW/strings_store.xml
+++ b/manager/src/main/res/values-zh-rTW/strings_store.xml
@@ -20,6 +20,7 @@
     <string name="store_offline">正在顯示已儲存的目錄</string>
 
     <string name="store_badge_update">可更新至 %1$s</string>
+    <string name="store_badge_reinstall">重新安裝 %1$s</string>
     <string name="store_badge_installed">已安裝</string>
     <string name="store_badge_prerelease">預先發行</string>
     <string name="store_updated_on">更新於 %1$s</string>

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -175,6 +175,7 @@
     <string name="modules_updating">Updating %1$s — %2$d of %3$d</string>
     <string name="modules_updates_title">Modules to update</string>
     <string name="modules_update_versions">%1$s → %2$s · %3$s</string>
+    <string name="modules_update_reinstall">Reinstall %1$s · %2$s</string>
     <string name="modules_update_ignored">Ignored</string>
     <string name="modules_update_selected">Update %1$d</string>
     <string name="modules_active_of">%1$d of %2$d active</string>
@@ -273,6 +274,7 @@
     <string name="action_not_in_store_summary">Updates for this module cannot be checked</string>
     <string name="action_update_to">Update to %1$s</string>
     <string name="action_update_from">From %1$s · %2$s</string>
+    <string name="action_reinstall_same">Same version · %1$s</string>
     <string name="action_update_running">Installing…</string>
     <string name="action_update_no_apk">This release has no APK to install</string>
     <string name="action_update_choose">Several builds — choose one in the store</string>

--- a/manager/src/main/res/values/strings_store.xml
+++ b/manager/src/main/res/values/strings_store.xml
@@ -32,6 +32,7 @@
 
     <!-- Rows -->
     <string name="store_badge_update">Update to %1$s</string>
+    <string name="store_badge_reinstall">Reinstall %1$s</string>
     <string name="store_badge_installed">Installed</string>
     <string name="store_badge_prerelease">Prerelease</string>
     <!-- Example: "Updated 23 Jul 2026" -->


### PR DESCRIPTION
Fixes #823.

Four things the reporter walked into, three of them what borrowing `com.android.shell`'s uid costs
the manager. Each commit carries its own reasoning.

**The receiver.** Below API 33 `ContextCompat.registerReceiver` stands in for the missing
`RECEIVER_NOT_EXPORTED` by demanding `<package>.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION`, and under
the host that name is nobody's — so every store install threw before `commit()`. Both installers now
register by hand, and the action carries a UUID, because a plain registration is visible to anything
installed.

**The replace flag.** `createSessionInternal` sets `INSTALL_REPLACE_EXISTING` for ordinary callers and
skips it for `SHELL_UID`/`ROOT_UID`, so a module the device already had failed with `ALREADY_EXISTS`.
That branch is the same from API 27 to AOSP main: a store update has never worked parasitically on any
release, and neither has updating an installed manager from the host.

**An update installing cannot satisfy.** ADB_X is tagged `4115-1.1.1` around a `versionCode 4` APK, so
`4115 > 4` stays true however often it is installed. 8 of the 745 catalogue entries with a single APK
are stuck that way, and no rule over `(code, name)` can settle it — 31 modules never change their tag
code, 17 reuse one versionName across several. So the Store remembers the release it installed and the
version that produced, and where the two names agree the row says "Reinstall 1.1.1" rather than
`1.1.1 → 1.1.1`.

**The in-app browser.** `AwSettings` reads `checkSelfPermission(INTERNET)` when it is constructed, and
AOSP's Shell only requests that from android-12 — so below it WebView loads cache-only and every page
fails as `ERR_CACHE_MISS`, on a device whose networking is fine. The context a WebView is built with
now answers that one question, and only where the platform says no.

Not verified on hardware: whether Chromium's own sockets are satisfied for uid 2000 once
`blockNetworkLoads` is off.
