### PR TITLE
Survive a failed injection, and quieten the scope logs

### DIFF
--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/VectorDaemon.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/VectorDaemon.kt
@@ -102,10 +102,17 @@ object VectorDaemon {
 
     applyNotificationWorkaround()
 
+    // Read this before `sendToBridge`, which leaves the main thread at euid 1000: the config
+    // database lives under a directory only root can enter, so the first process to open it has
+    // to do so while we still have root. On a successful injection a binder thread opens it for
+    // us during specialization, but when the injection fails nothing else has, and the daemon
+    // used to die here on an unreadable preference.
+    val isVerboseLog = ManagerService.isVerboseLog()
+
     // Setup IPC channel for applications by injecting DaemonService binder
     sendToBridge(VectorService.asBinder(), false, systemServerMaxRetry)
 
-    if (!ManagerService.isVerboseLog()) {
+    if (!isVerboseLog) {
       LogcatMonitor.stopVerbose()
     }
 

--- a/zygisk/src/main/cpp/ipc_bridge.cpp
+++ b/zygisk/src/main/cpp/ipc_bridge.cpp
@@ -290,9 +290,9 @@ lsplant::ScopedLocalRef<jobject> IPCBridge::RequestAppBinder(JNIEnv *env, jstrin
                 env->NewGlobalRef(heartbeat_binder.get());
             }
         }
-    } else {
-        LOGD("Transact call to request app binder failed.");
     }
+    // No else: a false transaction is the daemon declining, which is the ordinary answer for a
+    // process no module has in scope. The caller logs that outcome, with the process name.
 
     return result_binder;
 }

--- a/zygisk/src/main/cpp/module.cpp
+++ b/zygisk/src/main/cpp/module.cpp
@@ -324,12 +324,14 @@ void VectorModule::postAppSpecialize(const zygisk::AppSpecializeArgs *args) {
 
     // --- Framework Injection ---
     lsplant::JUTFString nice_name_str(env_, args->nice_name);
-    LOGD("Attempting injection into '{}'.", nice_name_str.get());
+    LOGD("Asking the daemon about '{}'.", nice_name_str.get());
 
     auto &ipc_bridge = IPCBridge::GetInstance();
     auto binder = ipc_bridge.RequestAppBinder(env_, args->nice_name);
     if (!binder) {
-        LOGD("No IPC binder obtained for '{}'. Skipping injection.", nice_name_str.get());
+        // Usually because nothing has it in scope, but the daemon may also not be up yet or have
+        // registered this process already. Only it knows which, and it logs the reason itself.
+        LOGD("Not injecting '{}': the daemon has no binder for it.", nice_name_str.get());
         SetAllowUnload(true);
         return;
     }


### PR DESCRIPTION
Two minor fixes, unrelated to each other.

A process no module has in scope produced three log lines about it, and one called the daemon's ordinary refusal a failure. The duplicate in `ipc_bridge.cpp` goes; the two in `module.cpp` now say what happened. The wording stops short of "out of scope" because the zygisk side cannot tell: `BridgeService.onTransact` also returns false when the daemon binder has not arrived yet, or when the process is already registered. The daemon logs the reason itself.

`sendToBridge` leaves the main thread at euid 1000, and the statement after it read the verbose-log preference out of the config database, which sits under a directory only root can enter. That normally works because a binder thread opens and caches the handle during specialization first, but only when the injection succeeded. When it failed nothing had, and the daemon died on the preference read instead of carrying on — the second half of the crash in #744 and #773. Reading it before `sendToBridge` leaves the check where it was and does the open while we still have root.
