### PR TITLE
Bypass the SystemUI notification flags on Android 15 too

### DIFF
--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/utils/Workarounds.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/utils/Workarounds.kt
@@ -38,9 +38,24 @@ fun IUserManager.getRealUsers(): List<UserInfo> {
   return users
 }
 
-/** Android 16 DP1 SystemUI FeatureFlag and Notification Builder workaround. */
+/**
+ * Notification.Builder workaround for the SystemUI feature flags.
+ *
+ * Android 16 reads an aconfig flag from the `systemui` container while constructing a
+ * `Notification`, and the generated `FeatureFlagsImpl` only reads it once, guarded by
+ * `systemui_is_cached`. The read goes out to `content://settings/config`, which the daemon cannot
+ * reach: it has an ActivityThread but no application record, so the system refuses it a provider
+ * and the constructor throws `SecurityException`. Setting the guard leaves the flags at their
+ * defaults and skips the read entirely.
+ *
+ * The read belongs to Android 16 and is gone again in Android 17, where the constructor sets the
+ * fields unconditionally. It reaches Android 15 all the same, on vendor builds that took the change
+ * without taking the SDK level: #96 and #880 are both Xiaomi HyperOS on 15. The test therefore
+ * spans the versions where the field can exist rather than naming one, and a device that never had
+ * it fails with a `ClassNotFoundException` that is ignored.
+ */
 fun applyNotificationWorkaround() {
-  if (Build.VERSION.SDK_INT == 36) {
+  if (Build.VERSION.SDK_INT in Build.VERSION_CODES.VANILLA_ICE_CREAM..36) {
     runCatching {
           val feature = Class.forName("android.app.FeatureFlagsImpl")
           val field = feature.getDeclaredField("systemui_is_cached").apply { isAccessible = true }


### PR DESCRIPTION
Constructing a `Notification` reads an aconfig flag of the `systemui` container ([`Notification()` on `android16-release`](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/android16-release/core/java/android/app/Notification.java#2741), [flag declaration](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/android16-release/core/java/android/app/notification.aconfig)). The generated `FeatureFlagsImpl` caches that read behind `systemui_is_cached`, and the read itself queries `content://settings/config`, which the daemon cannot obtain: it holds an `ActivityThread` but no application record, so `ActivityManagerService` refuses it a provider ([`ContentProviderHelper`](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/android16-release/services/core/java/com/android/server/am/ContentProviderHelper.java)) and the constructor throws `SecurityException`. The field is set only after the read returns, so the failure never converges and every later construction repeats it. Setting it in advance leaves the flags at their compiled defaults and removes the read ([feature flagging](https://source.android.com/docs/setup/build/feature-flagging)).

The bypass dates from `1b98e55cf` and was gated on `SDK_INT >= VANILLA_ICE_CREAM`. The read belongs to Android 16, but the gate was wider on purpose: #96 was a Xiaomi HyperOS device failing this way on Android 15, filed four days before [Android 16 DP1 was published](https://android-developers.googleblog.com/2024/11/first-developer-preview-android16.html), the vendor having taken the platform change without the SDK level. #597 rewrote the gate as `SDK_INT == 36` and that case was lost. #880 is the same report as #96, same vendor and same version, and its reporter confirms 2.0 (3021) predates #597 and works while 2.2 (3080) does not.

Android 17 sets the fields unconditionally and the flag is gone from the class ([`Notification()` on `android17-release`](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/android17-release/core/java/android/app/Notification.java)), so the test spans 35 to 36: the versions in which the field can exist, rather than the version that introduced it. A device that never carried it fails with the `ClassNotFoundException` already ignored there. The unguarded builders in `NotificationManager` are left as they are.
