### PR TITLE
Keep what saved instance state is restored through

### DIFF
--- a/manager/proguard-rules.pro
+++ b/manager/proguard-rules.pro
@@ -23,6 +23,29 @@
 # Gson models are constructed reflectively from field names.
 -keepclassmembers class org.matrix.vector.manager.data.model.** { <fields>; }
 
+# An enum's constants are reached reflectively: Enum.valueOf asks the class for its values()
+# method by name. Kotlin no longer calls that method itself — `entries` compiles to its own
+# synthetic field — so the last call site is usually gone and R8 shrinks values() away, which
+# leaves every enum in the APK undeserializable. Compose saved instance state is what reaches it
+# here: Parcel has no enum case and java.lang.Enum is Serializable, so a saved enum is written
+# as VAL_SERIALIZABLE, and restoring the activity after its process died threw
+# NoSuchMethodException on the navigation suite's own state value (#871). AGP's
+# proguard-android-optimize.txt carries this stanza, but that file has not been on the
+# proguardFiles list since #263, so it has to be written out here.
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+
+# The same restore path reaches Parcelables, and finds their CREATOR by a reflective field lookup
+# that R8 cannot see either, so it drops the field from every class that does not otherwise
+# reference it. Compose keeps its own state in one: a `mutableStateOf` that survives process death
+# is a ParcelableSnapshotMutableState, and reading it back threw BadParcelableException. The legacy
+# manager carried this rule by hand; the rewrite in #796 did not bring it across.
+-keepclassmembers class * implements android.os.Parcelable {
+    public static final ** CREATOR;
+}
+
 # OkHttp / Okio ship analysis-only references to optional platform classes.
 -dontwarn okhttp3.internal.**
 -dontwarn org.conscrypt.**


### PR DESCRIPTION
Fixes #871, and #834 before it.

The manager crashes when its activity is restored after the host process has been reaped. Two keep rules are missing from `manager/proguard-rules.pro`, and the second one is only reachable once the first is in place.

Android resolves an enum's constants by reflective name lookup: `Enum.valueOf` asks the class for `values()`. Kotlin no longer calls that method itself — `entries` compiles to its own synthetic field — so the last call site is gone and R8 shrinks it away, from 105 of the 106 enums the released manager carries. An enum held in saved instance state goes into the Bundle as `VAL_SERIALIZABLE`, since `Parcel` has no enum case and `java.lang.Enum` is `Serializable`, and it can then no longer be read back. The navigation suite scaffold state is one such enum, and it sits above every screen.

`CREATOR` is found the same way, by a field lookup R8 cannot see, and it had been dropped from every `Parcelable` the manager does not already keep by name. A `mutableStateOf` that survives process death is a `ParcelableSnapshotMutableState`, so with the enums restored the same read fails with `BadParcelableException` instead.

Both stanzas are AGP's, from `proguard-android-optimize.txt`. That file stopped being passed to `proguardFiles` in #263. The manager it was dropped from copied the `CREATOR` rule back by hand and declared no enums at all, so neither rule was missed until #796.
