### PR TITLE
Take the previous daemon down on an emulated soft reboot

### DIFF
--- a/zygisk/module/customize.sh
+++ b/zygisk/module/customize.sh
@@ -82,7 +82,7 @@ esac
 ui_print "- Device platform: $ARCH ($ABI32 / $ABI64)"
 
 ui_print "- Extracting root module files"
-for file in module.prop action.sh service.sh uninstall.sh sepolicy.rule framework/vector.dex cli daemon.apk daemon manager.apk; do
+for file in module.prop action.sh service.sh emulated-soft-reboot.sh uninstall.sh sepolicy.rule framework/vector.dex cli daemon.apk daemon manager.apk; do
     extract "$ZIPFILE" "$file" "$MODPATH"
 done
 

--- a/zygisk/module/emulated-soft-reboot.sh
+++ b/zygisk/module/emulated-soft-reboot.sh
@@ -1,0 +1,12 @@
+# ksud runs this stage at the start of an emulated soft reboot, before `stop`.
+# The daemon is detached from the service.sh that started it, so `stop` does not
+# reach it while the same cycle runs service.sh again; without this, the second
+# soft reboot leaves two daemons claiming the same proxy service name.
+
+# -f is required: app_process sets the nice name in argv only, so comm stays
+# "main" and `pkill vectord` matches nothing. The ^ anchor keeps the pattern
+# from matching a shell whose own command line contains the word.
+pids=$(pgrep -f '^vectord')
+[ -n "$pids" ] && kill -9 $pids
+
+exit 0


### PR DESCRIPTION
Fixes #878.

`ksud soft-reboot` does not reboot the kernel. It runs the `emulated-soft-reboot` stage, `stop`, post-fs-data, `start`, and then `on_services()`, which runs every active module's `service.sh` a second time. `stop` never reaches the daemon the previous cycle started, because [`service.sh`](https://github.com/JingMatrix/Vector/blob/a0ab735e13a3593839421c99c1c1aba6a129be7d/zygisk/module/service.sh#L6) detaches it, so from the second soft reboot onwards two daemons are alive at once. They then claim the same proxy service name — one squatting it on startup, one re-claiming it from its death recipient — each latches the other as `originService`, `SystemServerService.onTransact` forwards to it unconditionally, and the resulting binder ping-pong overflows a Java stack. The new daemon dies on `JNI FatalError ... StackOverflowError`, the survivor times out on the bridge, nothing is injected, and Xposed stays off until a real reboot. `FileSystem.tryLock()` does not prevent it: it returns true while the previous daemon is alive.

That stage is how a module is meant to shut its daemon down, and Zygisk Next uses it (`zygiskd exit`). This adds the equivalent for Vector.

Two notes on the script. `-f` is required because `app_process` sets the nice name in `argv` only, so `comm` stays `main` and `pkill vectord` matches nothing; the `^` anchor is required or the pattern also matches any shell whose own command line contains the word. The stage is blocking, so it has to stay cheap — this costs about 60 ms, where a `/proc` scan forking once per pid cost 9.5 s. If you would rather stop the daemon gracefully, `kill` followed by a short wait and a `kill -9` fallback would work too; I kept the plain `kill -9` because that is the form I measured.

`customize.sh` needs the second hunk because it sets `SKIPUNZIP=1` and installs from a fixed list, so a new file in `zygisk/module/` ships in the zip but never lands in `/data/adb/modules/zygisk_vector`. The `.sha256` sidecar `extract()` verifies is generated for every staged file by `prepareModuleFiles`, so no build change is needed. Installed permissions come from `set_perm_recursive "$MODPATH" 0 0 0755 0644`, which matches how Zygisk Next ships its own copy.

Verified on a Galaxy SM-S9280, Android 16, KernelSU 3.2.5 late-loaded as an LKM, Vector `a0ab735e`, by scripting the module directory directly on the device: four consecutive soft reboots on one boot, the two without this script left the framework dead as described in #878, and the two with it produced a single `vectord`, no `StackOverflowError`, `Injected Vector framework into system_server`, `Successfully injected Vector IPC binder for applications`, a working `cli status` and modules loading into apps again. I have not rebuilt the zip end to end, so the packaging change is reviewed rather than measured. The file here differs from the one I ran in two cosmetic ways: it drops a `/dev/kmsg` line I used to confirm the stage had fired, and the shebang, since `exec_script` invokes stage scripts as `busybox sh <path>` and the other module scripts carry none.
