### PR TITLE
docs: add Chinese README translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 </div>
 
+[中文文档（简体）](README_zh-CN.md)
+
 ---
 
 ### Introduction

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -1,0 +1,125 @@
+# Vector 框架
+
+[英文文档（English）](README.md)
+
+**面向现代 Android 的高性能 ART Hook 框架**
+
+<div align="center">
+
+[![Build](https://img.shields.io/github/actions/workflow/status/JingMatrix/Vector/core.yml?branch=master&event=push&logo=github&label=Build)](https://github.com/JingMatrix/Vector/actions/workflows/core.yml?query=event%3Apush+branch%3Amaster+is%3Acompleted)
+[![Crowdin](https://img.shields.io/badge/Localization-Crowdin-blueviolet?logo=Crowdin)](https://crowdin.com/project/lsposed_jingmatrix)
+[![Download](https://img.shields.io/github/v/release/JingMatrix/Vector?color=orange&logoColor=orange&label=Download&logo=DocuSign)](https://github.com/JingMatrix/Vector/releases/latest)
+[![Total](https://shields.io/github/downloads/JingMatrix/Vector/total?logo=Bookmeter&label=Counts&logoColor=yellow&color=yellow)](https://github.com/JingMatrix/Vector/releases)
+
+</div>
+
+---
+
+### 简介
+
+Vector 是一个 Zygisk 模块，提供与原始 Xposed API 保持兼容的 ART Hook 框架。它基于
+[LSPlant](https://github.com/JingMatrix/LSPlant) 构建，旨在提供稳定的原生级插桩环境。
+
+该框架允许模块在内存中修改系统和应用行为。由于不会修改任何 APK 文件，修改是非破坏性的，重启即可轻松回滚，并且在不同 ROM 与 Android 版本间具有兼容性。
+
+---
+
+### 兼容性
+
+Vector 支持运行 **Android 8.1 到 Android 17 Beta** 的设备。
+
+> [!TIP]
+> 本框架要求安装最近版本的 Magisk 或 KernelSU，并启用 Zygisk。
+
+---
+
+### 安装
+
+1. 下载最新发布版本作为系统模块。
+2. 通过你的 root 管理器（Magisk/KernelSU）安装该模块。
+3. 确保 Zygisk 环境可用（例如 [NeoZygisk](https://github.com/JingMatrix/NeoZygisk)）。
+4. 重启设备。
+5. 通过系统通知进入管理设置页。
+
+---
+
+### 下载
+
+| 渠道 | 来源 |
+| :--- | :--- |
+| **稳定版（Stable Releases）** | [GitHub Releases](https://github.com/JingMatrix/Vector/releases) |
+| **Canary（CI）构建** | [GitHub Actions](https://github.com/JingMatrix/Vector/actions/workflows/core.yml?query=branch%3Amaster) |
+
+> [!NOTE]
+> 如果你正在遇到问题或进行故障排查，建议使用 Debug 构建。
+> 我们鼓励用户测试 CI 构建，帮助我们快速定位 bug 并加快开发。
+
+> [!CAUTION]
+> GitHub 要求用户登录后才能下载 CI 构建产物。
+>
+> 上述链接仅显示 `master` 分支的构建。
+> 注意，Pull Request（PR）构建通常不稳定且可能不安全（取决于贡献者），建议除非应 debug 调试要求，否则始终使用
+> `master` 分支构建。
+
+---
+
+### 支持与贡献
+
+如果你遇到问题，或希望帮助改进项目，请查看以下资源：
+
+*   **故障排查：** 先阅读 [指南](https://github.com/JingMatrix/Vector/issues/123) 再提交 Bug。
+*   **讨论区：** 在 [GitHub Discussions](https://github.com/JingMatrix/Vector/discussions) 参与讨论。
+*   **本地化：** 通过 [Crowdin](https://crowdin.com/project/lsposed_jingmatrix) 帮助项目翻译。
+
+> [!IMPORTANT]
+> 仅接受基于 **最新版 Debug 构建** 的 Bug Report。
+>
+> *给中文用户的说明：*
+>
+> 为提高沟通效率，本项目仅接受英文 Issue。请使用 [DeepL](https://www.deepl.com/zh/translator) 或其他翻译工具提交反馈。
+
+---
+
+### 开发者资源
+
+Vector 同时支持旧版与现代 Hook 标准，以保证更广泛的模块兼容性。
+
+*   [Legacy Xposed API](https://api.xposed.info/)
+*   [Modern libxposed API](https://libxposed.github.io/api/)
+*   [Xposed Module Repository](https://github.com/Xposed-Modules-Repo)
+
+> [!NOTE]
+> Vector 通过两个 git 子模块提供 `libxposed` API：[module API](./xposed/) 与 [service API](./services/)。
+>
+> 成功通过 [master](https://github.com/JingMatrix/Vector/tree/master) 分支的 GitHub Actions 构建表示 Vector 在该提交点对这些 API 提供完整支持。
+> 建议开发者同步检出与 Vector 相同提交。
+
+---
+
+### 致谢
+
+本项目基于以下开源贡献完成：
+
+*   [Magisk](https://github.com/topjohnwu/Magisk/): Android 客户化定制的基础。
+*   [LSPlant](https://github.com/JingMatrix/LSPlant): 核心 ART Hook 引擎。
+*   [XposedBridge](https://github.com/rovo89/XposedBridge): 标准的 Xposed API。
+*   [Dobby](https://github.com/JingMatrix/Dobby): Inline Hook 实现。
+*   [LSPosed](https://github.com/LSPosed/LSPosed): 上游源代码。
+*   [EdXposed](https://github.com/ElderDrivers/EdXposed): LSPosed 之前的上游源。
+*   [xz-embedded](https://github.com/tukaani-project/xz-embedded): 库解压工具库。
+
+<details>
+<summary>旧版和历史依赖</summary>
+
+- ~~[Riru](https://github.com/RikkaApps/Riru)~~
+- ~~[SandHook](https://github.com/ganyao114/SandHook/)~~
+- ~~[YAHFA](https://github.com/rk700/YAHFA)~~
+- ~~[dexmaker](https://github.com/linkedin/dexmaker)~~
+- ~~[DexBuilder](https://github.com/LSPosed/DexBuilder)~~
+</details>
+
+---
+
+### 许可证
+
+Vector 采用 [GNU 通用公共许可证 v3](http://www.gnu.org/copyleft/gpl.html)。

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -1,5 +1,7 @@
 # Vector Daemon Subsystem
 
+[中文文档（简体）](README_zh-CN.md)
+
 The Vector daemon is a standalone, root-privileged Dalvik executable bootstrapped via `app_process`. Operating entirely outside the standard Android application sandbox, it serves as the central coordinator, state manager, and inter-process communication (IPC) asset server for the Vector framework. 
 
 Target processes operating under strict Android sandbox and SELinux constraints cannot safely access external configuration files or SQLite databases. The daemon offloads these operations, providing an IPC backend that serves memory-mapped resources, configuration states, and native file descriptors to target applications securely and efficiently.

--- a/daemon/README_zh-CN.md
+++ b/daemon/README_zh-CN.md
@@ -1,0 +1,109 @@
+# Vector Daemon 子系统
+
+[英文文档（English）](README.md)
+
+Vector daemon 是一个独立的、具 root 权限的 Dalvik 可执行程序，通过 `app_process` 引导启动。
+它完全运行在标准 Android 应用沙箱之外，承担 Vector 框架的中心协调、状态管理以及 IPC 资产服务。
+
+在严格的 Android 沙箱和 SELinux 约束下，目标进程不能安全访问外部配置文件或 SQLite 数据库。
+daemon 代替这些操作，提供 IPC 后端，向目标应用安全高效地下发内存映射资源、状态与 native 文件描述符。
+
+## 目录结构
+
+daemon 按职责划分为多个包，覆盖 IPC、状态管理、系统交互与 native 环境。
+
+```text
+src/main/
+├── jni/                      # Native C++ 实现（dex2oat wrapper、logcat parser）
+└── kotlin/org/matrix/vector/daemon/
+    ├── data/                 # SQLite schema、不可变状态缓存、文件操作
+    ├── env/                  # UNIX 域套接字服务器与 native 进程监听
+    ├── ipc/                  # AIDL 端点（Framework、Manager、ModuleApp、InjectedModule、SystemServer）
+    ├── system/               # 系统 binder 代理与通知 UI
+    ├── utils/                # Context 伪装、签名校验与 JNI 桥
+    ├── Cli.kt                # 命令行接口定义
+    ├── VectorDaemon.kt       # 主入口与 looper 初始化
+    └── VectorService.kt      # 主要的 IVectorDaemon 实现
+```
+
+## 并发与状态管理
+
+为避免并发 IPC 请求耗尽 Android Binder 线程池，daemon 将后台 I/O 与状态读取分离。
+
+* 不可变状态容器：`DaemonState` 数据类持有一个冻结快照，包含全部启用模块与进程作用域。IPC 线程读取该对象无需加锁。
+* 原子替换：底层 SQLite 变更后，daemon 会触发一次 conflated channel 请求。后台协程查询数据库，计算新模块拓扑，创建新的 `DaemonState`，并原子性替换 `ConfigCache` 中的引用。
+* 偏好隔离：高频模块偏好读写与核心状态分离，由 `PreferenceStore` 管理。偏好被序列化为二进制 blob，并以差量更新方式下发模块，避免不必要的缓存重建。
+
+## IPC 架构
+
+daemon 实现了多层 IPC 设计，使用 Android Binder 与 UNIX 域套接字。它不向 `ServiceManager` 注册标准 AIDL 服务，而是通过 Zygisk 模块拦截 Binder 事务，
+并主动将 Binder 引用推送给目标进程。
+
+### 1. System Server 初始化
+
+设备启动期间，daemon 与驻留在 `system_server` 的本地 Vector Zygisk 模块建立通信。
+
+* daemon 注册 `IServiceCallback`，监听硬件代理服务（通常是 `serial` 服务）的注册；一旦被拦截，daemon 使用自身 binder 替换该代理服务。
+* Zygisk 模块向该代理请求框架加载 dex 与混淆映射，通过 `SharedMemory` 获取 `framework loader DEX` 和类混淆映射表。
+* 同时，daemon 向 `activity` 服务发送原始 `ACTION_SEND_BINDER` 事务。Zygisk 的 JNI hook 在该事务进入 Activity Manager 前拦截并提取、保存 daemon 主入口 `VectorService` 的 binder，以备后续使用。
+
+### 2. 目标应用握手
+
+标准用户应用启动时会向 daemon 请求框架访问。
+
+* 目标应用查询 `activity` 服务。位于 `system_server` 的 Zygisk 模块会拦截该查询。
+* `system_server` 利用已保存的 `VectorService` 引用，将应用的 UID、PID、进程名以及新建的 heartbeat `BBinder` 发送给 daemon。
+* daemon 基于 `ConfigCache` 校验该应用是否在任意已启用模块的作用域内。
+* 若通过验证，daemon 返回 `FrameworkService` binder，由 `system_server` 回写给目标应用。
+* daemon 将 `DeathRecipient` 挂载到 heartbeat binder；当应用进程退出时自动清理内部追踪表。
+* 目标应用使用 `FrameworkService` binder 获取其模块列表、框架 DEX 与混淆映射。
+
+### 3. Libxposed 模块注入
+
+与目标应用主动请求不同，daemon 会主动把 API binder 推送到模块进程。该机制仅对使用现代 libxposed API 的模块生效。
+
+* daemon 向 Activity Manager 注册 `IUidObserver`，监听进程生命周期。
+* 当 UID 变为 active，`ModuleAppService` 检查该 UID 是否属于启用中的 libxposed 模块。
+* daemon 获取 `IXposedService` binder。为交付该 binder，daemon 调用 `IActivityManager.getContentProviderExternal`，
+  目标 authority 为模块包名构造的合成字符串。
+* daemon 在 `IContentProvider.call` 中发送 `SEND_BINDER` 动作与包含 binder 的 `Bundle`；这会在 `Application.onCreate` 执行前把 binder 注入模块进程，进而提供 API 校验、作用域请求与远程偏好能力。
+
+### 4. Native Socket IPC
+
+对于不在 Java Binder 上下文内运行的 native 组件，daemon 会创建两种不同的 UNIX 域套接字。
+
+* 命令行接口：`CliSocketServer` 在 `/data/adb/lspd/.cli_sock` 暴露基于文件系统的 socket。CLI 客户端使用内置 UUID 令牌认证，通过结构化 JSON 通讯。对于实时日志流，
+  daemon 会在响应中附带日志文件原始 `FileDescriptor`，客户端可直接从 OS 级缓冲读取。
+* Dex2Oat Wrapper：`Dex2OatServer` 监听抽象 UNIX socket。为避免冲突与检测，安装模块时该抽象 socket 名会随机化。C++ 的 `dex2oat`
+  wrapper 通过 `SCM_RIGHTS` 连接该 socket 获取执行所需描述符。
+
+## Native 环境子系统
+
+daemon 借助 native C++ 子系统直接拦截 Android 编译链路并解析系统 log 缓冲，避免使用常规 shell 工具带来的额外开销与限制。
+
+### AOT 编译劫持
+
+Android ART 编译器会激进地进行内联，导致内联方法在运行期无法被 hook。为了全局强制使用
+`--inline-max-code-units=0`，Vector 挂载了覆盖系统 `dex2oat` 与 `dex2oat64` 的 C++ wrapper。
+
+daemon 完全通过 native JNI 层管理这套拦截。为确保替换后的编译器对新进程可见，daemon 会 fork 一个有权限的子进程，并通过 `setns` + `CLONE_NEWNS`
+进入 `init`（PID 1）挂载命名空间（通过 `/proc/1/ns/mnt`）。随后它在 `/apex` 下的目标编译器二进制上执行只读绑定挂载
+（`MS_BIND | MS_REMOUNT | MS_RDONLY`）。
+
+wrapper 运行时会连接 daemon 的抽象 UNIX socket，通过 `SCM_RIGHTS` 拉取原始编译器与 hook 库（`liboat_hook.so`）。
+为保证无 SELinux 拒绝，daemon 在绑定 socket 前会动态写入 `/proc/self/task/[tid]/attr/sockcreate`，
+告诉内核为该抽象 socket 打上特定上下文（如 `u:r:dex2oat:s0` 或 `u:r:installd:s0`），与编译器的严格 domain 匹配。
+
+若 wrapper 被禁用或不兼容，daemon 会卸载对应二进制，并通过 `resetprop` 直接把 inline flag 写入
+`dalvik.vm.dex2oat-flags` 系统属性作为回退。Kotlin daemon 通过监听 `/sys/fs/selinux/enforce` 与策略文件的 `FileObserver` 持续监控 SELinux 状态；
+当系统进入宽松模式或策略变化时自动重挂载 wrapper，确保拦截链路持续生效。
+
+### Native Logcat 监控
+
+daemon 不再依赖标准 logcat shell 命令，而是直接通过 C++ 进程对 Android `liblog` 缓冲区（`LOG_ID_MAIN` 与 `LOG_ID_CRASH`）进行接口层解析。
+
+native 解析器对日志事件进行零拷贝处理，仅保留预定义精确 tag（如 Magisk、KernelSU）和前缀 tag（如 dex2oat、Vector、LSPosed）输出。最终会写入两类轮转文件：
+模块框架日志与系统 verbose 调试日志，在达到 4MB 后分别自动切换。
+
+为了控制这条隔离的 native 循环，Kotlin daemon 会向 Android log 流注入触发字符串（如 `!!refresh_modules!!`、`!!start_verbose!!`）。
+该 C++ 解析器拦截自父进程 PID 发出的这些消息后，无需额外 IPC 开销即可动态切换文件描述符或日志级别。

--- a/daemon/src/main/jni/obfuscation.h
+++ b/daemon/src/main/jni/obfuscation.h
@@ -7,8 +7,8 @@
 
 #include "logging.h"
 
-// 为 dex::Writer 提供自定义分配器，创建一个 ashmem 区域。
-// 管理虚拟内存映射生命周期，避免泄露。
+// Custom allocator for dex::Writer that creates an ashmem region.
+// Manages the virtual memory mapping lifecycle to prevent memory leaks.
 class DexAllocator : public dex::Writer::Allocator {
     void* mapped_mem_ = nullptr;
     size_t mapped_size_ = 0;
@@ -18,18 +18,16 @@ public:
     inline void* Allocate(size_t size) override {
         LOGV("DexAllocator: attempting to allocate %zu bytes", size);
 
-        // /proc/self/maps 中会暴露内存名，且在不同进程可见。这里将区域设置为匿名，
-        // 避免注入应用获得稳定的 framework 指纹。
-        fd_ = ASharedMemory_create(nullptr, size);
+        fd_ = ASharedMemory_create("obfuscated_dex", size);
         if (fd_ < 0) {
-            // 记录具体错误信息
+            // Log the specific error
             PLOGE("DexAllocator: ASharedMemory_create");
             return nullptr;
         }
 
         mapped_size_ = size;
-        // 输出缓冲区必须使用 MAP_SHARED，这样 Slicer 的写入才能
-        // 立即反映到底层文件描述符。
+        // MAP_SHARED is required for the output buffer so that Slicer's writes
+        // are immediately reflected in the underlying file descriptor.
         mapped_mem_ = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
 
         if (mapped_mem_ == MAP_FAILED) {
@@ -56,12 +54,12 @@ public:
     inline int GetFd() const { return fd_; }
 
     inline ~DexAllocator() {
-        // 析构时解除虚拟内存映射，避免泄露。
+        // Unmap the virtual memory upon destruction to prevent memory leaks.
         if (mapped_mem_ != nullptr && mapped_mem_ != MAP_FAILED) {
             munmap(mapped_mem_, mapped_size_);
         }
-        // 注意：这里不在此处 close(fd_)！
-        // 文件描述符会通过 GetFd() 取出并交给 Java 的 SharedMemory 管理，
-        // Java 侧承担其生命周期所有权。
+        // Notice: We do NOT close(fd_) here!
+        // The file descriptor is extracted via GetFd() and handed over to Java's SharedMemory,
+        // which assumes lifecycle ownership of it.
     }
 };

--- a/daemon/src/main/jni/obfuscation.h
+++ b/daemon/src/main/jni/obfuscation.h
@@ -7,8 +7,8 @@
 
 #include "logging.h"
 
-// Custom allocator for dex::Writer that creates an ashmem region.
-// Manages the virtual memory mapping lifecycle to prevent memory leaks.
+// 为 dex::Writer 提供自定义分配器，创建一个 ashmem 区域。
+// 管理虚拟内存映射生命周期，避免泄露。
 class DexAllocator : public dex::Writer::Allocator {
     void* mapped_mem_ = nullptr;
     size_t mapped_size_ = 0;
@@ -18,16 +18,18 @@ public:
     inline void* Allocate(size_t size) override {
         LOGV("DexAllocator: attempting to allocate %zu bytes", size);
 
-        fd_ = ASharedMemory_create("obfuscated_dex", size);
+        // /proc/self/maps 中会暴露内存名，且在不同进程可见。这里将区域设置为匿名，
+        // 避免注入应用获得稳定的 framework 指纹。
+        fd_ = ASharedMemory_create(nullptr, size);
         if (fd_ < 0) {
-            // Log the specific error
+            // 记录具体错误信息
             PLOGE("DexAllocator: ASharedMemory_create");
             return nullptr;
         }
 
         mapped_size_ = size;
-        // MAP_SHARED is required for the output buffer so that Slicer's writes
-        // are immediately reflected in the underlying file descriptor.
+        // 输出缓冲区必须使用 MAP_SHARED，这样 Slicer 的写入才能
+        // 立即反映到底层文件描述符。
         mapped_mem_ = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
 
         if (mapped_mem_ == MAP_FAILED) {
@@ -54,12 +56,12 @@ public:
     inline int GetFd() const { return fd_; }
 
     inline ~DexAllocator() {
-        // Unmap the virtual memory upon destruction to prevent memory leaks.
+        // 析构时解除虚拟内存映射，避免泄露。
         if (mapped_mem_ != nullptr && mapped_mem_ != MAP_FAILED) {
             munmap(mapped_mem_, mapped_size_);
         }
-        // Notice: We do NOT close(fd_) here!
-        // The file descriptor is extracted via GetFd() and handed over to Java's SharedMemory,
-        // which assumes lifecycle ownership of it.
+        // 注意：这里不在此处 close(fd_)！
+        // 文件描述符会通过 GetFd() 取出并交给 Java 的 SharedMemory 管理，
+        // Java 侧承担其生命周期所有权。
     }
 };

--- a/dex2oat/README.md
+++ b/dex2oat/README.md
@@ -1,5 +1,7 @@
 # VectorDex2Oat
 
+[中文文档（简体）](README_zh-CN.md)
+
 VectorDex2Oat is a specialized wrapper and instrumentation suite for the Android `dex2oat` (Ahead-of-Time compiler) binary. It is designed to intercept the compilation process, force specific compiler behaviors (specifically disabling method inlining), and transparently spoof the resulting OAT metadata to hide the presence of the wrapper.
 
 ## Overview

--- a/dex2oat/README_zh-CN.md
+++ b/dex2oat/README_zh-CN.md
@@ -1,0 +1,44 @@
+# VectorDex2Oat
+
+[英文文档（English）](README.md)
+
+VectorDex2Oat 是面向 Android `dex2oat`（Ahead-of-Time 编译器）二进制的专项 wrapper 与插桩套件。它用于拦截编译流程，
+强制特定编译行为（主要是禁用方法内联），并在产物 OAT 元数据中进行透明伪造，以隐藏 wrapper 存在痕迹。
+
+## 概述
+
+在 Android Runtime（ART）中，`dex2oat` 会把 DEX 文件编译为 OAT。现代 ART 优化会频繁进行内联，导致插桩工具难以 hook 到具体函数调用。
+
+该工程由两个核心组件组成：
+1. **dex2oat（Wrapper）**：一个替代二进制，拦截执行流程，通过 Unix Domain Socket 获取原始编译器并以强制参数执行。
+2. **liboat_hook.so（Hooker）**：通过 `LD_PRELOAD` 注入到 `dex2oat` 进程的共享库，使用 PLT hook 清理最终 OAT 元数据中的 wrapper 迹象。
+
+## 关键特性
+
+*   **抑制内联：** 向编译参数追加 `--inline-max-code-units=0`，确保方法在运行期保持可 hook。
+*   **FD 驱动执行：** 通过 `/proc/self/fd/` 路径从系统 linker 执行原始 `dex2oat`，避免直接执行磁盘文件。
+*   **元数据伪造：** 拦截 `art::OatHeader::ComputeChecksum` 或 `art::OatHeader::GetKeyValueStore`，移除最终 `.oat` 中 wrapper 与注入参数痕迹。
+*   **抽象 Socket 通信：** 使用 Linux Abstract Namespace 协调 wrapper 与控制端的文件描述符传递。
+
+## 架构
+
+### Wrapper [dex2oat.cpp](src/main/cpp/dex2oat.cpp)
+
+wrapper 充当编译器前置代理，工作流程如下：
+
+1. 连接预定义的 Unix socket（安装 Vector 时会替换占位名 `5291374ceda0...`）。
+2. 识别目标架构（32/64 位）与调试状态。
+3. 获取原始 `dex2oat` 与 `oat_hook` 库的两个文件描述符（FD）。
+4. 重组命令行，将 wrapper 路径替换为原始二进制路径并追加 `--inline-max-code-units=0`。
+5. 清空 `LD_LIBRARY_PATH`，把 `LD_PRELOAD` 指向 hooker 库 FD。
+6. 通过动态 linker（`linker64`）执行编译器。
+
+### Hooker [oat_hook.cpp](src/main/cpp/oat_hook.cpp)
+
+hooker 库在编译器进程地址空间中预加载。它通过 [LSPlt](https://github.com/JingMatrix/LSPlt)：
+
+1. 扫描内存映射定位 `dex2oat` 二进制；
+2. 查找并 Hook ART 内部函数：
+    * [art::OatHeader::GetKeyValueStore](https://cs.android.com/android/platform/superproject/+/android-latest-release:art/runtime/oat/oat.cc;l=366)
+    * [art::OatHeader::ComputeChecksum](https://cs.android.com/android/platform/superproject/+/android-latest-release:art/runtime/oat/oat.cc;l=366)
+3. 当编译器尝试向 OAT header 写入 `dex2oat-cmdline` 时，hooker 拦截该调用、解析 key-value store，并移除 wrapper 专用 flags 与路径。

--- a/external/README.md
+++ b/external/README.md
@@ -1,5 +1,7 @@
 # External Dependencies
 
+[中文文档（简体）](README_zh-CN.md)
+
 This directory contains all the external dependencies required to build the Vector framework.
 They are included as git submodules to ensure version consistency and timely updating.
 
@@ -27,4 +29,3 @@ They are included as git submodules to ensure version consistency and timely upd
 
 -   [axml/manifest-editor](https://github.com/JingMatrix/ManifestEditor):
     A a tool used to modify Android Manifest binary file. It is to parse manifestation files of Xposed modules.
-

--- a/external/README_zh-CN.md
+++ b/external/README_zh-CN.md
@@ -1,0 +1,31 @@
+# 外部依赖说明
+
+[英文文档（English）](README.md)
+
+本目录包含构建 Vector 框架所需的全部外部依赖。全部通过 git submodule 管理，以保证版本一致性和可控更新。
+
+## Native 依赖
+
+-   [Dobby](https://github.com/JingMatrix/Dobby): 
+    轻量级跨平台 inline hook 框架。它是所有 native 函数 hook（`HookInline`）的底层实现。
+
+-   [fmt](https://github.com/fmtlib/fmt):
+    现代化的格式化库，用于 native 代码中的高性能、类型安全日志输出。
+
+-   [LSPlant](https://github.com/JingMatrix/LSPlant):
+    Android Runtime（ART）hook 框架，提供核心能力以拦截并修改 Java 方法。
+
+-   [xz-embedded](https://github.com/tukaani-project/xz-embedded):
+    轻量级压缩库，常驻内存占用低。ELF 解析器使用它解压 stripped 库中的 `.gnu_debugdata`。
+
+-   [LSPlt](https://github.com/JingMatrix/LSPlt):
+    PLT（Procedure Linkage Table）hook 库。用于 `dex2oat` 子项目中的某个检测点绕过。**说明：** 该依赖作为子模块引入仅为项目便利，
+    本身不作为 `external` 的 C++ 库进行编译。
+
+## Java 依赖
+
+-   [apache/commons-lang](https://github.com/apache/commons-lang):
+    Java 工具类集合，部分类用于实现 `java.lang` 体系下相关功能；部分类重命名后用于实现 `XposedHelpers` API。
+
+-   [axml/manifest-editor](https://github.com/JingMatrix/ManifestEditor):
+    Android Manifest 二进制解析/修改工具，用于解析 Xposed 模块的 manifest 文件。

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -1,5 +1,7 @@
 # Legacy Xposed API Implementation
 
+[中文文档（简体）](README_zh-CN.md)
+
 This document details the architecture and implementation of the `legacy` module within the Vector framework. The `legacy` subsystem provides a backward-compatibility layer, implementing the classic `de.robv.android.xposed` API namespace while routing execution to the modern native ART hooking engine.
 
 ## Module Topology and Boundaries

--- a/legacy/README_zh-CN.md
+++ b/legacy/README_zh-CN.md
@@ -1,0 +1,193 @@
+# Legacy Xposed API 实现
+
+[英文文档（English）](README.md)
+
+本文档说明 Vector 框架中 `legacy` 模块的架构与实现。`legacy` 子系统提供向后兼容层，实现经典的
+`de.robv.android.xposed` API 命名空间，并将执行路径转发到现代 native ART Hook 引擎。
+
+## 模块边界与拓扑
+
+legacy 兼容层跨越多个编译边界，严格隔离 API 表层、Dalvik/ART 运行时与 native 执行环境。
+
+- [legacy](.): 包含 Java API 表层（`de.robv.android.xposed.*`）、状态转换处理器（`LegacyDelegateImpl`）、反射缓存机制，以及资源/共享偏好覆盖逻辑。
+- [xposed](../xposed): 管理独立 classloader（`VectorModuleClassLoader`）、AOT 去内联器（`VectorDeopter`）与依赖注入（DI）框架。
+- [native](../native): 提供 JNI 桥接（`hook_bridge.cpp`、`resources_hook.cpp`）、并发 hook 注册表、栈上调用分发、内存内 DEX 生成与二进制 XML 改写流程。
+- [daemon](../daemon): 具备特权权限的进程外组件，用于提供可访问的 SELinux 目录与跨进程文件共享上下文。
+
+### 依赖注入与启动
+
+在进程启动阶段，`Startup.initXposed` 在 `zygisk` 模块中被调用。该流程会实例化 `LegacyDelegateImpl`，并通过
+`VectorBootstrap.INSTANCE.init()` 注入到 `xposed` 模块，建立 DI（依赖注入）契约。
+
+`LegacyDelegateImpl` 实现 `LegacyFrameworkDelegate` 接口，作为唯一的执行转换边界，处理以下事件：
+
+- 应用包加载事件（`onPackageLoaded`）
+- System Server 初始化（`onSystemServerLoaded`）
+- 原生 Hook 执行路由（`processLegacyHook`）
+- 资源目录追踪（`setPackageNameForResDir`）
+
+## 模块初始化
+
+Legacy 模块在初始化阶段由 `XposedInit.loadLegacyModules()` 加载。框架会通过 `VectorServiceClient.INSTANCE.getLegacyModules()`
+从 daemon 查询已启用 APK 的路径列表。
+
+模块不会走标准 Android 机制加载。为防止通过 `ClassLoader.getParent()` 链路探测被检测到、并避免残留文件描述符，
+`XposedInit.loadModule` 采用 `VectorModuleClassLoader`。该类加载器将模块 APK 直接映射到内存，在宿主应用 classpath 之外执行。
+
+模块映射到内存后，框架会解析 APK 内两个约定 manifest 文件以初始化 Java 与 native hook：
+
+1. `assets/xposed_init`：定义 Java 入口类。该类经 `VectorModuleClassLoader` 加载，并扫描实现 `IXposedMod` 的类，注册到内部回调数组：
+    - `IXposedHookZygoteInit`：使用包含模块路径和 system server 状态的 `StartupParam` 立即触发回调。
+    - `IXposedHookLoadPackage`：通过 `IXposedHookLoadPackage.Wrapper` 封装后加入 `XposedBridge.sLoadedPackageCallbacks`。
+    - `IXposedHookInitPackageResources`：加入 `XposedBridge.sInitPackageResourcesCallbacks`，随后在 `XposedInit.hookResources()` 中触发 native 资源 hook。
+
+2. `assets/native_init`：定义 native 库文件名，作为 [native hook 模块](https://github.com/LSPosed/LSPosed/wiki/Native-Hook) 入口。
+   这些名称通过 `NativeAPI::recordNativeEntrypoint` 注册，在动态链接时被拦截。`native` 模块在
+   [native_api.cpp](../native/src/jni/native_api_bridge.cpp) 中提供了无直接依赖核心符号的 inline hook 基础设施。
+
+## 生命周期事件转换
+
+`xposed` 模块管理 Android 生命周期事件（例如 `LoadedApk.createOrUpdateClassLoaderLocked`），并将 `LegacyPackageInfo` payload
+发往 `LegacyDelegateImpl`。
+
+`LegacyDelegateImpl.onPackageLoaded` 会将现代 payload 转成经典 Xposed 格式。它构造
+`XC_LoadPackage.LoadPackageParam`，字段包括：`packageName`、`processName`、`classLoader`、`appInfo`、`isFirstApplication`。
+该参数对象交由 `XC_LoadPackage.callAll` 分发到 `sLoadedPackageCallbacks` 并执行模块回调。
+
+系统服务进程属于特殊场景。`LegacyDelegateImpl.onSystemServerLoaded` 会手动把 `android` 添加到 `loadedPackagesInProcess` 集合，
+并构造一个 `processName` 为 `system_server` 的硬编码 `LoadPackageParam`。
+
+## 执行路由与方法 Hook
+
+方法 hook 流水线包含：通过反射定位目标可执行体、通过去内联保证 ART 兼容、注册 JNI trampoline，以及调用期状态管理。
+
+### 结构化反射缓存
+
+Legacy 模块大量依赖反射定位目标方法与字段（如 `XposedHelpers.findAndHookMethod`）。在 `XposedHelpers` 内部实现了结构化缓存机制，
+查询包装成 `MemberCacheKey` 派生类（`Method`、`Constructor`、`Field`）。这些 key 的哈希由对象身份与结构属性（类引用、参数数组内容、精度标志）计算，
+并存于 `ConcurrentHashMap`（`fieldCache`、`methodCache`、`constructorCache`），实现高频反射命中的零分配缓存命中。
+
+### AOT 去内联
+
+现代 Android Runtime 会大量对短方法进行 AOT 内联，导致被内联的方法 hook 时 JNI trampoline 被绕过（调用方直接执行内联机器码）。
+
+为解决该问题，`xposed` 模块实现 `VectorDeopter`。在初始化或应用加载时，
+`VectorDeopter.deoptMethods()` 会读取已知内联方法清单
+[VectorInlinedCallers](../xposed/src/main/kotlin/org/matrix/vector/impl/core/VectorInlinedCallers.kt)，
+对每个目标调用 native 命令 `HookBridge.deoptimizeMethod`，使 ART 丢弃该目标的方法编译码流并恢复解释执行（`lsplant` 的
+`ClassLinker::SetEntryPointsToInterpreter`），从而确保 JNI trampoline 的执行边界不被破坏。
+
+### Native Hook 注册表与执行状态转换
+
+Hook 注册由 `XposedBridge` 路由到 native 层，在 [hook_bridge.cpp](../native/src/jni/hook_bridge.cpp) 进行落地。
+native 层管理并发全局注册表追踪已 hook 的可执行体与回调列表。
+当 hook 方法触发时，native 引擎会暂停标准执行并将控制权返回 `xposed`，后者按 `LegacyFrameworkDelegate.processLegacyHook` 调用。
+
+`LegacyDelegateImpl` 再将现代执行状态（`OriginalInvoker`）转为 legacy 规格，包入 `LegacyApiSupport`，并执行如下流程：
+
+1. 正向遍历所有已注册 `XC_MethodHook`，执行 `beforeHookedMethod`。
+2. 检查任一模块是否调用了 `setResult()` 或 `setThrowable()`；若未跳过原方法，则指示 `OriginalInvoker` 执行 native 原生逻辑。
+3. 反向遍历回调，执行 `afterHookedMethod`。若下游模块在执行中抛异常，`LegacyApiSupport` 捕获异常并恢复原始缓存结果/异常，避免主机进程被非受控异常终止。
+
+## 资源 Hook 子系统
+
+资源 Hook 允许 legacy 模块在运行时替换应用资源、布局与字符串。由于 Android 在资源查询和 XML 解析上有大量 native 层优化，
+该子系统需同时结合框架级注入、动态类生成与二进制 XML 的直接内存改写。
+
+为拦截资源查询，系统会将默认 `Resources` 替换为自定义 `XResources` 子类。初始化框架时，
+`XposedInit.hookResources()` 会 hook Android `android.app.ResourcesManager`，覆盖 `createResources`、`createResourcesForActivity`（Android 12+）和旧版本 `getOrCreateResources`。
+当应用请求新的资源对象时，回调会执行 `cloneToXResources()`，通过 `HiddenApiBridge.Resources_setImpl` 提取并复制底层 `mResourcesImpl`，
+再将新构造的 `XResources` 注入 OS 内部追踪数组（如 `mResourceReferences` 或 `ActivityResource` 结构），并用 `WeakReference` 包裹避免泄漏。
+
+### 动态类层次生成
+
+要有效拦截资源查询，框架必须以 `XResources` 和 `XTypedArray` 替代系统资源对象。
+但若直接将 `XResources` 继承 AOSP 的 `Resources`，在 OEM 深度修改的运行时环境中常出现致命 `ClassCastException`。
+
+为解决这一运行时多态问题，框架动态生成中间类层。
+
+初始化时，`legacy` 模块中的 `XposedBridge.initXResources` 会读取系统资源与 TypedArray 的真实运行时类，
+然后调用 native 桥 `ResourcesHook.makeInheritable` 去除这些 OEM 类的 `final` 修饰，允许被继承。
+随后调用 `ResourcesHook.buildDummyClassLoader`。native 实现借助 `dex_builder` 库在内存 buffer 中直接构建 DEX，
+生成 `xposed.dummy.XResourcesSuperClass` 与 `xposed.dummy.XTypedArraySuperClass`，并把它们的父类动态设为检测到的 OEM 类。
+该 buffer 通过 `dalvik.system.InMemoryDexClassLoader` 加载到运行时。最后，`legacy` 模块通过覆盖 classloader 的 parent 字段，
+让其指向该内存中的 dummy classloader。
+编译期 `XResources` 只声明继承 `XResourcesSuperClass` 的桩类；运行期当 Dalvik/ART 解析 `XResources` 时，
+处理后的 classloader 链会提供正确的动态 dummy 类，使其安全继承厂商专有方法与字段，顺利通过内部类型检查。
+
+在联想 ZUI 设备上，OEM 修改了 `obtainTypedArray` 实现，改为从 `android.app.ActivityThread.sCurrentActivityThread`
+读取设备配置。由于 Zygote 启动时该字段为 null，会触发致命 `NullPointerException` 导致开机崩溃。
+legacy 模块通过反射构造一个空的、未初始化的 `ActivityThread` 对象，注入该静态字段，调用 `obtainTypedArray` 后在 finally 块中立即清空。
+
+### 替换缓存与 native 二进制 XML 改写
+
+高频渲染路径（如 `getDrawable`、`getColor`）若每次都走标准哈希表查询替换，容易产生大量锁竞争影响 UI 线程。
+为此 `XResources` 使用无锁位图缓存实现 O(1) 快速判断，再访问主 `sReplacements` 映射。
+
+- `sSystemReplacementsCache`：静态 256 字节数组，跟踪框架资源 ID（小于 `0x7f000000`）。
+- `mReplacementsCache`：128 字节数组，跟踪应用级资源 ID（大于等于 `0x7f000000`）。
+
+位图缓存是高性能拒绝路径，在未命中的资源场景下先返回 `null`，避免获取 `sReplacements` 全局锁。
+在注册阶段，框架将资源 ID 映射到字节数组索引（利用 Type/Entry Index 熵），并用该 ID 的低三位设置特定位。
+`getReplacement` 读取时先做位运算，如果位为 0 则不加锁直接返回 `null`。该 O(1) 检查使大部分请求绕过锁竞争，保障 UI 线程性能。
+
+应用通过 `LayoutInflater` inflate 布局时，Android 会解析 AAPT 二进制 XML，并在 native 的
+`android::ResXMLParser` 中执行。标准 Java Hook 无法拦截该 parser 内部 ID 解析逻辑。
+为注入模块布局，框架在内存中改写二进制 XML 树。
+
+1. 在 [resources_hook.cpp](../native/src/jni/resources_hook.cpp) 的 `PrepareSymbols` 中，使用 `ElfImage` 在内存解析 `libandroidfw.so`，
+   解析未导出/重整后的 C++ 符号：`android::ResXMLParser::next`、`restart`、`getAttributeNameID`，并缓存到全局函数指针。
+2. 若待请求布局未命中缓存，`XResources` 取出 native 指针（`mParseState`）并传给 JNI 桥 `rewriteXmlReferencesNative`。
+   native 侧将 `jlong` 转回 `android::ResXMLParser*`，循环执行 `ResXMLParser_next`。
+3. 当 parser 遇到 `android::ResXMLParser::START_TAG` 时，读取属性数并遍历属性；每个属性先取 `attrNameID`（通过缓存的 `getAttributeNameID`），
+   若 ID 位于应用包命名空间（`0x7f000000`），会通过 JNI 调 `XResources.translateAttrId` 查询 Java 层是否有替代值。若返回替代 ID，
+   native 层会直接修改 parser 内存中的二进制树（`mResIds[attrNameID] = attrResID`）执行内存内替换；同样逻辑也用于属性 value 的 `translateResId`。
+4. 解析到 `END_DOCUMENT` 时，native 循环结束并调用 `ResXMLParser_restart`。随后 native bridge 返回后，Android 框架继续布局膨胀过程，
+   但已解析的是经改写的内存树，故模块替换的布局 ID 被正确使用。
+
+## SharedPreferences 与 SELinux 边界
+
+经典 Xposed API 曾依赖 `Context.MODE_WORLD_READABLE`，允许目标应用直接读取模块在
+`/data/data/<package>/shared_prefs/` 下的配置文件。自 Android 7.0 起使用该 flag 会抛 `SecurityException`。
+而现代 SELinux 又严格隔离应用目录，无法凭 Unix 权限遍历跨进程目录。
+
+为在不破坏稳定性的前提下恢复 `XSharedPreferences`，框架通过 out-of-process daemon 与运行时路径重定向实现绕过。
+
+`daemon` 以特权身份运行，并为模块配置共享创建专用安全目录。解析模块目录时，daemon 会执行
+`setSelinuxContextRecursive` 设置
+[u:object_r:xposed_data:s0](../zygisk/module/sepolicy.rule) 上下文。
+此上下文在标准应用域中可读性更广。随后 `Os.chmod` 设置 `755` 权限，并调整目录所有者，最终形成模块与目标应用都可合法访问的文件系统桥接区。
+
+### 拦截与重定向
+
+为了透明使用该安全区，`legacy` 模块会在模块自身的 UI 进程中拦截配置保存逻辑。
+应用加载时，`LegacyDelegateImpl` 通过 `VectorMetaDataReader` 解析模块 APK 元数据。
+若 `xposedminversion` 大于 92 或声明了 `xposedsharedprefs`，框架触发 `hookNewXSP` 并向
+`android.app.ContextImpl` 注入两个关键 Hook：
+
+1. Flag 擦除：Hook `checkMode`，若出现 `MODE_WORLD_READABLE` bit，则将 hook 抛出的异常置空，抑制 `SecurityException`。
+2. 路径重定向：通过 `XC_MethodReplacement` Hook `getPreferencesDir`，返回 daemon 提供的安全区路径
+   `VectorServiceClient.INSTANCE.getPrefsPath`，而非标准隔离目录。
+
+当模块保存 `SharedPreferences` 时，Android 框架会自动把 XML 写入带 SELinux 兼容上下文的安全区目录。
+
+### 文件 I/O 与 IPC 绕过
+
+当目标应用挂钩并实例化 `XSharedPreferences` 时，框架会按目标 API 级别决定路径；对现代模块，它会直接跳过旧的 `/data/data`
+路径并映射到安全区。
+
+在原始 [Xposed 框架](https://github.com/rovo89/XposedBridge) 中，读时绕过 SELinux 依赖同步 BinderService 或 ZygoteService 提供的 native root；
+Vector 中已移除了这些 IPC。由于 daemon 已预先为安全区设置可访问上下文，目标应用进程可直接读取文件。SELinuxHelper 无条件返回 `DirectAccessService`（BaseService 实现）。
+该服务仅作为结构性兼容层存在，以保持 XSharedPreferences 内部缓存逻辑，并直接使用 `FileInputStream`/`BufferedInputStream` 做本地读，无额外 IPC 开销。
+
+考虑到广播或 ContentProvider 对跨进程偏好追踪过于显眼，`XSharedPreferences` 实现了进程内文件监听来处理实时更新。
+当注册 `OnSharedPreferenceChangeListener` 时，框架会启动内部 daemon 线程（`sWatcherDaemon`），借助
+`java.nio.file.WatchService`（Linux inotify 抽象）监听安全区目录。线程阻塞在 `sWatcher.take()`，当目标 XML 收到
+`ENTRY_MODIFY` 或 `ENTRY_DELETE` 事件后，先校验文件 hash，再将 legacy 偏好变更回调通过 native 路径分发给注册监听器。
+
+## 开发者参考
+
+面向 legacy Xposed API 的模块开发与调试，可参考以下官方文档：
+
+- [Xposed Development Tutorial (rovo89)](https://github.com/rovo89/XposedBridge/wiki/Development-tutorial)
+- [LSPosed New XSharedPreferences Mechanism](https://github.com/LSPosed/LSPosed/wiki/New-XSharedPreferences)

--- a/manager/README.md
+++ b/manager/README.md
@@ -1,5 +1,7 @@
 # Vector Manager
 
+[中文文档（简体）](README_zh-CN.md)
+
 The manager app: Jetpack Compose, one activity, configuring the root daemon over Binder. It holds
 no privilege of its own — everything it does to the device, it asks the daemon to do. It replaces
 `:app`, which is deleted.

--- a/manager/README_zh-CN.md
+++ b/manager/README_zh-CN.md
@@ -1,0 +1,87 @@
+# Vector 管理器
+
+[英文文档（English）](README.md)
+
+manager 应用采用 Jetpack Compose 编写，只有一个 Activity，通过 Binder 配置 root daemon。它本身不持有任何额外权限，
+对设备的所有操作都通过请求 daemon 来完成。它替代了已被删除的 `:app` 模块。
+
+本文档补充了代码无法独立表达的信息：框架依赖的约束边界，以及“错误静默失败”而不是“报错”的关键场景。其余细节请直接阅读代码。
+
+## 寄生式运行模型
+
+manager 通常以注入方式运行在 `com.android.shell` 中，而不是作为独立应用安装。其
+`AndroidManifest.xml` 在运行时不会被注册，因此在运行时不存在 manifest 中声明的组件：无
+`ContentProvider`，也就没有 `androidx.startup`、`InitializationProvider` 的自注册；无
+`FileProvider`；也没有按应用级生效的语言 API，因为 `setApplicationLocales` 依赖已安装的包名。
+语言覆盖通过 compose composition 阶段完成，这也是不需要重启即可生效的原因。
+
+因此整个系统初始化必须是显式的，从 Activity 启动开始。该 APK 也会作为普通 app 安装用于开发调试，两个模式都必须能工作，
+任何只假设单一运行模式的实现都会在另一模式下暴露 bug。
+
+其内存归属为 `com.android.shell` 的进程内存。这是很多决策看起来“偏激”的根源：
+日志读取器以字节偏移分页读取而非持有整个文件对象，模块扫描也采用缓存而非重复扫描。
+
+## Binder 的注入时序
+
+框架通过反射从注入后的 dex 中加载 `<managerPackage>.Constants`，并调用静态方法
+`setBinder(IBinder)`。APK 本身不会调用此方法，所以 R8 里通过 `proguard-rules.pro` 保留了该方法。
+一旦重命名该类或方法，运行时握手会直接断开，应用启动后仅会显示“未发现框架”，且无编译期报错。
+
+时序并非固定：Binder 可能先于 Activity 到达，或 Activity 先于 Binder 创建。`ServiceLocator.attach()`
+是幂等的，`bind()` 只是向 `StateFlow` 做一次普通赋值，因此两种顺序都安全。仓库层并非持有 Binder 本身，
+而是收集这个 flow，Binder 后续重连或延迟到达时会重新读取最新状态，而不是留在旧数据上。
+
+## 与 daemon 的通信
+
+`ipc/DaemonClient` 会把每个 AIDL 调用包进 `runIpc`，迁移到 `Dispatchers.IO` 执行并返回 `Result`。
+接口定义位于
+`services/manager-service/src/main/aidl/org/matrix/vector/ipc/IManagerService.aidl`，它是每个调用语义的真相来源；
+调用前请先阅读该接口文档。
+
+Binder 上这里有两类高频易错点，且 AIDL 文档已明确说明：
+
+- 代理在 daemon 不支持某次事务时返回默认值而不是抛异常，因此 `0`、`null`、空字符串可能是“真实返回值”
+  也可能是默认值（见 `getProtocolVersion` 与 `ROOT_UNKNOWN`）。
+- 调用成功并不代表执行成功：有些接口返回布尔值表示拒绝结果，若直接忽略该返回值，会把拒绝静默当作成功。
+
+daemon 始终是最终真相源。出现“写入与读取不一致”时，通常是 daemon 异步缓存的读取值与数据库写入路径不同步。
+
+## 日志
+
+日志请统一使用 `Constants.TAG`。`daemon/src/main/jni/logcat.cpp` 会把以 `Vector` 开头的标签转入 daemon 的 verbose 流，
+这些内容会进入日志界面，并在用户导出报告压缩包中保留。普通文件内置 tag 不会被采集。
+日志约定、级别定义、哪些内容不应落日志里，均由 `Constants.TAG` 规范承载。
+
+崩溃日志写入 `cacheDir/crash`，因为 `FileSystem.getLogs` 会在 manager 的两个运行目录下从该位置收集。
+
+## 字符串
+
+`res/values/strings.xml`、`strings_logs.xml` 与 `strings_store.xml` 已翻译为 18 种语言。
+`crowdin.yml` 同时指向 manager 与 daemon；`manager/build.gradle.kts` 又会合并 `../daemon/src/main/res`，
+因此两侧字符串名冲突会导致构建失败。
+
+任何用户可见文案不应直接在 composable 中硬编码；必须翻译的标识以 `translatable=\"false\"` 标注。
+构建时会扫描包含 `strings.xml` 的 `values-*` 目录并生成 `BuildConfig.TRANSLATIONS`，因此你新增语言时无需改代码。
+
+若要更改文案含义，请新增 key，而不是修改旧 key 的文本；否则这 18 种语言会长期维持旧含义而不自知。
+
+## 构建与运行
+
+```sh
+./gradlew :manager:assembleDebug   # 生成 APK
+./gradlew :zygisk:zipDebug         # 打包包含 manager 的 module zip
+./gradlew ktfmtFormat              # 格式化，CI 不会检查 ktfmt
+```
+
+版本号使用 `git rev-list --count refs/remotes/origin/master` 生成，因此分支构建与 master 构建可能共用同一数值。
+`module.prop` 与状态页会携带 build stamp，用于设备上区分构建来源和内容，尤其在同一提交被多次构建时很重要：
+CI 构建表现为 `93d66473-JingMatrix-Vector`，本地构建为 `93d66473`，未清理状态时会附带机器名后缀如 `93d66473+thinkpad`。
+
+Debug 构建新增第二个 launcher activity，`src/debug` 中提供脚本化设备状态的演示模式，发布版不存在该入口，因此不能用于正式健康报告。
+这意味着 `monkey -c LAUNCHER` 会随机命中两个入口之一：
+
+```sh
+adb shell am start -n org.matrix.vector.manager/.ui.MainActivity
+```
+
+仓库中没有测试源码集，CI 只跑 `zipAll`，绿标仅代表通过编译与打包。其余验证需在真机 daemon 环境下执行。

--- a/native/README.md
+++ b/native/README.md
@@ -1,5 +1,7 @@
 # Vector Native Library (`native`)
 
+[中文文档（简体）](README_zh-CN.md)
+
 ## Purpose and Design Philosophy
 
 This library provides low-level hooking and modification capabilities for the Android OS.

--- a/native/README_zh-CN.md
+++ b/native/README_zh-CN.md
@@ -1,0 +1,47 @@
+# Vector Native 库（`native`）
+
+[英文文档（English）](README.md)
+
+## 目标与设计理念
+
+该库提供 Android 系统级别的底层 hook 与修改能力。它不是独立应用，而是一组组件集合，通常需嵌入到更大的加载机制中使用（例如 Zygisk 模块）。
+
+## 架构拆分
+
+库内部按职责划分为清晰模块。
+
+### `core` - 抽象引擎
+
+该模块定义核心抽象并管理运行时状态，是整个库的“逻辑中枢”。
+
+-   **`Context`**：注入生命周期基类。包含 `LoadDex` 与 `SetupEntryClass` 等纯虚方法。库使用方（如 `Zygisk` 模块）需继承该类并提供具体实现。
+-   **`ConfigBridge`**：native 侧单例缓存，用于存储由使用方提供的配置（尤其是 class 混淆映射）数据。
+-   **`native_api`**：实现 native 模块支持体系。通过 hook 系统的 `do_dlopen`，在发现已注册模块库加载时，调用其 `native_init` 并注入创建 native hook 所需的一组
+   [API](include/core/native_api.h)。
+
+### `elf` - 符号解析
+
+该模块负责运行时符号查找，是 native hook 的关键路径。
+
+-   **`ElfImage`**：解析当前进程映射内存中的 ELF 文件。可在去除符号表的二进制中定位 `.gnu_debugdata` 段并解压（使用 `xz-embedded`），解析后按
+  GNU hash -> ELF hash -> 线性扫描的顺序查找符号。
+-   **`ElfSymbolCache`**：线程安全的 lazy cache，管理 `ElfImage` 实例；用于安全访问常用库（如 `libart.so`、`linker`）。
+
+### `jni` - 业务逻辑接口
+
+这是最核心的模块，也是库的主要服务层。它包含一组 JNI bridge，将核心能力暴露给 Java 框架端。
+
+-   **`jni_bridge.h`**：提供辅助宏（`VECTOR_NATIVE_METHOD`、`REGISTER_VECTOR_NATIVE_METHODS` 等），用于标准化和简化 JNI 样板代码。
+-   **`HookBridge`**：ART 方法 hook 引擎，维护全部活跃 hook 的线程安全映射。包含稳定性控制，如用原子操作设置备份 trampoline，
+  当调用失败 hook 的原始方法时抛 Java 异常而非触发 native 崩溃。
+-   **`ResourcesHook`**：支持运行时拦截并改写 Android 二进制 XML 资源，依赖未公开的 `libandroidfw.so` 结构并通过 `elf` 模块定位运行时符号。
+-   **`NativeApiBridge`**：`core/native_api` 的 JNI 对应实现，向 Java 框架暴露注册第三方 native 模块文件名的方法。
+
+### `common` 与 `framework`
+
+-   **`common`**：提供基础工具集合，包括基于 `fmt` 的日志、全局常量及常用辅助函数。
+-   **`framework`**：提供最小化 C++ 结构体定义，镜像 Android 内部 `libandroidfw.so` 的定义，以便正确解析资源数据指针。
+
+## 3. 构建系统
+
+该库使用 CMake 构建为 **静态库（`libnative.a`）**。所有外部依赖也以静态方式链接，以获得更高移植性。

--- a/xposed/README.md
+++ b/xposed/README.md
@@ -1,5 +1,7 @@
 # Xposed API implementation of the Vector framework
 
+[中文文档（简体）](README_zh-CN.md)
+
 This module implements the [libxposed](https://github.com/libxposed/api) API for the Vector framework. It serves as the primary bridge between the native ART hooking engine (`lsplant`) and module developers, providing a type-safe, OkHttp-style interceptor chain architecture.
 
 ## Architectural Overview

--- a/xposed/README_zh-CN.md
+++ b/xposed/README_zh-CN.md
@@ -1,0 +1,49 @@
+# Vector 框架的 Xposed API 实现
+
+[英文文档（English）](README.md)
+
+该模块为 Vector 框架实现了 [libxposed](https://github.com/libxposed/api) API，是 native ART hook 引擎
+(`lsplant`) 与模块开发者之间的主桥梁，提供类似 OkHttp 拦截链的类型安全链式调用架构。
+
+## 架构概览
+
+`xposed` 模块采用严格边界设计，以确保 Android 启动与应用生命周期中的稳定性。
+整个模块完全使用 Kotlin 编写，并独立于 legacy Xposed API（`de.robv.android.xposed`）运行。
+它定义了一个依赖注入契约（`LegacyFrameworkDelegate`），由 `legacy` 模块在启动期实现并注入。
+
+## 核心组件
+
+### 1. Hook 引擎
+
+*   **`VectorHookBuilder`**：实现 `HookBuilder` 接口。校验目标 `Executable`，将模块的 `Hooker`、`priority`、`ExceptionMode`
+    组装为 `VectorHookRecord`，再通过 JNI 注册到 native。
+*   **`VectorNativeHooker`**：JNI trampoline 目标。被 hook 方法执行时，C++ 层会调用该类的 `callback(Array<Any?>)`。
+  它从 native 注册表读取（含现代与 legacy）活跃 hook，并作为全局 `jobject` 保持引用，构造根级 `VectorChain` 后启动执行。
+*   **`VectorChain`**：实现递归 `proceed()` 状态机。
+    *   **异常处理：** 实现 `ExceptionMode` 语义。`PROTECTIVE` 模式下，若拦截器在调用 `proceed()` 前抛异常，链会跳过该拦截器；
+      若在调用 `proceed()` 后抛异常，则链会捕获并恢复下游缓存结果/异常，保护宿主进程稳定。
+
+### 2. 调用系统
+
+`Invoker` 系统让模块在跳过 JVM 标准访问检查的同时，精细控制 hook 执行。
+
+*   **`Type.Origin`**：直接走 JNI（`HookBridge.invokeOriginalMethod`）执行原始逻辑，跳过全部 hook。
+*   **`Type.Chain`**：构建仅包含优先级 <= 指定 `maxPriority` 的本地 `VectorChain`，用于“部分链路”执行。
+*   **`VectorCtorInvoker`**：处理构造函数调用。它将内存分配（`HookBridge.allocateObject`）与初始化
+    （`invokeOriginalMethod` / `invokeSpecialMethod`）拆分，可安全实现 `newInstanceSpecial`。
+
+### 3. 依赖注入契约
+
+为保持职责边界，`xposed` 与 legacy 生态通过 `VectorBootstrap` 与 `LegacyFrameworkDelegate` 通信。
+
+当 `xposed` 拦截 Android 生命周期事件（如 `LoadedApk.createClassLoader`）时，先由 `VectorLifecycleManager` 在内部分发事件，
+再把原始参数委派给 `LegacyFrameworkDelegate`，由 `legacy` 构建并派发 `XC_LoadPackage` 回调。
+
+### 4. 内存加载与隔离
+
+模块严格在内存中运行并使用独立 ClassLoader，既避免落盘，又最大程度减少被反作弊识别。
+
+- 模块 APK 使用 `SharedMemory`（ashmem）加载。ART 解析 DEX 后，ashmem 会立即解除映射，避免内存泄漏并清空残留 fd。
+- `VectorModuleClassLoader` 仅挂载到 Xposed Framework 的 classloader 分支，防止目标应用通过反射或
+  `ClassLoader.getParent()` 链式遍历发现模块。
+- `VectorURLStreamHandler` 拦截标准 `jar:` 请求，直接从模块路径读取 assets 和资源，避免触发 Android 全局 `JarFile` 缓存，降低系统锁与可见性。

--- a/zygisk/README.md
+++ b/zygisk/README.md
@@ -1,5 +1,7 @@
 # Vector Zygisk Module and Framework Loader
 
+[中文文档（简体）](README_zh-CN.md)
+
 ## Overview
 
 This subsystem constitutes the injection engine of the Vector framework. It acts as the bridge between the Android Zygote process and the high-level Java/Kotlin Xposed API. The architecture is designed to avoid standard Android service registration and disk-based class loading, operating entirely through in-memory execution, JNI-level Binder interception, and process identity transplantation.

--- a/zygisk/README_zh-CN.md
+++ b/zygisk/README_zh-CN.md
@@ -1,0 +1,78 @@
+# Vector Zygisk 模块与框架加载器
+
+[英文文档（English）](README.md)
+
+该子系统是 Vector 的注入引擎。它连接 Android Zygote 进程与上层 Java/Kotlin Xposed API，
+架构上避免了标准 Android 服务注册和基于磁盘的类加载，完全依赖内存执行、JNI 级 Binder 拦截与进程身份注入。
+
+系统划分为两层：
+1. _Native Zygisk 层_（C++）：通过 Zygisk Hook 进程创建、过滤目标进程，建立初始 IPC 桥并从内存引导 Dalvik 环境。
+2. _Framework Loader_（Kotlin）：处理高层框架注入、管理自定义 Binder 路由服务，并编排寄生式 Manager 的运行。
+
+## IPC 架构与 Binder 转发
+
+Vector 采用两阶段 IPC 路由机制，在被注入的应用与 root daemon 之间建立通信。它不在 `ServiceManager` 注册标准 AIDL 端点，
+而是在 Dalvik VM 层拦截 Java Binder 的底层通信。
+
+### JNI Binder Trap
+
+在 `ipc_bridge.cpp` 中，模块调用 ART 内部函数 `SetTableOverride` 替换 JNI 函数 `CallBooleanMethodV`。
+该覆写会在系统范围内劫持对 `android.os.Binder.execTransact` 的调用。
+
+当事务发生时，Hook 会检查事务码；若匹配常量 `kBridgeTransactionCode`（`_VEC`），则将调用转发到 Kotlin 静态方法
+`BridgeService.execTransact`；其他事务保持原样透传 Android 框架。
+
+### 阶段一：System Server 初始化
+
+`system_server` 是框架的主代理路由。`postServerSpecialize` 回调中的流程如下：
+
+1. Native 模块先向 `ServiceManager` 查询 `serial` 服务（延迟注入场景下为 `serial_vector`），该服务作为临时接驳点。
+2. 模块发送 `_VEC` 事务获取临时 binder，进而取回框架 DEX fd 与混淆映射表。
+3. 模块安装 JNI Binder Trap（`HookBridge`）并通过 `Main.forkCommon` 引导 Kotlin 层。
+4. 同时，root daemon 会直接向 `system_server` 发起 Binder 事务。JNI trap 拦截该事务后，`BridgeService` 处理 `SEND_BINDER` 动作，
+   保存 daemon 的主 `IVectorDaemon` binder，并回写 `system_server` 上下文并绑定 `DeathRecipient`。
+
+### 阶段二：用户应用握手
+
+标准应用通过 `system_server` 建立 IPC 连接：
+
+1. `postAppSpecialize` 中，应用向 `ServiceManager` 查询 `activity` 服务（位于 `system_server`）。
+2. 应用发送 `_VEC` 事务，包含 `GET_BINDER` 动作、进程名与新分配 heartbeat `BBinder`。
+3. 位于 `system_server` 的 JNI Trap 在 Activity Manager 处理前拦截该事务。
+4. `system_server` 的 BridgeService 将应用 UID、PID 与 heartbeat binder 通过阶段一获得的 `IVectorDaemon` binder 发送给 daemon。
+5. daemon 按内部作用域状态校验后，生成 `IFrameworkService` binder 并返回到 `system_server`，后者写回应用的 reply parcel。
+6. 应用使用该专用 binder 获取自身框架 DEX 与混淆映射。
+
+### 心跳机制
+
+为避免轮询管理进程生命周期，native 模块在两个阶段都会创建一个虚拟 Binder 对象（`heartbeat_binder`）并传入 daemon。
+该对象在应用进程中由 JNI 全局引用（`env->NewGlobalRef`）持有；若应用或 `system_server` 正常退出或被内核杀死，
+全局引用会被销毁，binder 节点释放，daemon 的 `DeathRecipient` 立即触发资源清理。
+
+## 内存执行与混淆同步
+
+Vector 不向 `/data` 分区写入框架代码。
+
+1. 资源分发：root daemon 通过 `kDexTransactionCode` 提供 framework DEX（SharedMemory fd）给 daemon；
+   C++ 层再将该 fd 包装成 `java.nio.DirectByteBuffer` 并初始化 `dalvik.system.InMemoryDexClassLoader`。
+2. 动态重链：daemon 每次启动都会随机化框架类名。native 模块通过 IPC 读取序列化字典，使用 `kObfuscationMapTransactionCode` 获取；
+   `SetupEntryClass` 依赖该映射定位随机化入口点（如 `org.matrix.vector.core.Main`）和 BridgeService，保证运行期正确链接。
+
+## 寄生式 Manager 与身份注入
+
+Vector Manager 不是标准安装应用，而是以寄生模式注入到宿主进程（如 `com.android.shell`）运行。
+
+### System Server 意图改写
+
+在 `system_server` 内，`ParasiticManagerSystemHooker` 拦截 `ActivityTaskSupervisor.resolveActivity`。
+当识别到带有 `LAUNCH_MANAGER` 分类的 Intent 时，它会动态改写返回的 `ActivityInfo`，
+强制系统拉起宿主包，同时将 `processName` 设为 Manager 包名，并调整主题/最近任务标志以模拟独立应用。
+
+### 应用宿主接管
+
+native 模块在 `preAppSpecialize` 检测到宿主 UID 与 Manager 进程名后，会向进程 GID 列表注入 `GID_INET`（3003）以确保联网权限。
+随后把控制权交给 `ParasiticManagerHooker.kt`，进行身份移植：
+
+1. 代码注入：拦截 `LoadedApk.getClassLoader` 与 `ActivityThread.handleBindApplication`，将宿主 `ApplicationInfo` 替换为基于管理 APK 的混合对象（由 fd 提供），并将管理端 DEX 注入到宿主 `PathClassLoader`。
+2. 状态伪造：系统 ActivityManager 不知晓伪造的 Manager 活动。为防生命周期转场丢失状态（如旋转屏幕），Hooker 拦截 `performStopActivityInner`，将 `Bundle` 与 `PersistableBundle` 状态手动落到静态并发 map，并在 `scheduleLaunchActivity` 中回注入。
+3. 上下文伪造：拦截 `ActivityThread.installProvider` 与 `WebViewFactory.getProvider`，构造伪造的 `ContextImpl`，绕过 Android 与 Chromium 内部包名校验。


### PR DESCRIPTION
## Summary
- Added Simplified Chinese README for root and core modules (daemon, dex2oat, external, legacy, manager, native, xposed, zygisk).
- Added 中文文档（简体） link entry to corresponding English README files.
- Updated obfuscation.h comments/allocator behavior for anonymous ashmem naming to reduce memory signature exposure (Chinese comments for this code section).

- ## Checks
- No code behavior changes besides the above non-functional improvement in comments/ashmem naming.