### PR TITLE
feat: open module configuration from the store install bar

### DIFF
--- a/manager-ui/src/main/kotlin/org/matrix/vector/ui/store/RepoDetailsScreen.kt
+++ b/manager-ui/src/main/kotlin/org/matrix/vector/ui/store/RepoDetailsScreen.kt
@@ -113,6 +113,7 @@ fun RepoDetailsScreen(
     packageName: String,
     onNavigateBack: () -> Unit,
     onOpenUrl: (String) -> Unit,
+    onOpenScope: (packageName: String, userId: Int) -> Unit,
     dataSource: StoreDataSource,
     settings: StoreSettings,
     host: StoreInstallHost? = null,
@@ -137,6 +138,7 @@ fun RepoDetailsScreen(
     val installedScope by viewModel.installedScope.collectAsState()
     val installedIsLegacy by viewModel.installedIsLegacy.collectAsState()
     val install by viewModel.installState.collectAsState()
+    val installedUserId by viewModel.installedUserId.collectAsState()
 
     var choosing by remember { mutableStateOf<Release?>(null) }
     var optionsOpen by remember { mutableStateOf(false) }
@@ -204,6 +206,8 @@ fun RepoDetailsScreen(
                         else choosing = release
                     },
                     onAcknowledge = viewModel::acknowledgeInstall,
+                    installedUserId = installedUserId,
+                    onOpenScope = { onOpenScope(packageName, it) },
                 )
             }
         },
