### PR TITLE
Stage a module's native libraries where system_server may map them

### DIFF
--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/data/ConfigCache.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/data/ConfigCache.kt
@@ -396,6 +396,7 @@ object ConfigCache {
 
             val cached = currentState.modules[pkgName]
             if (cached != null) {
+              stageNativeLibrariesFor(cached)
               modules.add(cached)
               return@forEach
             }
@@ -431,12 +432,33 @@ object ConfigCache {
 
             FileSystem.loadModule(apkPath, state.isDexObfuscateEnabled).apkOrNull?.let {
               module.file = it
+              stageNativeLibrariesFor(module)
               modules.add(module)
               // We intentionally don't mutate state.modules here. Cache update will catch it.
             }
           }
         }
+    FileSystem.pruneStagedNativeLibraries(
+        state.miscPath, modules.mapTo(mutableSetOf()) { it.packageName })
     return modules
+  }
+
+  /**
+   * Hands a module bound for system_server the copy of its native libraries it can actually map.
+   *
+   * Only that scope needs one. Every other process may execute straight out of /data/app, so the
+   * in-APK entries the loader already builds serve them, and staging for them would buy nothing but
+   * disk. A module that ships no library, or whose staging failed, keeps a null here and loads
+   * exactly as it did before.
+   */
+  private fun stageNativeLibrariesFor(module: Module) {
+    val file = module.file ?: return
+    // system_server asks for its modules early enough that the cache may not have been built yet,
+    // and this is the same reason getPrefsPath does not trust the field either.
+    setupMiscPath()
+    val misc = state.miscPath ?: return
+    file.nativeLibraryDir =
+        FileSystem.stageNativeLibraries(misc, module.packageName, module.apkPath)
   }
 
   fun getModuleApkPath(info: ApplicationInfo): String? {

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/data/FileSystem.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/data/FileSystem.kt
@@ -3,6 +3,7 @@ package org.matrix.vector.daemon.data
 import android.content.res.AssetManager
 import android.content.res.Resources
 import android.os.Binder
+import android.os.Build
 import android.os.ParcelFileDescriptor
 import android.os.Process
 import android.os.RemoteException
@@ -397,6 +398,102 @@ object FileSystem {
           .onFailure { throw RemoteException("Failed to set SELinux context: ${it.message}") }
     }
     return path
+  }
+
+  /**
+   * Copies a module's native libraries out of its APK into a directory this framework owns, and
+   * answers with that directory.
+   *
+   * A module loaded into system_server cannot dlopen a library straight out of its own APK.
+   * Everything under /data/app is apk_data_file, and while system_server may read and map such a
+   * file it may not execute it; AOSP says why in so many words - "Executable files in /data are a
+   * persistence vector" - and forbids granting it. Every app domain does hold that permission,
+   * which is the whole reason the same module loads the same library without trouble in an ordinary
+   * process and fails only in system_server.
+   *
+   * The way past it is not a new rule but the one this module already ships. xposed_data is a type
+   * we declare ourselves, outside the data_file_type attribute that neverallow is written against,
+   * and `allow * xposed_data {file dir} *` already reaches every domain - system_server included.
+   * A copy placed under it is one system_server may map executable. Extraction has a second
+   * benefit: the library ends up at offset zero of an ordinary file, so it no longer has to be
+   * stored uncompressed and page-aligned inside the APK to be mappable at all.
+   *
+   * Note that this deliberately does not consult moduleLibraryNames. That list only names the
+   * libraries whose native_init we are asked to call, and a module is free to load its own
+   * libraries without declaring any - the module that prompted all this does exactly that.
+   *
+   * Returns null when the module ships nothing for this ABI or the copy failed, in which case the
+   * module still loads and only its native part fails, exactly as it does today.
+   */
+  fun stageNativeLibraries(root: Path, packageName: String, apkPath: String): String? =
+      runCatching {
+            val apk = File(apkPath)
+            val dir = root.resolve("lib").resolve(packageName)
+
+            // Re-extract only when the APK behind the copy changed. Getting this wrong in the
+            // lenient direction would leave system_server running a module's superseded native
+            // code, so the framework's own version is part of the stamp as well.
+            val stamp = "${apk.length()}:${apk.lastModified()}:${BuildConfig.VERSION_CODE}"
+            val stampFile = dir.resolve(".stamp").toFile()
+            if (stampFile.isFile && stampFile.readText() == stamp) return@runCatching dir.toString()
+
+            val abis =
+                if (Process.is64Bit()) Build.SUPPORTED_64_BIT_ABIS else Build.SUPPORTED_32_BIT_ABIS
+
+            ZipFile(apk).use { zip ->
+              val libraries =
+                  zip.entries().asSequence().filter { !it.isDirectory && it.name.endsWith(".so") }
+                      .toList()
+              // A module built for several ABIs keeps them in sibling directories, and only the one
+              // this process could load is worth copying.
+              val abi =
+                  abis.firstOrNull { abi -> libraries.any { it.name.startsWith("lib/$abi/") } }
+                      ?: return@runCatching null
+
+              dir.toFile().deleteRecursively()
+              Files.createDirectories(dir)
+
+              libraries
+                  .filter { it.name.startsWith("lib/$abi/") }
+                  .forEach { entry ->
+                    val target = dir.resolve(entry.name.substringAfterLast('/'))
+                    zip.getInputStream(entry).use { input ->
+                      Files.newOutputStream(target).use { input.copyTo(it) }
+                    }
+                    Os.chmod(target.toString(), "644".toInt(8))
+                  }
+
+              stampFile.writeText(stamp)
+              // The daemon runs with a zero umask, so every mode here is set rather than inherited.
+              Os.chmod(stampFile.absolutePath, "644".toInt(8))
+              // The misc root is searchable but not listable; the staged tree keeps that shape, and
+              // the label is what actually decides whether system_server may map these files.
+              Os.chmod(dir.parent.toString(), "711".toInt(8))
+              Os.chmod(dir.toString(), "711".toInt(8))
+              setSelinuxContextRecursive(dir, "u:object_r:xposed_data:s0")
+              SELinux.setFileContext(dir.parent.toString(), "u:object_r:xposed_data:s0")
+              dir.toString()
+            }
+          }
+          .onFailure { Log.e(TAG, "Failed to stage the native libraries of $packageName", it) }
+          .getOrNull()
+
+  /**
+   * Drops staged libraries belonging to modules that are no longer bound for system_server, so an
+   * uninstalled or rescoped module does not leave a copy of its native code behind for good.
+   */
+  fun pruneStagedNativeLibraries(root: Path?, keep: Set<String>) {
+    if (root == null) return
+    runCatching {
+          val libRoot = root.resolve("lib")
+          if (!libRoot.isDirectory()) return
+          Files.list(libRoot).use { stream ->
+            stream
+                .filter { it.fileName.toString() !in keep }
+                .forEach { it.toFile().deleteRecursively() }
+          }
+        }
+        .onFailure { Log.e(TAG, "Failed to prune staged native libraries", it) }
   }
 
   fun toGlobalNamespace(path: String): File {

--- a/legacy/src/main/java/de/robv/android/xposed/XposedInit.java
+++ b/legacy/src/main/java/de/robv/android/xposed/XposedInit.java
@@ -291,6 +291,13 @@ public final class XposedInit {
         Log.v(TAG, "Loading legacy module " + name + " from " + apk);
 
         var sb = new StringBuilder();
+        // In system_server the in-APK entries below can only ever be refused: /data/app is
+        // apk_data_file, which that domain may read and map but never execute. The daemon stages a
+        // copy under a label we own for exactly this reason, and it has to come first, because
+        // findLibrary answers with the first candidate it can open.
+        if (startsSystemServer && file.nativeLibraryDir != null) {
+            sb.append(file.nativeLibraryDir).append(File.pathSeparator);
+        }
         var abis = Process.is64Bit() ? Build.SUPPORTED_64_BIT_ABIS : Build.SUPPORTED_32_BIT_ABIS;
         for (String abi : abis) {
             sb.append(apk).append("!/lib/").append(abi).append(File.pathSeparator);

--- a/services/daemon-service/src/main/aidl/org/lsposed/lspd/models/PreLoadedApk.aidl
+++ b/services/daemon-service/src/main/aidl/org/lsposed/lspd/models/PreLoadedApk.aidl
@@ -8,4 +8,8 @@ parcelable PreLoadedApk {
     // module.prop 'exceptionMode', normalised by the daemon. false, the value an absent key
     // parses to, is PROTECTIVE - what ExceptionMode.DEFAULT is specified to fall back to.
     boolean exceptionPassthrough;
+    // Where the daemon staged this module's native libraries, for the one process that cannot map
+    // them out of the APK. Null when the module ships none for this ABI, when staging failed, or
+    // when the module was never destined for system_server in the first place.
+    @nullable String nativeLibraryDir;
 }

--- a/xposed/src/main/kotlin/org/matrix/vector/impl/core/VectorModuleManager.kt
+++ b/xposed/src/main/kotlin/org/matrix/vector/impl/core/VectorModuleManager.kt
@@ -30,6 +30,15 @@ object VectorModuleManager {
 
             // Construct the native library search path
             val librarySearchPath = buildString {
+                // In system_server the in-APK entries below can only ever be refused: /data/app is
+                // apk_data_file, which that domain may read and map but never execute. The daemon
+                // stages a copy under a label we own for exactly this reason, and it has to come
+                // first, because findLibrary answers with the first candidate it can open.
+                if (isSystemServer) {
+                    module.file.nativeLibraryDir?.let {
+                        append(it).append(File.pathSeparator)
+                    }
+                }
                 val abis =
                     if (Process.is64Bit()) Build.SUPPORTED_64_BIT_ABIS
                     else Build.SUPPORTED_32_BIT_ABIS
@@ -68,6 +77,14 @@ object VectorModuleManager {
                         else ExceptionMode.PROTECTIVE,
                 )
 
+            // Register any native JNI entrypoints declared by the module. This has to happen before
+            // the entry classes run: a module is free to load its libraries from its constructor or
+            // from onModuleLoaded, and an entrypoint recorded afterwards is one the dlopen hook has
+            // already missed. The legacy loader has always done it in this order.
+            module.file.moduleLibraryNames.forEach { libraryName ->
+                NativeAPI.recordNativeEntrypoint(libraryName)
+            }
+
             // Instantiate the module entry classes
             for (className in module.file.moduleClassNames) {
                 runCatching {
@@ -99,11 +116,6 @@ object VectorModuleManager {
                         )
                     }
                     .onFailure { e -> Log.e(TAG, "Failed to instantiate class $className", e) }
-            }
-
-            // Register any native JNI entrypoints declared by the module
-            module.file.moduleLibraryNames.forEach { libraryName ->
-                NativeAPI.recordNativeEntrypoint(libraryName)
             }
 
             Log.d(TAG, "Loaded module ${module.packageName} successfully.")


### PR DESCRIPTION
A module scoped to system_server cannot load its own native library:

```
java.lang.UnsatisfiedLinkError: dlopen failed: couldn't map
  ".../com.tsng.hidemyapplist-.../base.apk!/lib/arm64-v8a/libhmahook.so"
  segment 2: Permission denied
```

The dlopen is Android's rather than ours. The module calls `System.loadLibrary`, and the only thing this framework contributes is the search path, which both loaders build purely out of in-APK entries of the form `<apk>!/lib/<abi>`. bionic opens the APK, maps the read-only segments, and then fails on the first one that wants `PROT_EXEC` — [`ElfReader::MapSegment`][mapsegment], where the `%m` in [that message][dlerr] is `strerror(errno)`, so it is `EACCES` spelled out. The kernel asks for [`FILE__EXECUTE`][fileexec] exactly when a mapping requests `PROT_EXEC`, and `/data/app` is [`apk_data_file`][filecontexts], a type AOSP lets system_server [read, open, getattr and map][ssapk] but never execute. `appdomain` holds [`x_file_perms`][xperms] on [that same type][appte], which is why the identical library loads in every app process and fails only here. The Android 15 and 16 trees agree on all of it.

Granting the missing permission is not open to us: `system_server.te` carries [`neverallow system_server data_file_type:file no_x_file_perms`][neverallow], and `apk_data_file` is a `data_file_type`.

What this does instead needs no new rule. `xposed_data` is already declared a plain `file_type`, deliberately outside `data_file_type`, and the `allow * xposed_data {file dir} *` we already ship expands over every domain in the policy through [magiskpolicy's match-all operator][magiskpolicy], system_server among them, with `execute` and `map` included; the daemon already creates `/data/misc/<uuid>` and labels it. So `FileSystem.stageNativeLibraries` copies a system_server-bound module's `lib/<abi>/*.so` into `<misc>/lib/<package>/` at 0644 under 0711 directories, and the loader puts that directory first on the search path when it is loading into system_server. Everything else keeps the in-APK path it already had.

The copy is keyed to the APK's size and mtime and to the framework's versionCode, so a module that updates is re-extracted rather than leaving system_server running native code it has since replaced, and directories whose module is no longer bound for system_server are dropped. Staging deliberately pays no attention to `moduleLibraryNames`: that list only names the libraries whose `native_init` we are asked to call, and nothing stops a module loading its own without declaring any. [HMA][hma] ships no `native_init.list` at all, so gating on it would have fixed nothing for the module that prompted this.

While here, the modern loader registers the declared native entrypoints before the entry classes run instead of after, which is what the legacy loader has always done. A module that loads its library from a constructor or from `onModuleLoaded` was registering it after the `do_dlopen` hook had already missed it.

Verified on an SM-A536B, Android 15, enforcing, KernelSU with NeoZygisk, running `HMA-V3.8.2.r517` scoped to `system`. Before the change the kernel says it twice, once as the denial and once as the syscall it came from:

```
avc:  denied  { execute } for  comm="HMA-ServiceInit"
  path=".../com.tsng.hidemyapplist-.../base.apk"
  scontext=u:r:system_server:s0 tcontext=u:object_r:apk_data_file:s0
  tclass=file permissive=0

type=1300 ... arch=c00000b7 syscall=222 success=no exit=-13 a2=5 a3=12
  comm="HMA-ServiceInit" exe="/system/bin/app_process64" subj=u:r:system_server:s0
```

On arm64 syscall 222 is `mmap`, `a2=5` is `PROT_READ|PROT_EXEC`, `a3=0x12` is `MAP_PRIVATE|MAP_FIXED`, and `exit=-13` is `EACCES`; `readelf` puts the `R E` `PT_LOAD` of `libhmahook.so` at program-header index 2, which is where the reported "segment 2" comes from. After it, the same module in the same process loads out of the staged copy:

```
V/VectorNative: do_dlopen hook triggered for library:
  '/data/misc/<uuid>/lib/com.tsng.hidemyapplist/libhmahook.so'
```

with no execute denial anywhere in the boot, against two before, and HMA itself reporting `Module Activated [3.8.2-517]` and `System service running [104]`. A small test module written for this reproduces the same failure in system_server on master, loads from the staged directory on this branch, and in an ordinary app process, in the same boot, still loads straight out of its APK.

[mapsegment]: https://android.googlesource.com/platform/bionic/+/refs/heads/android16-release/linker/linker_phdr.cpp#852
[dlerr]: https://android.googlesource.com/platform/bionic/+/refs/heads/android16-release/linker/linker_phdr.cpp#866
[fileexec]: https://android.googlesource.com/kernel/common/+/refs/heads/android15-6.6/security/selinux/hooks.c#3793
[filecontexts]: https://android.googlesource.com/platform/system/sepolicy/+/refs/heads/android16-release/private/file_contexts#611
[ssapk]: https://android.googlesource.com/platform/system/sepolicy/+/refs/heads/android16-release/private/system_server.te#535
[xperms]: https://android.googlesource.com/platform/system/sepolicy/+/refs/heads/android16-release/public/global_macros#24
[appte]: https://android.googlesource.com/platform/system/sepolicy/+/refs/heads/android16-release/private/app.te#443
[neverallow]: https://android.googlesource.com/platform/system/sepolicy/+/refs/heads/android16-release/private/system_server.te#1452
[magiskpolicy]: https://github.com/topjohnwu/Magisk/blob/master/docs/tools.md#magiskpolicy
[hma]: https://github.com/Dr-TSNG/Hide-My-Applist/issues/363
