### PR TITLE
Keep the bars docked to the window out of the navigation bar

### DIFF
--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/home/HomeScreen.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/home/HomeScreen.kt
@@ -14,7 +14,8 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -40,6 +41,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -210,8 +212,12 @@ fun HomeScreen(
 
     Scaffold(
         // The header draws its own status-bar inset so it can run under the bar; letting the
-        // Scaffold consume it here would leave a band of plain background above the pane.
-        contentWindowInsets = WindowInsets(0),
+        // Scaffold consume it here would leave a band of plain background above the pane. The
+        // bottom is the Scaffold's to reserve, though: with the panels floating there is no
+        // navigation container underneath to have taken it, and the last row of the feed would end
+        // up behind three-button navigation. Already-consumed insets are excluded from this, so it
+        // still adds nothing in the arrangements where a container is there.
+        contentWindowInsets = ScaffoldDefaults.contentWindowInsets.only(WindowInsetsSides.Bottom),
         snackbarHost = { VectorSnackbarHost(snackbars) },
     ) { padding ->
         val listState = rememberLazyListState()

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/modules/ScopeScreen.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/modules/ScopeScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -1037,7 +1038,19 @@ private fun ApplyBar(
 ) {
     Surface(tonalElevation = 3.dp, color = MaterialTheme.colorScheme.surfaceContainerHigh) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp),
+            // The bar is the last child of the window, and this screen is a detail screen: the
+            // navigation container is hidden here, so nothing above has reserved the system bars
+            // and Scaffold hands its bottom slot the whole window. Without this the buttons sit
+            // under three-button navigation, where what is left of them is a few pixels tall.
+            //
+            // Inside the Surface rather than on it, so the tonal fill still runs to the bottom
+            // edge and the bar reads as one surface rather than as a strip floating above the
+            // system's own. Insets already consumed count for nothing here, so the same call is
+            // correct in the arrangements where a container below has taken them.
+            modifier =
+                Modifier.fillMaxWidth()
+                    .navigationBarsPadding()
+                    .padding(horizontal = 16.dp, vertical = 10.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Column(Modifier.weight(1f)) {

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/report/TroubleshootScreen.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/report/TroubleshootScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -120,7 +121,9 @@ fun TroubleshootScreen(
         bottomBar = {
             Surface(tonalElevation = 3.dp) {
                 Row(
-                    modifier = Modifier.fillMaxWidth().padding(20.dp),
+                    // Scaffold places its bottom slot against the bottom of the window and leaves
+                    // the system bars to it, so the button says where it stands itself.
+                    modifier = Modifier.fillMaxWidth().navigationBarsPadding().padding(20.dp),
                     horizontalArrangement = Arrangement.Center,
                 ) {
                     Button(onClick = { onOpenUrl(GitHubRepository.ISSUES_URL) }) {

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/update/FrameworkUpdateScreen.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/update/FrameworkUpdateScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -312,6 +313,10 @@ private fun UpdateBar(
         modifier =
             Modifier.fillMaxWidth()
                 .background(colors.surfaceContainer)
+                // After the fill, before the padding: the container colour runs to the bottom edge
+                // of the window while the flash button stays clear of three-button navigation,
+                // which Scaffold leaves to its bottom slot rather than reserving itself.
+                .navigationBarsPadding()
                 .padding(horizontal = 16.dp, vertical = 12.dp)
     ) {
         when (flash) {


### PR DESCRIPTION
`Scaffold` places its bottom slot against the bottom of the window and reserves nothing for it — the documentation says `topBar` and `bottomBar` are expected to handle insets themselves, which is why `NavigationBar` and `BottomAppBar` carry `windowInsets` of their own. Three of the four docked bars here are plain `Surface`s and reserved nothing: the scope editor's apply bar, the tracker button, the flash bar. `RepoDetailsScreen`'s install bar already did it and is the pattern they follow.

It bites on every detail screen whatever the navigation style, because the container is hidden away from a panel root and `NavigationSuiteScaffold` consumes `NoWindowInsets` while hidden. Three-button navigation is 48dp, which left a few pixels of Apply and Discard to aim at (#884); gesture navigation is 24dp and was covered too.

The padding sits inside each `Surface`, so the fill still reaches the bottom edge.

Home is the same fault inverted: `contentWindowInsets` was zero so the header could run under the status bar, which gave away the bottom as well. It now takes the bottom edge alone.

Verified on a Pixel 6 (Android 17) under both styles. The eleven `ModalBottomSheet`s need nothing.