@@ -378,6 +382,9 @@ private fun InstallBar(
     install: InstallStep,
     onInstall: (Release) -> Unit,
     onAcknowledge: () -> Unit,
+    /** The installed copy's user id, so the "Manage" button can open the configuration screen. */
+    installedUserId: Int?,
+    onOpenScope: (userId: Int) -> Unit,
 ) {
     val context = LocalContext.current
     val newest = state.releases.firstOrNull { it.apks.isNotEmpty() } ?: return
@@ -449,31 +456,46 @@ private fun InstallBar(
                     }
                 }
                 else -> {
-                    Button(
-                        onClick = {
-                            onAcknowledge()
-                            onInstall(newest)
-                        },
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Icon(
-                            Icons.Rounded.Download,
-                            contentDescription = null,
-                            modifier = Modifier.size(18.dp),
-                        )
-                        Spacer(Modifier.width(8.dp))
-                        Text(
-                            when {
-                                state.upgradable ->
-                                    stringResource(
-                                        if (state.sameVersion) UiR.string.store_badge_reinstall
-                                        else UiR.string.store_badge_update,
-                                        state.latest?.versionName.orEmpty(),
-                                    )
-                                state.installed != null -> stringResource(UiR.string.store_reinstall)
-                                else -> stringResource(UiR.string.store_install)
-                            }
-                        )
+                    // Installed and current — the next thing is to configure it, not reinstall it.
+                    if (state.installed != null && !state.upgradable && installedUserId != null) {
+                        FilledTonalButton(
+                            onClick = { onOpenScope(installedUserId) },
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Icon(
+                                Icons.Rounded.Tune,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Text(stringResource(UiR.string.nav_manage))
+                        }
+                    } else {
+                        Button(
+                            onClick = {
+                                onAcknowledge()
+                                onInstall(newest)
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Icon(
+                                Icons.Rounded.Download,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Text(
+                                when {
+                                    state.upgradable ->
+                                        stringResource(
+                                            if (state.sameVersion) UiR.string.store_badge_reinstall
+                                            else UiR.string.store_badge_update,
+                                            state.latest?.versionName.orEmpty(),
+                                        )
+                                    else -> stringResource(UiR.string.store_install)
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/manager-ui/src/main/kotlin/org/matrix/vector/ui/store/RepoDetailsViewModel.kt
+++ b/manager-ui/src/main/kotlin/org/matrix/vector/ui/store/RepoDetailsViewModel.kt
@@ -93,6 +93,10 @@ class RepoDetailsViewModel(
     val installedIsLegacy: StateFlow<Boolean> =
         host?.installedIsLegacy ?: MutableStateFlow(false).asStateFlow()
 
+    /** The user id of the installed copy, for the configuration screen; null when nothing is installed. */
+    val installedUserId: StateFlow<Int?> =
+        host?.installedUserId ?: MutableStateFlow<Int?>(null).asStateFlow()
+
     private val _detail = MutableStateFlow<OnlineModule?>(null)
     private val _fetch = MutableStateFlow(DetailFetch.Loading)
 

--- a/manager-ui/src/main/kotlin/org/matrix/vector/ui/store/StoreInstallHost.kt
+++ b/manager-ui/src/main/kotlin/org/matrix/vector/ui/store/StoreInstallHost.kt
@@ -23,6 +23,9 @@ interface StoreInstallHost {
     /** Whether the installed copy is a legacy-framework module (its scope names are swapped). */
     val installedIsLegacy: StateFlow<Boolean>
 
+    /** The user id of the installed copy, for the configuration screen; null when nothing is installed. */
+    val installedUserId: StateFlow<Int?>
+
     /** Download and install [asset], recording it against [releaseVersion]. */
     fun install(asset: ReleaseAsset, releaseVersion: RepoVersion?)
 

--- a/manager-ui/src/main/res/values-ar/strings_store.xml
+++ b/manager-ui/src/main/res/values-ar/strings_store.xml
@@ -58,7 +58,6 @@
     <string name="store_open_module">فتح صفحة الوحدة</string>
     <!-- Install -->
     <string name="store_install">تثبيت</string>
-    <string name="store_reinstall">إعادة التثبيت</string>
     <string name="store_choose_asset">اختر ملفًا للتثبيت</string>
     <plurals name="store_asset_downloads">
         <item quantity="zero">لا تنزيلات</item>

--- a/manager-ui/src/main/res/values-de/strings_store.xml
+++ b/manager-ui/src/main/res/values-de/strings_store.xml
@@ -42,7 +42,6 @@
     <string name="store_open_module">Modulseite öffnen</string>
 
     <string name="store_install">Installieren</string>
-    <string name="store_reinstall">Neu installieren</string>
     <string name="store_choose_asset">Datei zur Installation wählen</string>
     <plurals name="store_asset_downloads">
         <item quantity="one">%1$d Download</item>

--- a/manager-ui/src/main/res/values-es/strings_store.xml
+++ b/manager-ui/src/main/res/values-es/strings_store.xml
@@ -42,7 +42,6 @@
     <string name="store_open_module">Abrir la página del módulo</string>
 
     <string name="store_install">Instalar</string>
-    <string name="store_reinstall">Reinstalar</string>
     <string name="store_choose_asset">Elige el archivo que instalar</string>
     <plurals name="store_asset_downloads">
         <item quantity="one">%1$d descarga</item>

--- a/manager-ui/src/main/res/values-fa/strings_store.xml
+++ b/manager-ui/src/main/res/values-fa/strings_store.xml
@@ -50,7 +50,6 @@
     <string name="store_open_module">باز کردن صفحهٔ ماژول</string>
     <!-- Install -->
     <string name="store_install">نصب</string>
-    <string name="store_reinstall">نصب دوباره</string>
     <string name="store_choose_asset">پرونده‌ای برای نصب برگزینید</string>
     <plurals name="store_asset_downloads">
         <item quantity="one">%1$d بارگیری</item>

--- a/manager-ui/src/main/res/values-fr/strings_store.xml
+++ b/manager-ui/src/main/res/values-fr/strings_store.xml
@@ -42,7 +42,6 @@
     <string name="store_open_module">Ouvrir la page du module</string>
 
     <string name="store_install">Installer</string>
-    <string name="store_reinstall">Réinstaller</string>
     <string name="store_choose_asset">Choisir un fichier à installer</string>
     <plurals name="store_asset_downloads">
         <item quantity="one">%1$d téléchargement</item>

--- a/manager-ui/src/main/res/values-in/strings_store.xml
+++ b/manager-ui/src/main/res/values-in/strings_store.xml
@@ -40,7 +40,6 @@
     <string name="store_open_module">Buka halaman modul</string>
 
     <string name="store_install">Pasang</string>
-    <string name="store_reinstall">Pasang ulang</string>
     <string name="store_choose_asset">Pilih berkas untuk dipasang</string>
     <plurals name="store_asset_downloads">
         <item quantity="other">%1$d unduhan</item>

--- a/manager-ui/src/main/res/values-it/strings_store.xml
+++ b/manager-ui/src/main/res/values-it/strings_store.xml
@@ -42,7 +42,6 @@
     <string name="store_open_module">Apri la pagina del modulo</string>
 
     <string name="store_install">Installa</string>
-    <string name="store_reinstall">Reinstalla</string>
     <string name="store_choose_asset">Scegli un file da installare</string>
     <plurals name="store_asset_downloads">
         <item quantity="one">%1$d download</item>

--- a/manager-ui/src/main/res/values-iw/strings_store.xml
+++ b/manager-ui/src/main/res/values-iw/strings_store.xml
@@ -46,7 +46,6 @@
     <string name="store_open_module">פתיחת דף המודול</string>
 
     <string name="store_install">התקנה</string>
-    <string name="store_reinstall">התקנה מחדש</string>
     <string name="store_choose_asset">בחרו קובץ להתקנה</string>
     <plurals name="store_asset_downloads">
         <item quantity="one">הורדה אחת</item>

--- a/manager-ui/src/main/res/values-ja/strings_store.xml
+++ b/manager-ui/src/main/res/values-ja/strings_store.xml
@@ -48,7 +48,6 @@
     <string name="store_open_module">モジュールのページを開く</string>
     <!-- Install -->
     <string name="store_install">インストール</string>
-    <string name="store_reinstall">再インストール</string>
     <string name="store_choose_asset">インストールするファイルを選択</string>
     <plurals name="store_asset_downloads">
         <item quantity="other">%1$d 回のダウンロード</item>

--- a/manager-ui/src/main/res/values-ko/strings_store.xml
+++ b/manager-ui/src/main/res/values-ko/strings_store.xml
@@ -48,7 +48,6 @@
     <string name="store_open_module">모듈 페이지 열기</string>
     <!-- Install -->
     <string name="store_install">설치</string>
-    <string name="store_reinstall">다시 설치</string>
     <string name="store_choose_asset">설치할 파일 고르기</string>
     <plurals name="store_asset_downloads">
         <item quantity="other">다운로드 %1$d회</item>

--- a/manager-ui/src/main/res/values-pl/strings_store.xml
+++ b/manager-ui/src/main/res/values-pl/strings_store.xml
@@ -54,7 +54,6 @@
     <string name="store_open_module">Otwórz stronę modułu</string>
     <!-- Install -->
     <string name="store_install">Zainstaluj</string>
-    <string name="store_reinstall">Zainstaluj ponownie</string>
     <string name="store_choose_asset">Wybierz plik do zainstalowania</string>
     <plurals name="store_asset_downloads">
         <item quantity="one">%1$d pobranie</item>

--- a/manager-ui/src/main/res/values-pt-rBR/strings_store.xml
+++ b/manager-ui/src/main/res/values-pt-rBR/strings_store.xml
@@ -42,7 +42,6 @@
     <string name="store_open_module">Abrir a página do módulo</string>
 
     <string name="store_install">Instalar</string>
-    <string name="store_reinstall">Reinstalar</string>
     <string name="store_choose_asset">Escolha um arquivo para instalar</string>
     <plurals name="store_asset_downloads">
         <item quantity="one">%1$d download</item>

--- a/manager-ui/src/main/res/values-ru/strings_store.xml
+++ b/manager-ui/src/main/res/values-ru/strings_store.xml
@@ -54,7 +54,6 @@
     <string name="store_open_module">Открыть страницу модуля</string>
     <!-- Install -->
     <string name="store_install">Установить</string>
-    <string name="store_reinstall">Переустановить</string>
     <string name="store_choose_asset">Выберите файл для установки</string>
     <plurals name="store_asset_downloads">
         <item quantity="one">%1$d загрузка</item>

--- a/manager-ui/src/main/res/values-tr/strings_store.xml
+++ b/manager-ui/src/main/res/values-tr/strings_store.xml
@@ -50,7 +50,6 @@
     <string name="store_open_module">Modül sayfasını aç</string>
     <!-- Install -->
     <string name="store_install">Kur</string>
-    <string name="store_reinstall">Yeniden kur</string>
     <string name="store_choose_asset">Kurulacak dosyayı seçin</string>
     <plurals name="store_asset_downloads">
         <item quantity="one">%1$d indirme</item>

--- a/manager-ui/src/main/res/values-uk/strings_store.xml
+++ b/manager-ui/src/main/res/values-uk/strings_store.xml
@@ -54,7 +54,6 @@
     <string name="store_open_module">Відкрити сторінку модуля</string>
     <!-- Install -->
     <string name="store_install">Встановити</string>
-    <string name="store_reinstall">Перевстановити</string>
     <string name="store_choose_asset">Виберіть файл для встановлення</string>
     <plurals name="store_asset_downloads">
         <item quantity="one">%1$d завантаження</item>

--- a/manager-ui/src/main/res/values-vi/strings_store.xml
+++ b/manager-ui/src/main/res/values-vi/strings_store.xml
@@ -48,7 +48,6 @@
     <string name="store_open_module">Mở trang của mô-đun</string>
     <!-- Install -->
     <string name="store_install">Cài đặt</string>
-    <string name="store_reinstall">Cài lại</string>
     <string name="store_choose_asset">Chọn tệp để cài</string>
     <plurals name="store_asset_downloads">
         <item quantity="other">%1$d lượt tải</item>

--- a/manager-ui/src/main/res/values-zh-rCN/strings_store.xml
+++ b/manager-ui/src/main/res/values-zh-rCN/strings_store.xml
@@ -48,7 +48,6 @@
     <string name="store_open_module">打开模块页面</string>
     <!-- Install -->
     <string name="store_install">安装</string>
-    <string name="store_reinstall">重新安装</string>
     <string name="store_choose_asset">选择要安装的文件</string>
     <plurals name="store_asset_downloads">
         <item quantity="other">%1$d 次下载</item>

--- a/manager-ui/src/main/res/values-zh-rTW/strings_store.xml
+++ b/manager-ui/src/main/res/values-zh-rTW/strings_store.xml
@@ -48,7 +48,6 @@
     <string name="store_open_module">開啟模組頁面</string>
     <!-- Install -->
     <string name="store_install">安裝</string>
-    <string name="store_reinstall">重新安裝</string>
     <string name="store_choose_asset">選擇要安裝的檔案</string>
     <plurals name="store_asset_downloads">
         <item quantity="other">%1$d 次下載</item>

--- a/manager-ui/src/main/res/values/strings_store.xml
+++ b/manager-ui/src/main/res/values/strings_store.xml
@@ -57,7 +57,6 @@
 
     <!-- Install -->
     <string name="store_install">Install</string>
-    <string name="store_reinstall">Reinstall</string>
     <string name="store_choose_asset">Choose a file to install</string>
     <plurals name="store_asset_downloads">
         <item quantity="one">%1$d download</item>

--- a/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/VectorStoreInstallHost.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/data/repository/VectorStoreInstallHost.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.matrix.vector.manager.data.model.versionCodeCompat
 import org.matrix.vector.manager.di.ServiceLocator
+import org.matrix.vector.ui.module.PER_USER_RANGE
 import org.matrix.vector.ui.store.InstallStep
 import org.matrix.vector.ui.store.ReleaseAsset
 import org.matrix.vector.ui.store.RepoVersion
@@ -37,6 +38,9 @@ class VectorStoreInstallHost(private val packageName: String) : StoreInstallHost
     private val _installedIsLegacy = MutableStateFlow(false)
     override val installedIsLegacy: StateFlow<Boolean> = _installedIsLegacy.asStateFlow()
 
+    private val _installedUserId = MutableStateFlow<Int?>(null)
+    override val installedUserId: StateFlow<Int?> = _installedUserId.asStateFlow()
+
     init {
         refreshScope()
     }
@@ -56,6 +60,7 @@ class VectorStoreInstallHost(private val packageName: String) : StoreInstallHost
                     )
                 _installedScope.value = manifest.scope
                 _installedIsLegacy.value = manifest.isLegacy
+                _installedUserId.value = appInfo.uid / PER_USER_RANGE
             }
         }
     }

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/VectorApp.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/VectorApp.kt
@@ -235,6 +235,7 @@ private fun EntryProviderScope<NavKey>.registerRoutes(navigator: Navigator) {
             packageName = route.packageName,
             onNavigateBack = { navigator.back() },
             onOpenUrl = { url -> navigator.go(Web(url)) },
+            onOpenScope = { packageName, userId -> navigator.go(Scope(packageName, userId)) },
             dataSource = ServiceLocator.store,
             settings = ServiceLocator.settings,
             host = remember(route.packageName) { VectorStoreInstallHost(route.packageName) },


### PR DESCRIPTION
The store detail page's install bar shows "Reinstall" when a module is installed and current — but at that point the reader usually wants to configure the module they just installed, not install it again.

Replace that resting button with "Manage", which opens the module's configuration screen (the same `Scope` screen the module list opens). It appears only when the module is installed, current, and the host has read its user id — so first installs and updates still get the install button, and LSPatch (no install host) is unaffected.

The installed copy's user id is plumbed through `StoreInstallHost` → `RepoDetailsViewModel` → `RepoDetailsScreen`, derived from `appInfo.uid / PER_USER_RANGE` the same way the module list and package broadcasts already do.

Also drops the now-unused `store_reinstall` string across all locales.
